### PR TITLE
fix: make wget quiet to leave travisCI output clear

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ before_install:
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - docker build -t pouch:test . 
+  - docker build --quiet -t pouch:test . 
   - docker run -ti pouch:test bash -c "cd /go/src/github.com/alibaba/pouch && make check && make unit-test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV GO_VERSION=1.8.3
 ENV ARCH=amd64
 
 # install golang which version is GO_VERSION
-RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${ARCH}.tar.gz \
+RUN wget --quiet https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${ARCH}.tar.gz \
     && tar -C /usr/local -xzf go${GO_VERSION}.linux-${ARCH}.tar.gz \
     && rm go${GO_VERSION}.linux-${ARCH}.tar.gz
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**
I found that in travisCI, there are lots of content which seems redundant to influence the reading feelings:
```
Step 5/11 : RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${ARCH}.tar.gz     && tar -C /usr/local -xzf go${GO_VERSION}.linux-${ARCH}.tar.gz     && rm go${GO_VERSION}.linux-${ARCH}.tar.gz
 ---> Running in fb97d81845b8
--2017-11-07 02:31:13--  https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
Resolving storage.googleapis.com (storage.googleapis.com)... 209.85.147.128, 2607:f8b0:4001:c12::80
Connecting to storage.googleapis.com (storage.googleapis.com)|209.85.147.128|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 90029041 (86M) [application/x-gzip]
Saving to: 'go1.8.3.linux-amd64.tar.gz'
     0K .......... .......... .......... .......... ..........  0% 39.6M 2s
    50K .......... .......... .......... .......... ..........  0% 45.9M 2s
   100K .......... .......... .......... .......... ..........  0% 46.1M 2s
   150K .......... .......... .......... .......... ..........  0% 64.8M 2s
   200K .......... .......... .......... .......... ..........  0% 80.4M 2s
   250K .......... .......... .......... .......... ..........  0% 77.9M 2s
   300K .......... .......... .......... .......... ..........  0% 76.3M 1s
   350K .......... .......... .......... .......... ..........  0% 88.4M 1s
   400K .......... .......... .......... .......... ..........  0% 83.7M 1s
``` 

So I remove the log and add `--quiet` flag to wget.

Ping @sunyuan3 

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

**3.Describe how you did it**
add flag `--quiet`

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


