### PR TITLE
fix: make server http response include correct status code

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/alibaba/pouch/apis/metrics"
+	"github.com/alibaba/pouch/pkg/httputils"
 
 	"github.com/sirupsen/logrus"
 )
@@ -18,8 +19,8 @@ func (s *Server) pullImage(ctx context.Context, resp http.ResponseWriter, req *h
 	tag := req.FormValue("tag")
 
 	if image == "" {
-		resp.WriteHeader(http.StatusBadRequest)
-		return fmt.Errorf("fromImage cannot be empty")
+		err := fmt.Errorf("fromImage cannot be empty")
+		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
 
 	if tag == "" {
@@ -32,7 +33,6 @@ func (s *Server) pullImage(ctx context.Context, resp http.ResponseWriter, req *h
 
 	if err := s.ImageMgr.PullImage(ctx, image, tag, resp); err != nil {
 		logrus.Errorf("failed to pull image %s:%s: %v", image, tag, err)
-		resp.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
 
@@ -45,7 +45,6 @@ func (s *Server) listImages(ctx context.Context, resp http.ResponseWriter, req *
 	imageList, err := s.ImageMgr.ListImages(ctx, filters)
 	if err != nil {
 		logrus.Errorf("failed to list images in containerd: %v", err)
-		resp.WriteHeader(http.StatusBadRequest)
 		return err
 	}
 	return json.NewEncoder(resp).Encode(imageList)
@@ -58,7 +57,6 @@ func (s *Server) searchImages(ctx context.Context, resp http.ResponseWriter, req
 	response, err := s.ImageMgr.SearchImages(ctx, searchPattern, registry)
 	if err != nil {
 		logrus.Errorf("failed to search images from resgitry: %v", err)
-		resp.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
 	return json.NewEncoder(resp).Encode(response)

--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -2,10 +2,14 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
 	"time"
+
+	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/pkg/httputils"
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
@@ -62,7 +66,7 @@ type handler func(context.Context, http.ResponseWriter, *http.Request) error
 func (s *Server) filter(handler handler) http.HandlerFunc {
 	pctx := context.Background()
 
-	return func(resp http.ResponseWriter, req *http.Request) {
+	return func(w http.ResponseWriter, req *http.Request) {
 		ctx, cancel := context.WithCancel(pctx)
 		defer cancel()
 
@@ -70,7 +74,7 @@ func (s *Server) filter(handler handler) http.HandlerFunc {
 		clientInfo := req.RemoteAddr
 		defer func() {
 			d := time.Since(t) / (time.Millisecond)
-			// if elapse time of handler >= 500ms, log request
+			// If elapse time of handler >= 500ms, log request.
 			if d >= 500 {
 				logrus.Infof("End of Calling %s %s, costs %d ms. client %s", req.Method, req.URL.Path, d, clientInfo)
 			}
@@ -87,9 +91,40 @@ func (s *Server) filter(handler handler) http.HandlerFunc {
 			logrus.Debugf("Calling %s %s, client %s", req.Method, req.URL.RequestURI(), clientInfo)
 		}
 
-		if err := handler(ctx, resp, req); err != nil {
-			logrus.Errorf("invoke %s error %v. client %s", req.URL.RequestURI(), err, clientInfo)
-			resp.Write([]byte(err.Error()))
+		// Start to handle request.
+		err := handler(ctx, w, req)
+		if err == nil {
+			return
 		}
+		// Handle error if request handling fails.
+		HandleErrorResponse(w, err)
 	}
+}
+
+// HandleErrorResponse handles err from daemon side and constructs response for client side.
+func HandleErrorResponse(w http.ResponseWriter, err error) {
+	var (
+		code   int
+		errMsg string
+	)
+
+	// By default, daemon side returns code 500 if error happens.
+	code = http.StatusInternalServerError
+	errMsg = err.Error()
+
+	httpErr, ok := err.(httputils.HTTPError)
+	if ok {
+		code = httpErr.Code()
+		errMsg = httpErr.Error()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+
+	resp := types.Error{
+		Message: errMsg,
+	}
+	enc.Encode(resp)
 }

--- a/apis/server/system_bridge.go
+++ b/apis/server/system_bridge.go
@@ -15,7 +15,6 @@ func (s *Server) ping(context context.Context, resp http.ResponseWriter, req *ht
 func (s *Server) info(ctx context.Context, resp http.ResponseWriter, req *http.Request) (err error) {
 	info, err := s.SystemMgr.Info()
 	if err != nil {
-		resp.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
 	resp.WriteHeader(http.StatusOK)
@@ -25,7 +24,6 @@ func (s *Server) info(ctx context.Context, resp http.ResponseWriter, req *http.R
 func (s *Server) version(ctx context.Context, resp http.ResponseWriter, req *http.Request) (err error) {
 	info, err := s.SystemMgr.Version()
 	if err != nil {
-		resp.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
 	resp.WriteHeader(http.StatusOK)

--- a/apis/server/volume_bridge.go
+++ b/apis/server/volume_bridge.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/pkg/httputils"
 	"github.com/alibaba/pouch/pkg/randomid"
 
 	"github.com/gorilla/mux"
@@ -15,8 +16,7 @@ func (s *Server) createVolume(ctx context.Context, resp http.ResponseWriter, req
 	var volumeCreateReq types.VolumeCreateRequest
 
 	if err := json.NewDecoder(req.Body).Decode(&volumeCreateReq); err != nil {
-		resp.WriteHeader(http.StatusBadRequest)
-		return err
+		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
 
 	name := volumeCreateReq.Name
@@ -33,7 +33,6 @@ func (s *Server) createVolume(ctx context.Context, resp http.ResponseWriter, req
 	}
 
 	if err := s.VolumeMgr.Create(ctx, name, driver, options, labels); err != nil {
-		resp.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
 
@@ -50,7 +49,6 @@ func (s *Server) removeVolume(ctx context.Context, resp http.ResponseWriter, req
 	name := mux.Vars(req)["name"]
 
 	if err := s.VolumeMgr.Remove(ctx, name); err != nil {
-		resp.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
 	resp.WriteHeader(http.StatusOK)

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -3,6 +3,7 @@ package mgr
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"path"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/alibaba/pouch/daemon/meta"
 	"github.com/alibaba/pouch/daemon/spec"
 	"github.com/alibaba/pouch/pkg/collect"
+	"github.com/alibaba/pouch/pkg/httputils"
 	"github.com/alibaba/pouch/pkg/kmutex"
 	"github.com/alibaba/pouch/pkg/randomid"
 
@@ -158,7 +160,8 @@ func (cm *ContainerManager) Create(ctx context.Context, name string, config *typ
 // Start a pre created Container.
 func (cm *ContainerManager) Start(ctx context.Context, cfg types.ContainerStartConfig) (err error) {
 	if cfg.ID == "" {
-		return fmt.Errorf("either container name or id is required")
+		err := fmt.Errorf("either container name or id is required")
+		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
 
 	cm.km.Lock(cfg.ID)
@@ -169,7 +172,8 @@ func (cm *ContainerManager) Start(ctx context.Context, cfg types.ContainerStartC
 		return err
 	}
 	if c == nil || c.Config == nil || c.ContainerState == nil {
-		return fmt.Errorf("no container found by %s", cfg.ID)
+		err := fmt.Errorf("no container found by %s", cfg.ID)
+		return httputils.NewHTTPError(err, http.StatusNotFound)
 	}
 	c.DetachKeys = cfg.DetachKeys
 

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -40,7 +40,7 @@ func (mgr *SystemManager) Version() (types.SystemVersion, error) {
 		GitCommit:  "",
 		GoVersion:  runtime.Version(),
 		// TODO:  add a pkg to support getting kernel version
-		//KernelVersion: kernel.Version(),
+		// KernelVersion: kernel.Version(),
 		Os:      runtime.GOOS,
 		Version: version.Version,
 	}, nil

--- a/pkg/httputils/http_error.go
+++ b/pkg/httputils/http_error.go
@@ -1,0 +1,27 @@
+package httputils
+
+// HTTPError represents an HTTP error which contains potential status code.
+// For API layer, daemon side should return error message and using correct status code
+// to construct response when an error happens in handling requests.
+type HTTPError struct {
+	message    string
+	statusCode int
+}
+
+// NewHTTPError returns a brand new HTTPError with input message and status code
+func NewHTTPError(err error, code int) HTTPError {
+	return HTTPError{
+		message:    err.Error(),
+		statusCode: code,
+	}
+}
+
+// Error returns Message field of HTTPError
+func (err HTTPError) Error() string {
+	return err.message
+}
+
+// Code returns status code field of HTTPError
+func (err HTTPError) Code() int {
+	return err.statusCode
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

This PR adds more details for status code in http response.

Handling an error from daemon, usually api side in server should construct error with status code according to HTTP. In the original implementation, we just get an error and warp with a StatusInternalServerError(500) which seems to be a little bit coarse-grained. 

So I defined a struct as below:
```
// HTTPError represents an HTTP error which contains potential status code.
// For API layer, daemon side should return error message and using correct status code
// to construct response when an error happens in handling requests.
type HTTPError struct {
	message    string
	statusCode int
}
```

If one place returns err with status code known, the we can explicitly return err by `return httputils.NewHTTPError(err, code)` to clearly specify status code.

In addition, when API side returns response, code does like this:
```
		// Start to handle request.
		err := handler(ctx, w, req)
		if err == nil {
			return
		}
		// Handle error if request handling fails.
		HandleErrorResponse(w, err)
	}
```

**2.Does this pull request fix one issue?** 
fixes https://github.com/alibaba/pouch/issues/32

**3.Describe how you did it**
Defining a new http error struct and handling them on api side.

**4.Describe how to verify it**
Test needs added.

**5.Special notes for reviews**
NONE


