### PR TITLE
fix: make cli parse -H flag and make tcp connection work

### DIFF
--- a/apis/types/tls.go
+++ b/apis/types/tls.go
@@ -1,9 +1,0 @@
-package types
-
-// TLSConfig contains information of tls which users can specify
-type TLSConfig struct {
-	CA           string
-	Cert         string
-	Key          string
-	VerifyRemote bool
-}

--- a/cli/create.go
+++ b/cli/create.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/alibaba/pouch/client"
-
 	"github.com/spf13/cobra"
 )
 
@@ -31,13 +29,8 @@ func (cc *CreateCommand) Run(args []string) {
 	config := cc.config()
 	config.Image = args[0]
 
-	client, err := client.New("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to new client: %v\n", err)
-		return
-	}
-
-	result, err := client.ContainerCreate(config.ContainerConfig, config.HostConfig, "")
+	apiClient := cc.cli.Client()
+	result, err := apiClient.ContainerCreate(config.ContainerConfig, config.HostConfig, "")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create container: %v\n", err)
 		return

--- a/cli/image.go
+++ b/cli/image.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alibaba/pouch/client"
-
 	"github.com/spf13/cobra"
 )
 
@@ -37,13 +35,9 @@ func (i *ImageCommand) addFlags() {
 
 // Run is the entry of images container command.
 func (i *ImageCommand) Run(args []string) {
-	client, err := client.New("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to new client: %v\n", err)
-		return
-	}
+	apiClient := i.cli.Client()
 
-	imageList, err := client.ImageList()
+	imageList, err := apiClient.ImageList()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get image list: %s\n", err)
 		return

--- a/cli/main.go
+++ b/cli/main.go
@@ -2,6 +2,7 @@ package main
 
 func main() {
 	cli := NewCli().SetFlags()
+
 	base := &baseCommand{cmd: cli.rootCmd, cli: cli}
 
 	// Add all subcommands.

--- a/cli/pull.go
+++ b/cli/pull.go
@@ -9,7 +9,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/alibaba/pouch/client"
 	"github.com/alibaba/pouch/ctrd"
 
 	"github.com/containerd/containerd/progress"
@@ -48,13 +47,8 @@ func (p *PullCommand) Run(args []string) {
 		tag = fields[1]
 	}
 
-	client, err := client.New("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to new client: %v\n", err)
-		return
-	}
-
-	responseBody, err := client.ImagePull(name, tag)
+	apiClient := p.cli.Client()
+	responseBody, err := apiClient.ImagePull(name, tag)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to pull image: %v \n", err)
 		return

--- a/cli/start.go
+++ b/cli/start.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alibaba/pouch/client"
-
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -72,14 +70,9 @@ func (s *StartCommand) Run(args []string) {
 		}()
 	}
 
-	client, err := client.New("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to new client: %v\n", err)
-		return
-	}
-
+	apiClient := s.cli.Client()
 	// start container
-	if err := client.ContainerStart(container, ""); err != nil {
+	if err := apiClient.ContainerStart(container, ""); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to start container %s: %v\n", container, err)
 		return
 	}

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alibaba/pouch/client"
-
 	"github.com/spf13/cobra"
 )
 
@@ -29,15 +27,11 @@ func (s *StopCommand) Init(c *Cli) {
 
 // Run is the entry of stop command.
 func (s *StopCommand) Run(args []string) {
+	apiClient := s.cli.Client()
+
 	container := args[0]
 
-	client, err := client.New("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to new client: %v\n", err)
-		return
-	}
-
-	if err = client.ContainerStop(container); err != nil {
+	if err := apiClient.ContainerStop(container); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to stop container %s: %v \n", container, err)
 		return
 	}

--- a/cli/version.go
+++ b/cli/version.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alibaba/pouch/client"
-
 	"github.com/spf13/cobra"
 )
 
