### PR TITLE
feature: add support for tls verification on both client and daemon

### DIFF
--- a/apis/types/tls.go
+++ b/apis/types/tls.go
@@ -1,0 +1,9 @@
+package types
+
+// TLSConfig contains information of tls which users can specify
+type TLSConfig struct {
+	CA           string
+	Cert         string
+	Key          string
+	VerifyRemote bool
+}

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	apitypes "github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/volume"
 )
 
@@ -30,4 +31,7 @@ type Config struct {
 
 	// Containerd's config file.
 	ContainerdConfig string
+
+	// TLS configuration
+	TLS apitypes.TLSConfig
 }

--- a/main.go
+++ b/main.go
@@ -133,6 +133,8 @@ func setupFlags(cmd *cobra.Command) {
 		"containerd-config",
 		"/etc/containerd/config.toml",
 		"Specify the path of Containerd binary")
+
+	utils.SetupTLSFlag(flagSet, &cfg.TLS)
 }
 
 func initLog() {

--- a/pkg/utils/tls.go
+++ b/pkg/utils/tls.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/alibaba/pouch/apis/types"
+
+	"github.com/spf13/pflag"
+)
+
+// GenTLSConfig returns a tls config object according to inputting parameters.
+func GenTLSConfig(key, cert, ca string) (*tls.Config, error) {
+	tlsConfig := &tls.Config{}
+	tlsCert, err := tls.LoadX509KeyPair(cert, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read X509 key pair (cert: %q, key: %q): %v", cert, key, err)
+	}
+	tlsConfig.Certificates = []tls.Certificate{tlsCert}
+	if ca != "" {
+		cp, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read system certificates: %v", err)
+		}
+		pem, err := ioutil.ReadFile(ca)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate %q: %v", ca, err)
+		}
+		if !cp.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("failed to append certificates from PEM file: %q", ca)
+		}
+
+		tlsConfig.ClientCAs = cp
+	}
+
+	return tlsConfig, nil
+}
+
+// SetupTLSFlag setups flags of tls arguments
+func SetupTLSFlag(fs *pflag.FlagSet, tlsCfg *types.TLSConfig) {
+	fs.StringVar(&tlsCfg.Key, "tlskey", "", "Specify key file of tls")
+	fs.StringVar(&tlsCfg.Cert, "tlscert", "", "Specify cert file of tls")
+	fs.StringVar(&tlsCfg.CA, "tlscacert", "", "Specify CA file of tls")
+	fs.BoolVar(&tlsCfg.VerifyRemote, "tlsverify", false, "Switch if verify the remote when using tls")
+}


### PR DESCRIPTION
Signed-off-by: Frank Yang <yyb196@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
if user specified cert and key files of tls when starting pouchd and pouchd listened on tcp address, client must have certificate published by the same CA to connect to the daemon.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
 fixes #24
**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**

