### PR TITLE
bugfix: use a KMutex to protect container's operation

### DIFF
--- a/pkg/kmutex/kmutex.go
+++ b/pkg/kmutex/kmutex.go
@@ -1,0 +1,135 @@
+package kmutex
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type value struct {
+	c     chan struct{}
+	waits int32
+}
+
+// KMutex is a lock implement. One key can acquire only one lock. There is no
+// lock between different keys.
+type KMutex struct {
+	sync.Mutex
+	keys map[string]*value
+}
+
+// New creates a KMutex instance.
+func New() *KMutex {
+	m := &KMutex{
+		keys: make(map[string]*value),
+	}
+
+	ticker := time.NewTicker(time.Minute)
+	go func() {
+		for {
+			<-ticker.C
+
+			var removes []string
+
+			m.Mutex.Lock()
+
+			for k, v := range m.keys {
+				if v.waits == 0 {
+					removes = append(removes, k)
+					close(v.c)
+				}
+			}
+			for _, k := range removes {
+				delete(m.keys, k)
+			}
+
+			m.Mutex.Unlock()
+		}
+	}()
+
+	return m
+}
+
+func (m *KMutex) lock(k string) (*value, bool) {
+	v, ok := m.keys[k]
+	if !ok {
+		m.keys[k] = &value{
+			c:     make(chan struct{}, 1),
+			waits: 0,
+		}
+		return nil, true
+	}
+
+	return v, false
+}
+
+// Trylock trys to lock, will not block.
+func (m *KMutex) Trylock(k string) bool {
+	m.Mutex.Lock()
+	defer m.Mutex.Unlock()
+
+	v, ok := m.lock(k)
+	if ok {
+		return true
+	}
+
+	select {
+	case <-v.c:
+		return true
+	default:
+		return false
+	}
+}
+
+// LockWithTimeout trys to lock, if can't acquire the lock, will block util timeout.
+func (m *KMutex) LockWithTimeout(k string, to time.Duration) bool {
+	m.Mutex.Lock()
+
+	v, ok := m.lock(k)
+	if ok {
+		m.Mutex.Unlock()
+		return true
+	}
+
+	atomic.AddInt32(&v.waits, 1)
+	defer atomic.AddInt32(&v.waits, -1)
+
+	m.Mutex.Unlock()
+
+	select {
+	case <-v.c:
+		return true
+	case <-time.After(to):
+		return false
+	}
+}
+
+// Lock waits to acquire lock.
+func (m *KMutex) Lock(k string) bool {
+	m.Mutex.Lock()
+
+	v, ok := m.lock(k)
+	if ok {
+		m.Mutex.Unlock()
+		return true
+	}
+
+	atomic.AddInt32(&v.waits, 1)
+	defer atomic.AddInt32(&v.waits, -1)
+
+	m.Mutex.Unlock()
+
+	<-v.c
+	return true
+}
+
+// Unlock release the lock.
+func (m *KMutex) Unlock(k string) {
+	m.Mutex.Lock()
+	defer m.Mutex.Unlock()
+
+	v, ok := m.keys[k]
+	if ok && len(v.c) == 0 {
+		v.c <- struct{}{}
+	}
+}

--- a/pkg/kmutex/kmutex_test.go
+++ b/pkg/kmutex/kmutex_test.go
@@ -1,0 +1,67 @@
+package kmutex
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestKMutex(t *testing.T) {
+	m := New()
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			k := strconv.Itoa(i)
+
+			if m.Trylock(k) == false {
+				t.Fatalf("failed to trylock: %d", i)
+			}
+			if m.Trylock(k) == true {
+				t.Fatalf("trylock is error: %d", i)
+			}
+
+			m.Unlock(k)
+
+			if m.Trylock(k) == false {
+				t.Fatalf("failed to trylock: %d", i)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestKMutexTimeout(t *testing.T) {
+	m := New()
+
+	running := make(chan struct{})
+	wait := make(chan struct{})
+	go func() {
+		if m.Trylock("key") == false {
+			t.Fatalf("failed to trylock")
+		}
+
+		close(running)
+
+		time.Sleep(time.Second * 10)
+		close(wait)
+	}()
+
+	<-running
+
+	go func() {
+		<-wait
+		t.Fatalf("failed to trylock with timeout")
+	}()
+
+	if m.LockWithTimeout("key", time.Second*5) == true {
+		t.Fatalf("trylock with timeout is error")
+	}
+}


### PR DESCRIPTION
KMutex is a lock implement, the same key can acquire only one lock, but
there is no lock between different keys.

Signed-off-by: skoo87 <marckywu@gmail.com>

