### PR TITLE
fix: pouch pull image decode exception error

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -31,9 +31,10 @@ func (s *Server) pullImage(ctx context.Context, resp http.ResponseWriter, req *h
 		metrics.ImagePullSummary.WithLabelValues(image + ":" + tag).Observe(metrics.SinceInMicroseconds(start))
 	}(time.Now())
 
+	// Error information has be sent to client, so no need call resp.Write
 	if err := s.ImageMgr.PullImage(ctx, image, tag, resp); err != nil {
 		logrus.Errorf("failed to pull image %s:%s: %v", image, tag, err)
-		return err
+		return nil
 	}
 
 	return nil

--- a/cli/pull.go
+++ b/cli/pull.go
@@ -84,6 +84,10 @@ func renderOutput(responseBody io.ReadCloser) {
 func display(w io.Writer, statuses []ctrd.ProgressInfo, start time.Time) {
 	var total int64
 	for _, status := range statuses {
+		if status.ErrorMessage != "" {
+			fmt.Fprintf(os.Stderr, "%s\n", status.ErrorMessage)
+			return
+		}
 		total += status.Offset
 		switch status.Status {
 		case "downloading", "uploading":

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -62,14 +62,12 @@ func (mgr *ImageManager) PullImage(pctx context.Context, image, tag string, out 
 		close(wait)
 	}()
 
-	if err := mgr.client.PullImage(ctx, image+":"+tag, stream); err != nil {
-		return err
-	}
+	err := mgr.client.PullImage(ctx, image+":"+tag, stream)
 
 	// wait goroutine to exit.
 	<-wait
 
-	return nil
+	return err
 }
 
 // ListImages lists images stored by containerd.


### PR DESCRIPTION
Signed-off-by: HusterWan zirenwan@gmail.com

**1.Describe what this PR did**
fix json decode error when pouch pull image error

**2.Does this pull request fix one issue?** 
fixes #123 .

**3.Describe how you did it**
return error message through stream body when pouch pull image

**4.Describe how to verify it**
excute command line:  pouch pull busybox, will print error information
pouch:
![image](https://user-images.githubusercontent.com/10414039/33248165-11a76d7a-d2e9-11e7-89ff-f503569c1641.png)
pouchd
![image](https://user-images.githubusercontent.com/10414039/33248176-2618355a-d2e9-11e7-90d9-7d15aa8522e6.png)

**5.Special notes for reviews**
https://golang.org/pkg/net/http/#ResponseWriter
1)  WriteHeader  can only be called once
2)  before call Write, if  not call WriteHeader before, will call WriteHeader(http.StatusOK) first

there is a goroutine to send downloading progress information to client when pouch pull image, so when goroutine call Write once, the http header code will be set 200, later call WriteHeader(500) will print error: call multi WriteHeader,  and 500 will not send to client.

so we should not  only use http code to judge if pull is ok, but contains error information in ProgressMessage, then client can deal with error information appropriately

