### PR TITLE
feature: add make install and uninstall in Makefile

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,91 @@
+# Installation
+
+We have two different ways to experience Pouch, one for end-users, the other for developers. In the former one, installation can help you with Pouch installing out of box. The latter one is for those who wish to get involved in Pouch with hacking.
+
+If you wish to experience Pouch, please choose [End User Quick-Start](#end-user-quick-start). And if you are looking forward to becoming a hacker, [Developer Quick-Start](#developer-quick-start) is a must-read for you.
+
+## End User Quick-Start
+
+You can install Pouch automatically on your machine with very few steps. Currently we support two kinds of Linux Distribution: Ubuntu and CentOS.
+
+## Ubuntu
+
+To be added.
+
+## CentOS
+
+To be added.
+
+## Developer Quick-Start
+
+As a developer, you may need to build and test Pouch binaries via source code. To build pouchd which is so-called "pouch daemon" and pouch which is so-called "pouch cli", the following build system dependencies are required:
+
+* Go 1.9.x or above
+* Linux Kernel 3.10+ 
+
+First, clone the repository and checkout whichever branch you like (in the following example, checkout branch master):
+
+``` shell
+$ git clone https://github.com/alibaba/pouch.git
+$ cd pouch
+$ git checkout master
+```
+
+Second, build and install pouch binaries (pouchd and pouch). With the required dependencies installed, the Makefile target named build will compile the pouch and pouchd binaries in current work directory. Or you can just execute `make install` to build binaries and install them in destination directory (/usr/local/bin by default).
+
+``` shell
+$ make install
+```
+
+Third, install containerd, runc and runv binaries. Since pouchd is a kind of container engine, and pouch is a cli tool, if you hope to experience container management ability via Pouch, there are several additional binaries needed:
+
+* [containerd](https://github.com/containerd/containerd): an industry-standard container runtime;
+* [runc](https://github.com/opencontainers/runc): a CLI tool for spawning and running containers according to the OCI specification;
+* [runv](https://github.com/hyperhq/runv): a hypervisor-based runtime for OCI.
+
+Here are the versions of these binaries which we suggest you should lock to:
+
+```
+containerd: 1.0.0-beta.3 
+runc: 1.0.0-rc4
+runv: 1.0.0
+```
+
+You can use the following command to install containerd:
+
+``` shell
+$ wget https://github.com/containerd/containerd/releases/download/v1.0.0-beta.3/containerd-1.0.0-beta.3.linux-amd64.tar.gz
+$ tar -xzvf containerd-1.0.0-beta.3.linux-amd64.tar.gz -C /usr/local
+```
+
+You can refer to [runV installation](https://github.com/hyperhq/runv#build) and [runC installation](https://github.com/opencontainers/runc#building)
+
+Forth, with all needed binaries installed, we could start pouchd via:
+
+``` shell
+$ pouchd
+INFO[0000] starting containerd                           module=containerd revision=a543c937eb0a05e1636714ee2be70819d745b960 version=v1.0.0-beta.2
+INFO[0000] setting subreaper...                          module=containerd
+INFO[0000] loading plugin "io.containerd.content.v1.content"...  module=containerd type=io.containerd.content.v1
+INFO[0000] loading plugin "io.containerd.snapshotter.v1.btrfs"...  module=containerd type=io.containerd.snapshotter.v1
+WARN[0000] failed to load plugin io.containerd.snapshotter.v1.btrfs  error="path /var/lib/containerd/io.containerd.snapshotter.v1.btrfs must be a btrfs filesystem to be used with the btrfs snapshotter" module=containerd
+INFO[0000] loading plugin "io.containerd.snapshotter.v1.overlayfs"...  module=containerd type=io.containerd.snapshotter.v1
+INFO[0000] loading plugin "io.containerd.metadata.v1.bolt"...  module=containerd type=io.containerd.metadata.v1
+WARN[0000] could not use snapshotter btrfs in metadata plugin  error="path /var/lib/containerd/io.containerd.snapshotter.v1.btrfs must be a btrfs filesystem to be used with the btrfs snapshotter" module="containerd/io.containerd.metadata.v1.bolt"
+INFO[0000] loading plugin "io.containerd.differ.v1.walking"...  module=containerd type=io.containerd.differ.v1
+INFO[0000] loading plugin "io.containerd.grpc.v1.containers"...  module=containerd type=io.containerd.grpc.v1
+```
+
+After pouchd's running, you could interact with pouchd by pouch cli:
+
+```
+$ pouch images ls
+IMAGE ID             IMAGE NAME                                               SIZE
+3e8fa85ddfef         docker.io/library/busybox:latest                         2699
+504cf109b492         docker.io/library/redis:alpine                           2035
+```
+
+## Feedback
+
+We hope this guide would help you get up and run with Pouch. And feel free to send feedback via [ISSUE](https://github.com/alibaba/pouch/issues/new), if you have any questions. If you wish to contribute to Pouch on this guide, please just submit a pull request.
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [Introduction](#introduction)
 - [Advantanges and Disadvantages](#advantages)
 - [Docs](docs)
-    - [Installation]()
+    - [Installation](#installation)
     - [Usage]()
     - [Software Design]()
     - [Contribute]()
@@ -42,12 +42,16 @@ Pouch pays more emphasis on view of application, and we can call this "applicati
 * Application delivery turns to be out of box. Pouch improve the portability of application, no matter cross-platform or cross-os.
 * Application delivery period should be minimal. Pouch shorted this by standardizing the application image spec between developers and operators.
 
+## Installation
+
+See [INSTALLATION.md](INSTALLATION.md).
+
 ## FAQ
 File [FAQ.md](FAQ.md) contains frequently asked question (FAQ).
 
 ## Roadmap
 
-See [ROADMAP](ROADMAP.md)
+See [ROADMAP.md](ROADMAP.md).
 
 ## License
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

1.I add `make install` and `make uninstall` in Makefile.
`make install` can help us automatically build binaries and install binaries `pouch` and `pouchd` into $PATH (/usr/local).
And `make uninstall` removes both two binaries.

2.docs: add an INSTALLATION.md for installation of Pouch

This fixes part of issue https://github.com/alibaba/pouch/issues/13, because it can only be installed statically, and it has not been integrated with system service or other system management tools.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

**3.Describe how you did it**
Update Makefile

**4.Describe how to verify it**
`make install` and execute `pouchd` directly.

**5.Special notes for reviews**
NONE


