### PR TITLE
bugfix: modify volume config

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -1,13 +1,13 @@
 package config
 
 import (
-	"github.com/alibaba/pouch/volume/types"
+	"github.com/alibaba/pouch/volume"
 )
 
 // Config refers to daemon's whole configurations.
 type Config struct {
 	//Volume config
-	types.Config
+	volume.Config
 
 	// Server listening address.
 	Listen []string

--- a/daemon/mgr/volume.go
+++ b/daemon/mgr/volume.go
@@ -39,7 +39,7 @@ type VolumeManager struct {
 }
 
 // NewVolumeManager creates a brand new volume manager.
-func NewVolumeManager(ms *meta.Store, cfg types.Config) (*VolumeManager, error) {
+func NewVolumeManager(ms *meta.Store, cfg volume.Config) (*VolumeManager, error) {
 	// init voluem config
 	cfg.RemoveVolume = true
 	cfg.VolumeMetaPath = path.Join(path.Dir(ms.BaseDir), "volume", "volume.db")

--- a/volume/config.go
+++ b/volume/config.go
@@ -1,4 +1,4 @@
-package types
+package volume
 
 import (
 	"time"

--- a/volume/core.go
+++ b/volume/core.go
@@ -15,13 +15,13 @@ import (
 
 // Core represents volume core struct.
 type Core struct {
-	types.Config
+	Config
 	BaseURL       string
 	EnableControl bool
 }
 
 // NewCore returns Core struct instance with volume config.
-func NewCore(cfg types.Config) (*Core, error) {
+func NewCore(cfg Config) (*Core, error) {
 	c := &Core{Config: cfg}
 	if cfg.ControlAddress != "" {
 		c.EnableControl = true
@@ -30,7 +30,7 @@ func NewCore(cfg types.Config) (*Core, error) {
 		c.EnableControl = false
 	}
 
-	if err := store.MetaNewStore(cfg); err != nil {
+	if err := store.MetaNewStore(cfg.VolumeMetaPath); err != nil {
 		return nil, err
 	}
 

--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -16,16 +16,16 @@ func RegisterMetaStore(m metaStorer) {
 }
 
 type metaStorer interface {
-	New(types.Config) error
-	Put([]byte, []byte) error
-	Del([]byte) error
-	Get([]byte) ([]byte, error)
+	New(path string) error
+	Put(key []byte, value []byte) error
+	Del(key []byte) error
+	Get(key []byte) ([]byte, error)
 	List() ([][]byte, error)
 }
 
 // MetaNewStore is used to make a metadata store instance.
-func MetaNewStore(conf types.Config) error {
-	return ms.New(conf)
+func MetaNewStore(path string) error {
+	return ms.New(path)
 }
 
 // MetaPut is used to put volume metadate into store.


### PR DESCRIPTION
Modify volume config structure, call volume config like this:
volume.Config, instead of "types.Config".

When volume metadata path is not existed, make the metadata directory.
fixes https://github.com/alibaba/pouch/issues/44

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
