### PR TITLE
bugfix: modify go vet errror

### DIFF
--- a/volume/modules/ceph/ceph.go
+++ b/volume/modules/ceph/ceph.go
@@ -113,12 +113,12 @@ func (c *Ceph) Path(ctx driver.Context, v *types.Volume) (string, error) {
 // Options returns ceph volume options.
 func (c *Ceph) Options() map[string]types.Option {
 	return map[string]types.Option{
-		"conf":          {"/etc/ceph/ceph.conf", "set ceph config file"},
-		"key":           {"", "set ceph keyring file"},
-		"pool":          {"rbd", "set rbd image pool"},
-		"image-feature": {"", "set rbd image feature"},
-		"object-size":   {"4M", "set rbd image object size"},
-		"base":          {"", "create image by base image"},
+		"conf":          {Value: "/etc/ceph/ceph.conf", Desc: "set ceph config file"},
+		"key":           {Value: "", Desc: "set ceph keyring file"},
+		"pool":          {Value: "rbd", Desc: "set rbd image pool"},
+		"image-feature": {Value: "", Desc: "set rbd image feature"},
+		"object-size":   {Value: "4M", Desc: "set rbd image object size"},
+		"base":          {Value: "", Desc: "create image by base image"},
 	}
 }
 

--- a/volume/modules/local/local.go
+++ b/volume/modules/local/local.go
@@ -81,10 +81,10 @@ func (p *Local) Path(ctx driver.Context, v *types.Volume) (string, error) {
 // Options returns local volume's options.
 func (p *Local) Options() map[string]types.Option {
 	return map[string]types.Option{
-		"ids":      {"", "local volume user's ids"},
-		"reqID":    {"", "create local volume request id"},
-		"freeTime": {"", "local volume free time"},
-		"mount":    {"", "local directory"},
+		"ids":      {Value: "", Desc: "local volume user's ids"},
+		"reqID":    {Value: "", Desc: "create local volume request id"},
+		"freeTime": {Value: "", Desc: "local volume free time"},
+		"mount":    {Value: "", Desc: "local directory"},
 	}
 }
 

--- a/volume/modules/tmpfs/tmpfs.go
+++ b/volume/modules/tmpfs/tmpfs.go
@@ -63,9 +63,9 @@ func (p *Tmpfs) Path(ctx driver.Context, v *types.Volume) (string, error) {
 // Options returns tmpfs volume's options.
 func (p *Tmpfs) Options() map[string]types.Option {
 	return map[string]types.Option{
-		"ids":      {"", "tmpfs volume user's ids"},
-		"reqID":    {"", "create tmpfs volume request id"},
-		"freeTime": {"", "tmpfs volume free time"},
+		"ids":      {Value: "", Desc: "tmpfs volume user's ids"},
+		"reqID":    {Value: "", Desc: "create tmpfs volume request id"},
+		"freeTime": {Value: "", Desc: "tmpfs volume free time"},
 	}
 }
 

--- a/volume/vars.go
+++ b/volume/vars.go
@@ -20,16 +20,16 @@ const (
 )
 
 var commonOptions = map[string]types.Option{
-	"size":      {"", "volume size"},
-	"backend":   {"", "volume backend"},
-	"sifter":    {"", "volume scheduler sifter"},
-	"fs":        {"ext4", "volume make filesystem"},
-	"wbps":      {"", "volume write bps"},
-	"rbps":      {"", "volume read bps"},
-	"iops":      {"", "volume total iops"},
-	"riops":     {"", "volume read iops"},
-	"wiops":     {"", "volume write iops"},
-	"namespace": {"default", "volume namespace"},
+	"size":      {Value: "", Desc: "volume size"},
+	"backend":   {Value: "", Desc: "volume backend"},
+	"sifter":    {Value: "", Desc: "volume scheduler sifter"},
+	"fs":        {Value: "ext4", Desc: "volume make filesystem"},
+	"wbps":      {Value: "", Desc: "volume write bps"},
+	"rbps":      {Value: "", Desc: "volume read bps"},
+	"iops":      {Value: "", Desc: "volume total iops"},
+	"riops":     {Value: "", Desc: "volume read iops"},
+	"wiops":     {Value: "", Desc: "volume write iops"},
+	"namespace": {Value: "default", Desc: "volume namespace"},
 }
 
 // ListCommonOptions returns common options.


### PR DESCRIPTION
Modify go vet error:
    "types.Option composite literal uses unkeyed fields"

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>