### PR TITLE
fix: pouch images -q should only show the ID

### DIFF
--- a/cli/image.go
+++ b/cli/image.go
@@ -49,7 +49,7 @@ func (i *ImageCommand) runImages(args []string) error {
 
 	if i.flagQuiet {
 		for _, image := range imageList {
-			fmt.Println(image.Name)
+			fmt.Println(image.ID)
 		}
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

**1.Describe what this PR did**

This PR is to fix the bug, which `pouch images -q` only show the name, not ID.

**2.Does this pull request fix one issue?** 

#189

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**


