### PR TITLE
fix: make pouchd accepts no args

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,8 +23,9 @@ var (
 
 func main() {
 	var cmdServe = &cobra.Command{
-		Use:  "pouchd",
-		Args: cobra.MinimumNArgs(0),
+		Use:          "pouchd",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDaemon()
@@ -33,7 +34,9 @@ func main() {
 
 	setupFlags(cmdServe)
 
-	cmdServe.Execute()
+	if err := cmdServe.Execute(); err != nil {
+		os.Exit(1)
+	}
 }
 
 // runDaemon prepares configs, setups essential details and runs pouchd daemon.


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

1. make root command of pouchd accept no args and return non-zero exit code when error；
2. make pouchd error will not output command usage.

**2.Does this pull request fix one issue?** 

fixes #112 

**3.Describe how you did it**
Make root command of pouchd accept no arg. Actually in fact, pouchd only accepts flags.

**4.Describe how to verify it**
```
root@ubuntu:~/go/src/github.com/alibaba/pouch# ./pouchd asdfghj
Error: unknown command "asdfghj" for "pouchd"
Usage:
  pouchd [flags]

Flags:
  -c, --containerd string          where does containerd listened on (default "/var/run/containerd.sock")
      --containerd-config string   Specify the path of Containerd binary (default "/etc/containerd/config.toml")
      --containerd-path string     Specify the path of Containerd binary (default "/usr/local/bin/containerd")
  -D, --debug                      switch debug level
  -h, --help                       help for pouchd
      --home-dir string            The pouchd's home directory (default "/etc/pouchd")
  -l, --listen stringArray         which address to listen on (default [unix:///var/run/pouchd.sock])
      --tlscacert string           Specify CA file of tls
      --tlscert string             Specify cert file of tls
      --tlskey string              Specify key file of tls
      --tlsverify                  Switch if verify the remote when using tls

root@ubuntu:~/go/src/github.com/alibaba/pouch# echo $?
1
```

**5.Special notes for reviews**
none


