### PR TITLE
feature: add discard backend for containerio

### DIFF
--- a/daemon/containerio/discard.go
+++ b/daemon/containerio/discard.go
@@ -1,0 +1,43 @@
+package containerio
+
+import (
+	"io"
+)
+
+func init() {
+	Register(func() Backend {
+		return &discardIO{}
+	})
+}
+
+type discardIO struct{}
+
+func (d *discardIO) Name() string {
+	return "discard"
+}
+
+func (d *discardIO) Init(opt *Option) error {
+	return nil
+}
+
+func (d *discardIO) Out() io.Writer {
+	return d
+}
+
+func (d *discardIO) In() io.Reader {
+	return d
+}
+
+func (d *discardIO) Close() error {
+	return nil
+}
+
+func (d *discardIO) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (d *discardIO) Read(p []byte) (int, error) {
+	block := make(chan struct{})
+	<-block
+	return 0, nil
+}

--- a/daemon/containerio/options.go
+++ b/daemon/containerio/options.go
@@ -39,6 +39,16 @@ func WithRootDir(dir string) func(*Option) {
 	}
 }
 
+// WithDiscard specified the discard backend.
+func WithDiscard() func(*Option) {
+	return func(opt *Option) {
+		if opt.backends == nil {
+			opt.backends = make(map[string]struct{})
+		}
+		opt.backends["discard"] = struct{}{}
+	}
+}
+
 // WithRawFile specified the raw-file backend.
 func WithRawFile() func(*Option) {
 	return func(opt *Option) {


### PR DESCRIPTION
"discard" is a empty  backend, we can use it to ignore stdio. We will use
it to implement the "exec" feature.

Signed-off-by: skoo87 <marckywu@gmail.com>


