### PR TITLE
fix: make error msg of CLI appear just once

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -77,8 +77,9 @@ func (c *Cli) AddCommand(parent, child Command) {
 	parentCmd := parent.Cmd()
 	childCmd := child.Cmd()
 
-	// make command error not return command usage
+	// make command error not return command usage and error
 	childCmd.SilenceUsage = true
+	childCmd.SilenceErrors = true
 
 	childCmd.PreRun = func(cmd *cobra.Command, args []string) {
 		c.NewAPIClient()

--- a/cli/main.go
+++ b/cli/main.go
@@ -25,7 +25,7 @@ func main() {
 	cli.AddCommand(base, &VolumeCommand{})
 
 	if err := cli.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

Without this PR, cli error will appear twice like in issue https://github.com/alibaba/pouch/issues/192:
```
#pouch start "  fbb47a  "
Error: failed to start container   fbb47a  : failed to get container info with prefix:   fbb47a  , there are 0 containers
failed to start container   fbb47a  : failed to get container info with prefix:   fbb47a  , there are 0 containers
```
This is not reasonable and weird.

**2.Does this pull request fix one issue?** 
fixes https://github.com/alibaba/pouch/issues/194

**3.Describe how you did it**
Make cli silenceerror true.

**4.Describe how to verify it**
```
root@ubuntu:~/go/src/github.com/alibaba/pouch# pouch start "  fbb47a  "
Error: failed to start container   fbb47a  : {"message":"failed to get container info with prefix:   fbb47a  , there are 0 containers"}
```

**5.Special notes for reviews**
NONE


