### PR TITLE
fix: make client build work on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ server: modules
 	GOOS=linux $(GOBUILD) -o $(BINARY_NAME)
 
 client:
-	GOOS=linux $(GOBUILD) -o $(CLI_BINARY_NAME) github.com/alibaba/pouch/cli
+	$(GOBUILD) -o $(CLI_BINARY_NAME) github.com/alibaba/pouch/cli
 
 clean:
 	$(GOCLEAN)


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

I think pouch cli is platform independent. And I always build pouch cli on my OSX, so I try to remove the linux-binding for client building in Makefile

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


