### PR TITLE
fix: make pouchd's root dir located in /var/lib

### DIFF
--- a/docs/commandline/pouchd.md
+++ b/docs/commandline/pouchd.md
@@ -20,7 +20,7 @@ Flags:
       --containerd-path string     Specify the path of Containerd binary (default "/usr/local/bin/containerd")
   -D, --debug                      switch debug level
   -h, --help                       help for this command
-      --home-dir string            The pouchd's home directory (default "/etc/pouchd")
+      --home-dir string            The pouchd's home directory (default "/var/lib/pouch")
   -l, --listen stringArray         which address to listen on (default [unix:///var/run/pouchd.sock])
       --tlscacert string           Specify CA file of tls
       --tlscert string             Specify cert file of tls

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func setupFlags(cmd *cobra.Command) {
 	flagSet.StringVar(
 		&cfg.HomeDir,
 		"home-dir",
-		"/etc/pouchd",
+		"/var/lib/pouch",
 		"The pouchd's home directory")
 
 	flagSet.StringArrayVarP(


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
I agree with @qingyunha that pouchd's root dir should be located in /var/lib or somewhere else. Since I think /etc/pouchd should store things like configuration.

Maybe in the future, we could add pouchd's configuration file in /etc/pouchd/config.json ...

**2.Does this pull request fix one issue?** 
fixes #172 

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
/cc @skoo87 @yyb196 

