### PR TITLE
refactor: make cli code more consistent

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -32,7 +32,8 @@ type Cli struct {
 func NewCli() *Cli {
 	return &Cli{
 		rootCmd: &cobra.Command{
-			Use: "pouch",
+			Use:   "pouch",
+			Short: "An efficient container engine",
 		},
 		padding: 3,
 	}
@@ -40,9 +41,12 @@ func NewCli() *Cli {
 
 // SetFlags sets all global options.
 func (c *Cli) SetFlags() *Cli {
-	cmd := c.rootCmd
-	cmd.PersistentFlags().StringVarP(&c.Option.host, "host", "H", "unix:///var/run/pouchd.sock", "Specify listen address of pouchd")
-	utils.SetupTLSFlag(cmd.PersistentFlags(), &c.Option.TLS)
+	flags := c.rootCmd.PersistentFlags()
+	flags.StringVarP(&c.Option.host, "host", "H", "unix:///var/run/pouchd.sock", "Specify connecting address of Pouch CLI")
+	flags.StringVar(&c.Option.TLS.Key, "tlskey", "", "Specify key file of TLS")
+	flags.StringVar(&c.Option.TLS.Cert, "tlscert", "", "Specify cert file of TLS")
+	flags.StringVar(&c.Option.TLS.CA, "tlscacert", "", "Specify CA file of TLS")
+	flags.BoolVar(&c.Option.TLS.VerifyRemote, "tlsverify", false, "Use TLS and verify remote")
 	return c
 }
 
@@ -67,20 +71,20 @@ func (c *Cli) Run() error {
 }
 
 // AddCommand add a subcommand.
-func (c *Cli) AddCommand(parent, command Command) {
-	command.Init(c)
+func (c *Cli) AddCommand(parent, child Command) {
+	child.Init(c)
 
-	cmd := command.Cmd()
+	parentCmd := parent.Cmd()
+	childCmd := child.Cmd()
 
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+	// make command error not return command usage
+	childCmd.SilenceUsage = true
+
+	childCmd.PreRun = func(cmd *cobra.Command, args []string) {
 		c.NewAPIClient()
 	}
 
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		command.Run(args)
-	}
-
-	parent.Cmd().AddCommand(cmd)
+	parentCmd.AddCommand(childCmd)
 }
 
 // NewTableDisplay creates a display instance, and uses to format output with table.

--- a/cli/command.go
+++ b/cli/command.go
@@ -8,7 +8,6 @@ import (
 type Command interface {
 	Init(*Cli)
 	Cmd() *cobra.Command
-	Run([]string)
 }
 
 type baseCommand struct {
@@ -17,8 +16,6 @@ type baseCommand struct {
 }
 
 func (b *baseCommand) Init(cli *Cli) {}
-
-func (b *baseCommand) Run(args []string) {}
 
 func (b *baseCommand) Cmd() *cobra.Command {
 	return b.cmd

--- a/cli/container.go
+++ b/cli/container.go
@@ -2,25 +2,12 @@ package main
 
 import (
 	"github.com/alibaba/pouch/apis/types"
-
-	"github.com/spf13/cobra"
 )
 
 type container struct {
 	name   string
 	tty    bool
 	volume []string
-}
-
-func (c *container) init() *cobra.Command {
-	cmd := &cobra.Command{}
-
-	// TODO add flag
-	cmd.Flags().StringVar(&c.name, "name", "", "specified the container's name")
-	cmd.Flags().BoolVarP(&c.tty, "tty", "t", false, "allocate a tty device")
-	cmd.Flags().StringSliceVarP(&c.volume, "volume", "v", nil, "create container with volumes")
-
-	return cmd
 }
 
 func (c *container) config() *types.ContainerConfigWrapper {

--- a/cli/image.go
+++ b/cli/image.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -19,35 +18,40 @@ type ImageCommand struct {
 // Init initialize images command.
 func (i *ImageCommand) Init(c *Cli) {
 	i.cli = c
-
 	i.cmd = &cobra.Command{
 		Use:   "images",
-		Short: "show images",
+		Short: "List all images",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return i.runImages(args)
+		},
 	}
 
 	i.addFlags()
 }
 
+// addFlags adds flags for specific command.
 func (i *ImageCommand) addFlags() {
-	i.cmd.Flags().BoolVarP(&i.flagQuiet, "quiet", "q", false, "only show image numeric id")
-	i.cmd.Flags().BoolVar(&i.flagDigest, "digest", false, "show image with digest")
+	flagSet := i.cmd.Flags()
+	flagSet.BoolVarP(&i.flagQuiet, "quiet", "q", false, "Only show image numeric ID")
+	flagSet.BoolVar(&i.flagDigest, "digest", false, "Show images with digest")
 }
 
-// Run is the entry of images container command.
-func (i *ImageCommand) Run(args []string) {
+// runImages is the entry of images container command.
+func (i *ImageCommand) runImages(args []string) error {
 	apiClient := i.cli.Client()
 
 	imageList, err := apiClient.ImageList()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get image list: %s\n", err)
-		return
+		return fmt.Errorf("failed to get image list: %v", err)
+
 	}
 
 	if i.flagQuiet {
 		for _, image := range imageList {
 			fmt.Println(image.Name)
 		}
-		return
+		return nil
 	}
 
 	if i.flagDigest {
@@ -63,4 +67,5 @@ func (i *ImageCommand) Run(args []string) {
 			fmt.Printf("%-20s %-56s %s\n", image.ID, image.Name, image.Size)
 		}
 	}
+	return nil
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"fmt"
 	"os"
 )
 
 func main() {
-	cli := NewCli().SetFlags()
+	cli := NewCli()
+
+	// set global flags for rootCmd in cli.
+	cli.SetFlags()
 
 	base := &baseCommand{cmd: cli.rootCmd, cli: cli}
 
@@ -21,6 +25,7 @@ func main() {
 	cli.AddCommand(base, &VolumeCommand{})
 
 	if err := cli.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -17,18 +16,27 @@ func (p *PsCommand) Init(c *Cli) {
 	p.cli = c
 	p.cmd = &cobra.Command{
 		Use:   "ps",
-		Short: "list all containers",
+		Short: "List all containers",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.runPs(args)
+		},
 	}
+	p.addFlags()
 }
 
-// Run is the entry of PsCommand command.
-func (p *PsCommand) Run(args []string) {
+// addFlags adds flags for specific command.
+func (p *PsCommand) addFlags() {
+	// TODO: add flags here
+}
+
+// runPs is the entry of PsCommand command.
+func (p *PsCommand) runPs(args []string) error {
 	apiClient := p.cli.Client()
 
 	containers, err := apiClient.ContainerList()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get container list: %v\n", err)
-		return
+		return fmt.Errorf("failed to get container list: %v", err)
 	}
 
 	display := p.cli.NewTableDisplay()
@@ -37,4 +45,5 @@ func (p *PsCommand) Run(args []string) {
 		display.AddRow([]string{c.Names[0], c.ID[:6], c.Status, c.Image})
 	}
 	display.Flush()
+	return nil
 }

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -15,24 +14,30 @@ type StopCommand struct {
 // Init initialize stop command.
 func (s *StopCommand) Init(c *Cli) {
 	s.cli = c
-
 	s.cmd = &cobra.Command{
 		Use:   "stop [container]",
 		Short: "Stop a running container",
 		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return s.runStop(args)
+		},
 	}
-
-	// TODO add flag
+	s.addFlags()
 }
 
-// Run is the entry of stop command.
-func (s *StopCommand) Run(args []string) {
+// addFlags adds flags for specific command.
+func (s *StopCommand) addFlags() {
+	// TODO: add flags here
+}
+
+// runStop is the entry of stop command.
+func (s *StopCommand) runStop(args []string) error {
 	apiClient := s.cli.Client()
 
 	container := args[0]
 
 	if err := apiClient.ContainerStop(container); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to stop container %s: %v \n", container, err)
-		return
+		return fmt.Errorf("failed to stop container %s: %v", container, err)
 	}
+	return nil
 }

--- a/cli/version.go
+++ b/cli/version.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -15,22 +14,31 @@ type VersionCommand struct {
 // Init initialize version command.
 func (v *VersionCommand) Init(c *Cli) {
 	v.cli = c
-
 	v.cmd = &cobra.Command{
 		Use:   "version",
-		Short: "Print version",
+		Short: "Print versions about Pouch CLI and Pouchd",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return v.runVersion()
+		},
 	}
+	v.addFlags()
 }
 
-// Run is the entry of version command.
-func (v *VersionCommand) Run(args []string) {
+// addFlags adds flags for specific command.
+func (v *VersionCommand) addFlags() {
+	// TODO: add flags here
+}
+
+// runVersion is the entry of version command.
+func (v *VersionCommand) runVersion() error {
 	apiClient := v.cli.Client()
 
 	result, err := apiClient.SystemVersion()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get system version: %v\n", err)
-		return
+		return fmt.Errorf("failed to get system version: %v", err)
 	}
 
 	v.cli.Print(result)
+	return nil
 }

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -29,8 +29,10 @@ func (v *VolumeCommand) Init(c *Cli) {
 	c.AddCommand(v, &VolumeRemoveCommand{})
 }
 
-// Run is the entry of VolumeCommand command.
-func (v *VolumeCommand) Run(args []string) {}
+// RunE is the entry of VolumeCommand command.
+func (v *VolumeCommand) RunE(args []string) error {
+	return nil
+}
 
 // VolumeCreateCommand is used to implement 'volume create' command.
 type VolumeCreateCommand struct {
@@ -49,49 +51,30 @@ func (v *VolumeCreateCommand) Init(c *Cli) {
 
 	v.cmd = &cobra.Command{
 		Use:   "create [args]",
-		Short: "Create a pouch volume",
+		Short: "Create a volume",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return v.runVolumeCreate(args)
+		},
 	}
-
-	flagSet := v.cmd.Flags()
-
-	flagSet.StringVarP(
-		&v.name,
-		"name",
-		"n",
-		"",
-		"create volume name")
-	flagSet.StringVarP(
-		&v.driver,
-		"driver",
-		"d",
-		"local",
-		"create volume with driver")
-	flagSet.StringSliceVarP(
-		&v.options,
-		"option",
-		"o",
-		nil,
-		"create volume with options")
-	flagSet.StringSliceVarP(
-		&v.labels,
-		"label",
-		"l",
-		nil,
-		"create volume with labels")
-
-	flagSet.StringSliceVarP(
-		&v.selectors,
-		"selector",
-		"s",
-		nil,
-		"create volume with selectors")
+	v.addFlags()
 }
 
-// Run is the entry of VolumeCreateCommand command.
-func (v *VolumeCreateCommand) Run(args []string) {
+// addFlags adds flags for specific command.
+func (v *VolumeCreateCommand) addFlags() {
+	flagSet := v.cmd.Flags()
+	flagSet.StringVarP(&v.name, "name", "n", "", "Specify name for volume")
+	flagSet.StringVarP(&v.driver, "driver", "d", "local", "Specify volume driver name (default 'local')")
+	flagSet.StringSliceVarP(&v.options, "option", "o", nil, "Set volume driver options")
+	flagSet.StringSliceVarP(&v.labels, "label", "l", nil, "Set labels for volume")
+	flagSet.StringSliceVarP(&v.selectors, "selector", "s", nil, "Set volume selectors")
+}
+
+// runVolumeCreate is the entry of VolumeCreateCommand command.
+func (v *VolumeCreateCommand) runVolumeCreate(args []string) error {
 	logrus.Debugf("create a volume: %s, options: %v, labels: %v, selectors: %v",
 		v.name, v.options, v.labels, v.selectors)
-	v.volumeCreate()
+	return v.volumeCreate()
 }
 
 func (v *VolumeCreateCommand) volumeCreate() error {
@@ -102,48 +85,47 @@ func (v *VolumeCreateCommand) volumeCreate() error {
 		Labels:     map[string]string{},
 	}
 
-	// analyze labels.
-	for _, l := range v.labels {
-		label := strings.Split(l, "=")
-		if len(label) != 2 {
-			err := fmt.Errorf("unknown label: %s", l)
-			v.cli.Print(err)
-			return err
-		}
-		volumeReq.Labels[label[0]] = label[1]
-	}
-
-	// analyze options.
-	for _, o := range v.options {
-		option := strings.Split(o, "=")
-		if len(option) != 2 {
-			err := fmt.Errorf("unknown option: %s", o)
-			v.cli.Print(err)
-			return err
-		}
-		volumeReq.DriverOpts[option[0]] = option[1]
-	}
-
-	// analyze selectors.
-	for _, s := range v.selectors {
-		selector := strings.Split(s, "=")
-		if len(selector) != 2 {
-			err := fmt.Errorf("unknown selector: %s", s)
-			v.cli.Print(err)
-			return err
-		}
-		volumeReq.DriverOpts["selector."+selector[0]] = selector[1]
+	if err := parseVolume(volumeReq, v); err != nil {
+		return err
 	}
 
 	apiClient := v.cli.Client()
-
 	volume, err := apiClient.VolumeCreate(volumeReq)
 	if err != nil {
-		logrus.Errorln(err)
 		return err
 	}
 
 	v.cli.Print(volume)
+	return nil
+}
+
+func parseVolume(volumeReq *types.VolumeCreateRequest, v *VolumeCreateCommand) error {
+	// analyze labels.
+	for _, label := range v.labels {
+		l := strings.Split(label, "=")
+		if len(label) != 2 {
+			return fmt.Errorf("unknown label %s: label format must be key=value", label)
+		}
+		volumeReq.Labels[l[0]] = l[1]
+	}
+
+	// analyze options.
+	for _, option := range v.options {
+		opt := strings.Split(option, "=")
+		if len(opt) != 2 {
+			return fmt.Errorf("unknown option %s: option format must be key=value", option)
+		}
+		volumeReq.DriverOpts[opt[0]] = opt[1]
+	}
+
+	// analyze selectors.
+	for _, selector := range v.selectors {
+		s := strings.Split(selector, "=")
+		if len(s) != 2 {
+			return fmt.Errorf("unknown selector %s: selector format must be key=value", selector)
+		}
+		volumeReq.DriverOpts["selector."+s[0]] = s[1]
+	}
 	return nil
 }
 
@@ -155,24 +137,30 @@ type VolumeRemoveCommand struct {
 // Init initializes VolumeRemoveCommand command.
 func (v *VolumeRemoveCommand) Init(c *Cli) {
 	v.cli = c
-
 	v.cmd = &cobra.Command{
-		Use:     "remove <volume name>",
+		Use:     "remove <name>",
 		Aliases: []string{"rm"},
-		Short:   "Remove pouch volume",
+		Short:   "Remove volume",
 		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return v.runVolumeRm(args)
+		},
 	}
+	v.addFlags()
 }
 
-// Run is the entry of VolumeRemoveCommand command.
-func (v *VolumeRemoveCommand) Run(args []string) {
+// addFlags adds flags for specific command.
+func (v *VolumeRemoveCommand) addFlags() {
+	// TODO: add flags here
+}
+
+// runVolumeRm is the entry of VolumeRemoveCommand command.
+func (v *VolumeRemoveCommand) runVolumeRm(args []string) error {
 	name := args[0]
 
 	logrus.Debugf("remove a volume: %s", name)
 
 	apiClient := v.cli.Client()
 
-	if err := apiClient.VolumeRemove(name); err != nil {
-		logrus.Errorln(err)
-	}
+	return apiClient.VolumeRemove(name)
 }

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ func main() {
 		Use:          "pouchd",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDaemon()
 		},
@@ -35,8 +34,25 @@ func main() {
 	setupFlags(cmdServe)
 
 	if err := cmdServe.Execute(); err != nil {
+		logrus.Error(err)
 		os.Exit(1)
 	}
+}
+
+// setupFlags setups flags for command line.
+func setupFlags(cmd *cobra.Command) {
+	flagSet := cmd.Flags()
+
+	flagSet.StringVar(&cfg.HomeDir, "home-dir", "/var/lib/pouch", "Specify root dir of pouchd")
+	flagSet.StringArrayVarP(&cfg.Listen, "listen", "l", []string{"unix:///var/run/pouchd.sock"}, "Specify listening addresses of Pouchd")
+	flagSet.BoolVarP(&cfg.Debug, "debug", "D", false, "Switch daemon log level to DEBUG mode")
+	flagSet.StringVarP(&cfg.ContainerdAddr, "containerd", "c", "/var/run/containerd.sock", "Specify listening address of containerd")
+	flagSet.StringVar(&cfg.ContainerdPath, "containerd-path", "/usr/local/bin/containerd", "Specify the path of containerd binary")
+	flagSet.StringVar(&cfg.ContainerdConfig, "containerd-config", "/etc/containerd/config.toml", "Specify the path of containerd configuration file")
+	flagSet.StringVar(&cfg.TLS.Key, "tlskey", "", "Specify key file of TLS")
+	flagSet.StringVar(&cfg.TLS.Cert, "tlscert", "", "Specify cert file of TLS")
+	flagSet.StringVar(&cfg.TLS.CA, "tlscacert", "", "Specify CA file of TLS")
+	flagSet.BoolVar(&cfg.TLS.VerifyRemote, "tlsverify", false, "Use TLS and verify remote")
 }
 
 // runDaemon prepares configs, setups essential details and runs pouchd daemon.
@@ -103,52 +119,6 @@ func runDaemon() error {
 	sigHandles = append(sigHandles, d.Shutdown)
 
 	return d.Run()
-}
-
-// setupFlags setups flags for command line.
-func setupFlags(cmd *cobra.Command) {
-	flagSet := cmd.Flags()
-
-	flagSet.StringVar(
-		&cfg.HomeDir,
-		"home-dir",
-		"/var/lib/pouch",
-		"The pouchd's home directory")
-
-	flagSet.StringArrayVarP(
-		&cfg.Listen,
-		"listen",
-		"l",
-		[]string{"unix:///var/run/pouchd.sock"},
-		"which address to listen on")
-
-	flagSet.BoolVarP(
-		&cfg.Debug,
-		"debug",
-		"D",
-		false,
-		"switch debug level")
-
-	flagSet.StringVarP(
-		&cfg.ContainerdAddr,
-		"containerd",
-		"c",
-		"/var/run/containerd.sock",
-		"where does containerd listened on")
-
-	flagSet.StringVar(
-		&cfg.ContainerdPath,
-		"containerd-path",
-		"/usr/local/bin/containerd",
-		"Specify the path of Containerd binary")
-
-	flagSet.StringVar(
-		&cfg.ContainerdConfig,
-		"containerd-config",
-		"/etc/containerd/config.toml",
-		"Specify the path of Containerd configuration file")
-
-	utils.SetupTLSFlag(flagSet, &cfg.TLS)
 }
 
 // initLog initializes log Level and log format of daemon.

--- a/pkg/utils/tls.go
+++ b/pkg/utils/tls.go
@@ -5,8 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
-
-	"github.com/spf13/pflag"
 )
 
 // TLSConfig contains information of tls which users can specify
@@ -42,12 +40,4 @@ func GenTLSConfig(key, cert, ca string) (*tls.Config, error) {
 	}
 
 	return tlsConfig, nil
-}
-
-// SetupTLSFlag setups flags of tls arguments
-func SetupTLSFlag(fs *pflag.FlagSet, tlsCfg *TLSConfig) {
-	fs.StringVar(&tlsCfg.Key, "tlskey", "", "Specify key file of tls")
-	fs.StringVar(&tlsCfg.Cert, "tlscert", "", "Specify cert file of tls")
-	fs.StringVar(&tlsCfg.CA, "tlscacert", "", "Specify CA file of tls")
-	fs.BoolVar(&tlsCfg.VerifyRemote, "tlsverify", false, "Switch if verify the remote when using tls")
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

This PR refactors cli a lot. I list the change in the following:

* make all commands' setflag as the same with the format of:

```
// Init initializes PsCommand command.
func (p *PsCommand) Init(c *Cli) {
	p.cli = c
	p.cmd = &cobra.Command{
		......
	}
	p.addFlags()
}
// addFlags adds flags for specific command.
func (p *PsCommand) addFlags() {
	// TODO: add flags here
}
```

* Remove `Run([]string)` in Command interface and change to define a RunE function in every single command's own scope;

* Try to use `return fmt.Errorf("failed to set raw mode")`to replace below case. and print the error message at last in main. I think this simplifies code a lot.
```
fmt.Fprintf(os.Stderr, "failed to set raw mode")
return
```

* change flag name and command usage in more well-organized way.


**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**

```
root@ubuntu:~/go/src/github.com/alibaba/pouch# ./pouch create --name foo busybox:latest
container ID: e1d541722d68dc5d133cca9e7bd8fd9338603e1763096c8e853522b60d11f7b9, name: foo
```

And the integration test will verify the correctness of this PR.

**5.Special notes for reviews**


