### PR TITLE
refactor: refactor the container manager

### DIFF
--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -1,7 +1,10 @@
 package mgr
 
 import (
+	"sync"
+
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/daemon/meta"
 )
 
 type containerExecConfig struct {
@@ -16,4 +19,30 @@ type ContainerRemoveOption struct {
 	Force  bool
 	Volume bool
 	Link   bool
+}
+
+// Container represents the container instance in runtime.
+type Container struct {
+	sync.Mutex
+	meta *types.ContainerInfo
+}
+
+// ID returns container's id.
+func (c *Container) ID() string {
+	return c.meta.ID
+}
+
+// IsRunning returns container is running or not.
+func (c *Container) IsRunning() bool {
+	return c.meta.Status == types.RUNNING
+}
+
+// IsStopped returns container is stopped or not.
+func (c *Container) IsStopped() bool {
+	return c.meta.Status == types.STOPPED
+}
+
+// Write writes container's meta data into meta store.
+func (c *Container) Write(store *meta.Store) error {
+	return store.Put(c.meta)
 }

--- a/daemon/mgr/container_utils.go
+++ b/daemon/mgr/container_utils.go
@@ -1,0 +1,59 @@
+package mgr
+
+import (
+	"fmt"
+
+	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/daemon/meta"
+
+	"github.com/pkg/errors"
+)
+
+// containerID returns the container's id, the parameter 'nameOrPrefix' may be container's
+// name, id or prefix id.
+func (mgr *ContainerManager) containerID(nameOrPrefix string) (string, error) {
+	var obj meta.Object
+
+	// name is the container's name.
+	id, ok := mgr.NameToID.Get(nameOrPrefix).String()
+	if ok {
+		return id, nil
+	}
+
+	// name is the container's prefix of the id.
+	objs, err := mgr.Store.GetWithPrefix(nameOrPrefix)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get container info with prefix: %s", nameOrPrefix)
+	}
+	if len(objs) != 1 {
+		return "", fmt.Errorf("failed to get container info with prefix: %s, more than one", nameOrPrefix)
+	}
+	obj = objs[0]
+
+	meta, ok := obj.(*types.ContainerInfo)
+	if !ok {
+		return "", fmt.Errorf("failed to get container info, invalid meta's type")
+	}
+
+	return meta.ID, nil
+}
+
+func (mgr *ContainerManager) container(nameOrPrefix string) (*Container, error) {
+	res, ok := mgr.cache.Get(nameOrPrefix).Result()
+	if ok {
+		return res.(*Container), nil
+	}
+
+	id, err := mgr.containerID(nameOrPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	// lookup again
+	res, ok = mgr.cache.Get(id).Result()
+	if ok {
+		return res.(*Container), nil
+	}
+
+	return nil, fmt.Errorf("container: %s not found", id)
+}


### PR DESCRIPTION
define a "Container" structure, it represents the container instance in
pouch engine. The "Container"s are stored in memory, so we can use
"Container".Lock() to protect itself instead of the "KMutex", because
there is defects that using "KMutex"

Signed-off-by: skoo87 <marckywu@gmail.com>