@@ -26,13 +24,9 @@ func (v *VersionCommand) Init(c *Cli) {
 
 // Run is the entry of version command.
 func (v *VersionCommand) Run(args []string) {
-	client, err := client.New("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to new client: %v\n", err)
-		return
-	}
+	apiClient := v.cli.Client()
 
-	result, err := client.SystemVersion()
+	result, err := apiClient.SystemVersion()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get system version: %v\n", err)
 		return

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/alibaba/pouch/apis/types"
-	"github.com/alibaba/pouch/client"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -137,13 +135,9 @@ func (v *VolumeCreateCommand) volumeCreate() error {
 		volumeReq.DriverOpts["selector."+selector[0]] = selector[1]
 	}
 
-	client, err := client.New("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to new client: %v\n", err)
-		return err
-	}
+	apiClient := v.cli.Client()
 
-	volume, err := client.VolumeCreate(volumeReq)
+	volume, err := apiClient.VolumeCreate(volumeReq)
 	if err != nil {
 		logrus.Errorln(err)
 		return err
@@ -176,13 +170,9 @@ func (v *VolumeRemoveCommand) Run(args []string) {
 
 	logrus.Debugf("remove a volume: %s", name)
 
-	client, err := client.New("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to new client: %v\n", err)
-		return
-	}
+	apiClient := v.cli.Client()
 
-	if err = client.VolumeRemove(name); err != nil {
+	if err := apiClient.VolumeRemove(name); err != nil {
 		logrus.Errorln(err)
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,16 +12,7 @@ var (
 	testHost = "unix:///var/run/pouchd.sock"
 )
 
-func newClient(t *testing.T) *Client {
-	client, err := New("")
-	if err != nil {
-		t.Fatal("failed to new client: ", err)
-	}
-
-	return client
-}
-
-func TestNewClient(t *testing.T) {
+func TestNewAPIClient(t *testing.T) {
 	assert := assert.New(t)
 	kvs := map[string]bool{
 		"":                      false,
@@ -30,11 +22,11 @@ func TestNewClient(t *testing.T) {
 	}
 
 	for host, expectError := range kvs {
-		cli, err := New(host)
+		cli, err := NewAPIClient(host, utils.TLSConfig{})
 		if expectError {
-			assert.Error(err, fmt.Sprintf("test data %v", host))
+			assert.Error(err, fmt.Sprintf("test data: %v", host))
 		} else {
-			assert.NoError(err, fmt.Sprintf("test data %v", host))
+			assert.NoError(err, fmt.Sprintf("test data %v: %v", host, err))
 		}
 
 		t.Logf("client info %+v", cli)

--- a/client/container.go
+++ b/client/container.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ContainerCreate creates a new container based in the given configuration.
-func (cli *Client) ContainerCreate(config *types.ContainerConfig, hostConfig *types.HostConfig, containerName string) (*types.ContainerCreateResp, error) {
+func (client *APIClient) ContainerCreate(config *types.ContainerConfig, hostConfig *types.HostConfig, containerName string) (*types.ContainerCreateResp, error) {
 	createConfig := types.ContainerConfigWrapper{
 		ContainerConfig: config,
 		HostConfig:      hostConfig,
@@ -18,7 +18,7 @@ func (cli *Client) ContainerCreate(config *types.ContainerConfig, hostConfig *ty
 		q.Set("name", containerName)
 	}
 
-	resp, err := cli.post("/containers/create", q, createConfig)
+	resp, err := client.post("/containers/create", q, createConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -32,21 +32,21 @@ func (cli *Client) ContainerCreate(config *types.ContainerConfig, hostConfig *ty
 }
 
 // ContainerStart starts a created container.
-func (cli *Client) ContainerStart(name, detachKeys string) error {
+func (client *APIClient) ContainerStart(name, detachKeys string) error {
 	q := url.Values{}
 	if detachKeys != "" {
 		q.Set("detachKeys", detachKeys)
 	}
 
-	resp, err := cli.post("/containers/"+name+"/start", q, nil)
+	resp, err := client.post("/containers/"+name+"/start", q, nil)
 	ensureCloseReader(resp)
 
 	return err
 }
 
 // ContainerStop stops a container
-func (cli *Client) ContainerStop(name string) error {
-	resp, err := cli.post("/containers/"+name+"/stop", nil, nil)
+func (client *APIClient) ContainerStop(name string) error {
+	resp, err := client.post("/containers/"+name+"/stop", nil, nil)
 	ensureCloseReader(resp)
 
 	return err

--- a/client/image.go
+++ b/client/image.go
@@ -8,12 +8,12 @@ import (
 )
 
 // ImagePull requests daemon to pull an image from registry.
-func (cli *Client) ImagePull(name, tag string) (io.ReadCloser, error) {
+func (client *APIClient) ImagePull(name, tag string) (io.ReadCloser, error) {
 	q := url.Values{}
 	q.Set("fromImage", name)
 	q.Set("tag", tag)
 
-	resp, err := cli.post("/images/create", q, nil)
+	resp, err := client.post("/images/create", q, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +21,8 @@ func (cli *Client) ImagePull(name, tag string) (io.ReadCloser, error) {
 }
 
 // ImageList requests daemon to list all images
-func (cli *Client) ImageList() ([]types.Image, error) {
-	resp, err := cli.get("/images/json", nil)
+func (client *APIClient) ImageList() ([]types.Image, error) {
+	resp, err := client.get("/images/json", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/request.go
+++ b/client/request.go
@@ -36,19 +36,19 @@ type Response struct {
 	Body       io.ReadCloser
 }
 
-func (cli *Client) get(path string, query url.Values) (*Response, error) {
-	return cli.sendRequest("GET", path, query, nil)
+func (client *APIClient) get(path string, query url.Values) (*Response, error) {
+	return client.sendRequest("GET", path, query, nil)
 }
 
-func (cli *Client) post(path string, query url.Values, obj interface{}) (*Response, error) {
-	return cli.sendRequest("POST", path, query, obj)
+func (client *APIClient) post(path string, query url.Values, obj interface{}) (*Response, error) {
+	return client.sendRequest("POST", path, query, obj)
 }
 
-func (cli *Client) delete(path string, query url.Values) (*Response, error) {
-	return cli.sendRequest("DELETE", path, query, nil)
+func (client *APIClient) delete(path string, query url.Values) (*Response, error) {
+	return client.sendRequest("DELETE", path, query, nil)
 }
 
-func (cli *Client) sendRequest(method, path string, query url.Values, obj interface{}) (*Response, error) {
+func (client *APIClient) sendRequest(method, path string, query url.Values, obj interface{}) (*Response, error) {
 	var body io.Reader
 	if method == "POST" {
 		if obj != nil {
@@ -62,12 +62,12 @@ func (cli *Client) sendRequest(method, path string, query url.Values, obj interf
 		}
 	}
 
-	req, err := http.NewRequest(method, cli.baseURL+getAPIPath(path, query), body)
+	req, err := http.NewRequest(method, client.baseURL+getAPIPath(path, query), body)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := cli.httpCli.Do(req)
+	resp, err := client.HTTPCli.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/system.go
+++ b/client/system.go
@@ -7,8 +7,8 @@ import (
 )
 
 // SystemPing shows weather server is ok.
-func (cli *Client) SystemPing() (string, error) {
-	resp, err := cli.get("/_ping", nil)
+func (client *APIClient) SystemPing() (string, error) {
+	resp, err := client.get("/_ping", nil)
 	if err != nil {
 		return "", err
 	}
@@ -23,8 +23,8 @@ func (cli *Client) SystemPing() (string, error) {
 }
 
 // SystemVersion requests daemon for system version.
-func (cli *Client) SystemVersion() (*types.SystemVersion, error) {
-	resp, err := cli.get("/version", nil)
+func (client *APIClient) SystemVersion() (*types.SystemVersion, error) {
+	resp, err := client.get("/version", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +37,8 @@ func (cli *Client) SystemVersion() (*types.SystemVersion, error) {
 }
 
 // SystemInfo requests daemon for system info.
-func (cli *Client) SystemInfo() (*types.SystemInfo, error) {
-	resp, err := cli.get("/info", nil)
+func (client *APIClient) SystemInfo() (*types.SystemInfo, error) {
+	resp, err := client.get("/info", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/volume.go
+++ b/client/volume.go
@@ -3,8 +3,8 @@ package client
 import "github.com/alibaba/pouch/apis/types"
 
 // VolumeCreate creates a volume
-func (cli *Client) VolumeCreate(req *types.VolumeCreateRequest) (*types.VolumeInfo, error) {
-	resp, err := cli.post("/volumes/create", nil, req)
+func (client *APIClient) VolumeCreate(req *types.VolumeCreateRequest) (*types.VolumeInfo, error) {
+	resp, err := client.post("/volumes/create", nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -18,8 +18,8 @@ func (cli *Client) VolumeCreate(req *types.VolumeCreateRequest) (*types.VolumeIn
 }
 
 // VolumeRemove removes a volume
-func (cli *Client) VolumeRemove(name string) error {
-	resp, err := cli.delete("/volumes/"+name, nil)
+func (client *APIClient) VolumeRemove(name string) error {
+	resp, err := client.delete("/volumes/"+name, nil)
 	ensureCloseReader(resp)
 
 	return err

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	apitypes "github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/volume"
 )
 
@@ -33,5 +33,5 @@ type Config struct {
 	ContainerdConfig string
 
 	// TLS configuration
-	TLS apitypes.TLSConfig
+	TLS utils.TLSConfig
 }

--- a/pkg/utils/tls.go
+++ b/pkg/utils/tls.go
@@ -6,10 +6,16 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/alibaba/pouch/apis/types"
-
 	"github.com/spf13/pflag"
 )
+
+// TLSConfig contains information of tls which users can specify
+type TLSConfig struct {
+	CA           string
+	Cert         string
+	Key          string
+	VerifyRemote bool
+}
 
 // GenTLSConfig returns a tls config object according to inputting parameters.
 func GenTLSConfig(key, cert, ca string) (*tls.Config, error) {
@@ -39,7 +45,7 @@ func GenTLSConfig(key, cert, ca string) (*tls.Config, error) {
 }
 
 // SetupTLSFlag setups flags of tls arguments
-func SetupTLSFlag(fs *pflag.FlagSet, tlsCfg *types.TLSConfig) {
+func SetupTLSFlag(fs *pflag.FlagSet, tlsCfg *TLSConfig) {
 	fs.StringVar(&tlsCfg.Key, "tlskey", "", "Specify key file of tls")
 	fs.StringVar(&tlsCfg.Cert, "tlscert", "", "Specify cert file of tls")
 	fs.StringVar(&tlsCfg.CA, "tlscacert", "", "Specify CA file of tls")


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

This PR changed a lot in cli and APIClient.
I do not think `transport *http.Transport` is reasonable in Cli. It should be APIClient.

To fix #80 , I add code `c.NewAPIClient()` in every command's `PreRun`. This will initialize a client according to host when running.

**2.Does this pull request fix one issue?** 

fixes #80 

**3.Describe how you did it**
NONE

**4.Describe how to verify it**

```
pouch (move-api-call-to-pkg-client) $ ./pouch -H tcp://127.0.0.1:2345 version adaa
failed to get system version: Get http://127.0.0.1:2345/version: dial tcp 127.0.0.1:2345: getsockopt: connectionrefused
pouch (move-api-call-to-pkg-client) $ ./pouch version
failed to get system version: Get http://d/version: dial unix /var/run/pouchd.sock: connect: no such file or directory
```

**5.Special notes for reviews**
NONE


