### PR TITLE
fix: avoid potential race in safemap

### DIFF
--- a/pkg/collect/map.go
+++ b/pkg/collect/map.go
@@ -34,6 +34,8 @@ func (m *SafeMap) Put(k string, v interface{}) {
 
 // Remove removes the key-value pair.
 func (m *SafeMap) Remove(k string) {
+	m.Lock()
+	defer m.Unlock()
 	delete(m.inner, k)
 }
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

avoid potential race in safemap, since I think we need locked the object when doing deleting action.
But feel free to close this if I was somewhere wrong. 

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


