### PR TITLE
fix: make arg number correct in command line

### DIFF
--- a/cli/image.go
+++ b/cli/image.go
@@ -21,7 +21,7 @@ func (i *ImageCommand) Init(c *Cli) {
 	i.cmd = &cobra.Command{
 		Use:   "images",
 		Short: "List all images",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return i.runImages(args)
 		},

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -17,7 +17,7 @@ func (p *PsCommand) Init(c *Cli) {
 	p.cmd = &cobra.Command{
 		Use:   "ps",
 		Short: "List all containers",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.runPs(args)
 		},

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -52,7 +52,7 @@ func (v *VolumeCreateCommand) Init(c *Cli) {
 	v.cmd = &cobra.Command{
 		Use:   "create [args]",
 		Short: "Create a volume",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return v.runVolumeCreate(args)
 		},


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

This PR fixes arg number allowed in command line.
`pouch ps` and `pouch images` allows no args input.
And `pouch volume create` takes no args as well.

P.S. Flags are not args.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE

/cc @Letty5411 