### PR TITLE
bugfix: fix the timeout error of "pouch stop"

### DIFF
--- a/ctrd/watch.go
+++ b/ctrd/watch.go
@@ -68,6 +68,7 @@ func (w *watch) add(pack containerPack) {
 			exitCode: status.ExitCode(),
 			exitTime: status.ExitTime(),
 		}
+		pack.ch <- msg
 
 		for _, hook := range w.hooks {
 			if err := hook(pack.id, msg); err != nil {
@@ -75,8 +76,6 @@ func (w *watch) add(pack containerPack) {
 				break
 			}
 		}
-
-		pack.ch <- msg
 
 	}(pack)
 


### PR DESCRIPTION
e.g.
pouch stop d56e78b
Error: failed to stop container d56e78: {"message":"failed to destroy container: d56e78b56a79846d77d6d5f4d16260715e30dd7ebb118dbef91f7c639485a3a9: time out"}

Signed-off-by: skoo87 <marckywu@gmail.com>


