### PR TITLE
feature: add stop command and recover container

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -4,41 +4,63 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/gorilla/mux"
 )
 
-func (s *Server) createContainer(ctx context.Context, resp http.ResponseWriter, req *http.Request) (err error) {
+func (s *Server) createContainer(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
 	var config types.ContainerConfigWrapper
-	name := req.FormValue("name")
 
-	err = json.NewDecoder(req.Body).Decode(&config)
-	if err != nil {
+	if err := json.NewDecoder(req.Body).Decode(&config); err != nil {
 		resp.WriteHeader(http.StatusBadRequest)
 		return err
 	}
+
+	name := req.FormValue("name")
 
 	ret, err := s.ContainerMgr.Create(ctx, name, &config)
 	if err != nil {
 		resp.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
-	//resp.WriteHeader(http.StatusCreated)
+
+	resp.WriteHeader(http.StatusCreated)
 	return json.NewEncoder(resp).Encode(ret)
 }
 
-func (s *Server) startContainer(ctx context.Context, resp http.ResponseWriter, req *http.Request) (err error) {
+func (s *Server) startContainer(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
 	name := mux.Vars(req)["name"]
 	config := types.ContainerStartConfig{
 		ID:         name,
 		DetachKeys: req.FormValue("detachKeys"),
 	}
-	err = s.ContainerMgr.Start(ctx, config)
-	if err != nil {
+
+	if err := s.ContainerMgr.Start(ctx, config); err != nil {
 		resp.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
+
+	resp.WriteHeader(http.StatusOK)
+	return nil
+}
+
+func (s *Server) stopContainer(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
+	t, err := strconv.Atoi(req.FormValue("t"))
+	if err != nil {
+		resp.WriteHeader(http.StatusBadRequest)
+		return err
+	}
+
+	name := mux.Vars(req)["name"]
+
+	if err := s.ContainerMgr.Stop(ctx, name, time.Duration(t)*time.Second); err != nil {
+		resp.WriteHeader(http.StatusInternalServerError)
+		return err
+	}
+
 	resp.WriteHeader(http.StatusOK)
 	return nil
 }

--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -19,6 +19,7 @@ func initRoute(s *Server) http.Handler {
 	// container
 	r.Path("/containers/create").Methods(http.MethodPost).Handler(s.filter(s.createContainer))
 	r.Path("/containers/{name:.*}/start").Methods(http.MethodPost).Handler(s.filter(s.startContainer))
+	r.Path("/containers/{name:.*}/stop").Methods(http.MethodPost).Handler(s.filter(s.stopContainer))
 
 	// image
 	r.Path("/images/create").Methods(http.MethodPost).Handler(s.filter(s.pullImage))

--- a/cli/main.go
+++ b/cli/main.go
@@ -8,6 +8,7 @@ func main() {
 	cli.AddCommand(base, &PullCommand{})
 	cli.AddCommand(base, &CreateCommand{})
 	cli.AddCommand(base, &StartCommand{})
+	cli.AddCommand(base, &StopCommand{})
 	cli.AddCommand(base, &VersionCommand{})
 	cli.AddCommand(base, &ImageCommand{})
 	cli.AddCommand(base, &VolumeCommand{})

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// StopCommand use to implement 'stop' command, it stops a container.
+type StopCommand struct {
+	baseCommand
+}
+
+// Init initialize stop command.
+func (s *StopCommand) Init(c *Cli) {
+	s.cli = c
+
+	s.cmd = &cobra.Command{
+		Use:   "stop [container]",
+		Short: "Stop a running container",
+		Args:  cobra.MinimumNArgs(1),
+	}
+
+	// TODO add flag
+}
+
+// Run is the entry of stop command.
+func (s *StopCommand) Run(args []string) {
+	container := args[0]
+
+	req, err := s.cli.NewPostRequest(fmt.Sprintf("/containers/%s/stop", container), nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to new post request: %v \n", err)
+		return
+	}
+
+	respone := req.Send()
+
+	if err := respone.Error(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to request: %v \n", err)
+		return
+	}
+	respone.Close()
+}

--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -142,7 +142,9 @@ func (c *Client) DestroyContainer(ctx context.Context, id string) (*Message, err
 	}
 
 	if err := pack.container.Delete(ctx, containerd.WithSnapshotCleanup); err != nil {
-		return msg, errors.Wrap(err, "failed to delete container")
+		if !errdefs.IsNotFound(err) {
+			return msg, errors.Wrap(err, "failed to delete container")
+		}
 	}
 
 	logrus.Infof("success to destroy container: %s", id)


### PR DESCRIPTION
"./pouch stop ID" be used to stop a running container. When restart the
pouchd, will recover these running containers.

Signed-off-by: skoo87 <marckywu@gmail.com>





