### PR TITLE
bugfix: avoid complaining about "is up to date"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ CLI_BINARY_NAME=pouch
 GOPATH=$(shell cd ../../../..; pwd)
 PACKAGES=$(shell GOPATH=`cd ../../../..; pwd` go list ./... | grep -v /vendor/ | sed 's/^_//')
 
+.PHONY: check build client server clean fmt lint vet unit-test modules
+
 build: server client
 
 server: modules


### PR DESCRIPTION
Signed-off-by: Frank Yang <yyb196@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
before this pr, if user run "make client" under root dir of pouch, it complains that "make: `client' is up to date."
it because we have an exactly dir named client. to fix this bug we should make all targets in Makefile phony.


**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**

