### PR TITLE
fix: make container create pass correct container name

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -31,9 +31,10 @@ func (cc *CreateCommand) Run(args []string) {
 	if len(args) == 2 {
 		config.Cmd = strings.Fields(args[1])
 	}
+	containerName := cc.name
 
 	apiClient := cc.cli.Client()
-	result, err := apiClient.ContainerCreate(config.ContainerConfig, config.HostConfig, "")
+	result, err := apiClient.ContainerCreate(config.ContainerConfig, config.HostConfig, containerName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create container: %v\n", err)
 		return

--- a/test/pouch_cli_create_test.go
+++ b/test/pouch_cli_create_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/go-check/check"
+)
+
+// PouchCreateSuite is the test suite fo help CLI.
+type PouchCreateSuite struct {
+}
+
+func init() {
+	check.Suite(&PouchCreateSuite{})
+}
+
+// SetUpTest does common setup in the beginning of each test.
+func (suite *PouchCreateSuite) SetUpTest(c *check.C) {
+	SkipIfFalse(c, IsLinux)
+}
+
+// TestPouchCreateName is to verify the correctness of creating contaier with specified name.
+func (suite *PouchCreateSuite) TestPouchCreateName(c *check.C) {
+	out, err := exec.Command("pouch", "create", "--name", "foo", "busybox:latest").Output()
+	c.Assert(err, check.IsNil)
+
+	if !strings.Contains(string(out), "foo") {
+		c.Fatalf("unexpected output %s expected foo\n", string(out))
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
This pr makes container create pass correct container name. And add a test case to cover this.

**2.Does this pull request fix one issue?** 
fixes #175 

**3.Describe how you did it**
Make function call take container name.

**4.Describe how to verify it**
Execute command, and you will find that the container name is exactly correct:
```
$ pouch create --name foo busybox:latest
container's id: ff15e41d96ecbfd4e3961bf39e31554e2b8cda46cf35fe65af4b8bb8434f1521, name: foo
```

**5.Special notes for reviews**
None 


