### PR TITLE
bugfix: containerd should use same log level as pouchd does

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alibaba/pouch/daemon"
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/pkg/exec"
+	"github.com/alibaba/pouch/pkg/utils"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -48,6 +49,7 @@ func main() {
 					Args: []string{
 						"-c", cfg.ContainerdConfig,
 						"-a", cfg.ContainerdAddr,
+						"-l", utils.If(cfg.Debug, "debug", "info").(string),
 					},
 				},
 			}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,9 @@
+package utils
+
+// If implements ternary operator. if cond is true return v1, or return v2 instead.
+func If(cond bool, v1, v2 interface{}) interface{} {
+	if cond {
+		return v1
+	}
+	return v2
+}


### PR DESCRIPTION
Signed-off-by: Frank Yang <yyb196@gmail.com>

containerd should use same log level as pouchd does, then every compoent in pouchd prints detailed logs if starting pouchd with -D flag

