### PR TITLE
bugfix: add linux build tags

### DIFF
--- a/module
+++ b/module
@@ -4,7 +4,10 @@ volume_module() {
     # generate 'volume_build.go' file
     if [ ! -f $volume_build ]; then
     cat << END > $volume_build
+// +build linux
+
 // The file is automatically generated, DON'T EDIT.
+
 package main
 
 // import default package.

--- a/volume/modules/ceph/ceph.go
+++ b/volume/modules/ceph/ceph.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package ceph
 
 import (

--- a/volume/modules/ceph/map.go
+++ b/volume/modules/ceph/map.go
@@ -1,12 +1,13 @@
+// +build linux
+
 package ceph
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 	"time"
-
-	"encoding/json"
 
 	"github.com/alibaba/pouch/pkg/exec"
 	"github.com/alibaba/pouch/volume/driver"

--- a/volume/modules/ceph/types.go
+++ b/volume/modules/ceph/types.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package ceph
 
 import (

--- a/volume/modules/local/local.go
+++ b/volume/modules/local/local.go
@@ -1,12 +1,13 @@
+// +build linux
+
 package local
 
 import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
-
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/alibaba/pouch/volume/driver"

--- a/volume/modules/local/quota.go
+++ b/volume/modules/local/quota.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package local
 
 import (

--- a/volume/modules/tmpfs/tmpfs.go
+++ b/volume/modules/tmpfs/tmpfs.go
@@ -1,13 +1,14 @@
+// +build linux
+
 package tmpfs
 
 import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"syscall"
-
-	"strconv"
 	"time"
 
 	"github.com/alibaba/pouch/pkg/utils"

--- a/volume_build.go
+++ b/volume_build.go
@@ -1,4 +1,7 @@
+// +build linux
+
 // The file is automatically generated, DON'T EDIT.
+
 package main
 
 // import default package.


### PR DESCRIPTION
On macxos, with "go build" to build pouch caused errors. The modules of
volume only build on linux os, so add tags in volume modules.

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>