### PR TITLE
refactor: refact manager module

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -75,28 +75,24 @@ func (d *Daemon) Run() error {
 	if err != nil {
 		return err
 	}
-
-	systemMgr, err := internal.GenSystemMgr(d.config)
-	if err != nil {
-		return err
-	}
-
-	volumeMgr, err := internal.GenVolumeMgr(d.config, d)
-	if err != nil {
-		return err
-	}
-
-	d.systemMgr = systemMgr
 	d.imageMgr = imageMgr
+
+	systemMgr, err := internal.GenSystemMgr(&d.config)
+	if err != nil {
+		return err
+	}
+	d.systemMgr = systemMgr
+
+	volumeMgr, err := internal.GenVolumeMgr(&d.config, d)
+	if err != nil {
+		return err
+	}
 	d.volumeMgr = volumeMgr
 
 	containerMgr, err := internal.GenContainerMgr(ctx, d)
 	if err != nil {
 		return err
 	}
-
-	d.systemMgr = systemMgr
-	d.imageMgr = imageMgr
 	d.containerMgr = containerMgr
 
 	d.server = server.Server{
@@ -123,6 +119,11 @@ func (d *Daemon) Config() *config.Config {
 // ImgMgr gets manager of image.
 func (d *Daemon) ImgMgr() mgr.ImageMgr {
 	return d.imageMgr
+}
+
+// VolMgr gets manager of volume.
+func (d *Daemon) VolMgr() mgr.VolumeMgr {
+	return d.volumeMgr
 }
 
 // Containerd gets containerd client.

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -32,10 +32,23 @@ type ContainerMgr interface {
 
 // ContainerManager is the default implement of interface ContainerMgr.
 type ContainerManager struct {
-	Store    *meta.Store
-	Client   *ctrd.Client
-	NameToID *collect.SafeMap
-	ImageMgr ImageMgr
+	Store     *meta.Store
+	Client    *ctrd.Client
+	NameToID  *collect.SafeMap
+	ImageMgr  ImageMgr
+	VolumeMrg VolumeMgr
+}
+
+// NewContainerManager creates a brand new container manager.
+func NewContainerManager(ctx context.Context, store *meta.Store, cli *ctrd.Client, imgMgr ImageMgr, volMgr VolumeMgr) (*ContainerManager, error) {
+	mgr := &ContainerManager{
+		Store:     store,
+		NameToID:  collect.NewSafeMap(),
+		Client:    cli,
+		ImageMgr:  imgMgr,
+		VolumeMrg: volMgr,
+	}
+	return mgr, mgr.Restore(ctx)
 }
 
 // Restore containers from meta store to memory and recover those container.

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -20,7 +20,7 @@ type SystemManager struct {
 }
 
 // NewSystemManager creates a brand new system manager.
-func NewSystemManager(cfg config.Config) (*SystemManager, error) {
+func NewSystemManager(cfg *config.Config) (*SystemManager, error) {
 	return &SystemManager{
 		name: "system_manager",
 	}, nil

--- a/internal/generator.go
+++ b/internal/generator.go
@@ -2,78 +2,38 @@ package internal
 
 import (
 	"context"
-	"sync"
 
 	"github.com/alibaba/pouch/ctrd"
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/daemon/meta"
 	"github.com/alibaba/pouch/daemon/mgr"
-	"github.com/alibaba/pouch/pkg/collect"
-)
-
-var (
-	contMgr  *mgr.ContainerManager
-	contOnce sync.Once
-	contErr  error
-	imgMgr   *mgr.ImageManager
-	imgOnce  sync.Once
-	imgErr   error
-	sysMgr   *mgr.SystemManager
-	sysOnce  sync.Once
-	sysErr   error
 )
 
 // DaemonProvider provides resources which are needed by container manager and are from daemon.
 type DaemonProvider interface {
 	Config() *config.Config
 	Containerd() *ctrd.Client
+	ImgMgr() mgr.ImageMgr
+	VolMgr() mgr.VolumeMgr
 	MetaStore() *meta.Store
 }
 
 // GenContainerMgr generates a ContainerMgr instance according to config cfg.
 func GenContainerMgr(ctx context.Context, d DaemonProvider) (mgr.ContainerMgr, error) {
-	contOnce.Do(func() {
-		imgMgr, err := GenImageMgr(d.Config(), d)
-		if err != nil {
-			contErr = err
-			return
-		}
-
-		contMgr = &mgr.ContainerManager{
-			Store:    d.MetaStore(),
-			NameToID: collect.NewSafeMap(),
-			Client:   d.Containerd(),
-			ImageMgr: imgMgr,
-		}
-
-		if err := contMgr.Restore(ctx); err != nil {
-			contErr = err
-		}
-	})
-
-	return contMgr, contErr
+	return mgr.NewContainerManager(ctx, d.MetaStore(), d.Containerd(), d.ImgMgr(), d.VolMgr())
 }
 
 // GenSystemMgr generates a SystemMgr instance according to config cfg.
-func GenSystemMgr(cfg config.Config) (mgr.SystemMgr, error) {
-	//TODO
-	sysOnce.Do(func() {
-		sysMgr, sysErr = mgr.NewSystemManager(cfg)
-	})
-
-	return sysMgr, sysErr
+func GenSystemMgr(cfg *config.Config) (mgr.SystemMgr, error) {
+	return mgr.NewSystemManager(cfg)
 }
 
 // GenImageMgr generates a SystemMgr instance according to config cfg.
 func GenImageMgr(cfg *config.Config, d DaemonProvider) (mgr.ImageMgr, error) {
-	imgOnce.Do(func() {
-		imgMgr, imgErr = mgr.NewImageManager(cfg, d.Containerd())
-	})
-
-	return imgMgr, imgErr
+	return mgr.NewImageManager(cfg, d.Containerd())
 }
 
 // GenVolumeMgr generates a VolumeMgr instance.
-func GenVolumeMgr(cfg config.Config, d DaemonProvider) (mgr.VolumeMgr, error) {
+func GenVolumeMgr(cfg *config.Config, d DaemonProvider) (mgr.VolumeMgr, error) {
 	return mgr.NewVolumeManager(d.MetaStore(), cfg.Config)
 }


### PR DESCRIPTION
Container manager is differnet from other managers, such as volume manager, it have no "New" function. In addition, there is no need to guarantee that it will only be executed once, only need to follow the order to start every modules "New".

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>