### PR TITLE
fix: make cli error return non-zero exit code

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -69,8 +69,8 @@ func (c *Cli) Client() *client.APIClient {
 }
 
 // Run executes the client program.
-func (c *Cli) Run() {
-	c.rootCmd.Execute()
+func (c *Cli) Run() error {
+	return c.rootCmd.Execute()
 }
 
 // AddCommand add a subcommand.

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,5 +1,9 @@
 package main
 
+import (
+	"os"
+)
+
 func main() {
 	cli := NewCli().SetFlags()
 
@@ -14,5 +18,8 @@ func main() {
 	cli.AddCommand(base, &VersionCommand{})
 	cli.AddCommand(base, &ImageCommand{})
 	cli.AddCommand(base, &VolumeCommand{})
-	cli.Run()
+
+	if err := cli.Run(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**
In the original source code, when command RUN, we ignore the error from `c.rootCmd.Execute()`, with no error returned, there will be no exit code to judge from.
This PR adds error returning when executing a command. And return exit code 1 when there is a non-nil error.

**2.Does this pull request fix one issue?** 
fixes #105 

**3.Describe how you did it**
adds error returning when executing a command

**4.Describe how to verify it**
```
pouch (fix-105) $ ./pouch asdfghj
Error: unknown command "asdfghj" for "pouch"
Run 'pouch --help' for usage.
pouch (fix-105) $ echo $?
1
pouch (fix-105) $ ./pouch volume
Error: requires at least 1 arg(s), only received 0
Usage:
  pouch volume [command] [flags]
  pouch volume [command]

Available Commands:
  create      Create a pouch volume
  remove      Remove pouch volumes

Flags:
  -h, --help   help for volume

Global Flags:
  -H, --host string        Specify listen address of pouchd (default "unix:///var/run/pouchd.sock")
      --timeout duration   Set timeout (default 10s)
      --tlscacert string   Specify CA file of tls
      --tlscert string     Specify cert file of tls
      --tlskey string      Specify key file of tls
      --tlsverify          Switch if verify the remote when using tls

Use "pouch volume [command] --help" for more information about a command.

pouch (fix-105) $ echo $?
1
```

**5.Special notes for reviews**
And could you add the exit code checking into the integration test? @Letty5411 


