### PR TITLE
feature: add pouchd -v command

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,14 +11,16 @@ import (
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/pkg/exec"
 	"github.com/alibaba/pouch/pkg/utils"
+	"github.com/alibaba/pouch/version"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var (
-	cfg        config.Config
-	sigHandles []func() error
+	cfg          config.Config
+	sigHandles   []func() error
+	printVersion bool
 )
 
 func main() {
@@ -53,10 +55,17 @@ func setupFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.TLS.Cert, "tlscert", "", "Specify cert file of TLS")
 	flagSet.StringVar(&cfg.TLS.CA, "tlscacert", "", "Specify CA file of TLS")
 	flagSet.BoolVar(&cfg.TLS.VerifyRemote, "tlsverify", false, "Use TLS and verify remote")
+	flagSet.BoolVarP(&printVersion, "version", "v", false, "Print daemon version")
 }
 
 // runDaemon prepares configs, setups essential details and runs pouchd daemon.
 func runDaemon() error {
+	//user specifies --version or -v, print version and return.
+	if printVersion {
+		fmt.Println(version.Version)
+		return nil
+	}
+
 	// initialize log.
 	initLog()
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Sometimes users need to check pouchd's version without pouch client, especially on those scenarios that we cannot send socket/HTTP request.

Add `pouchd --version` or `pouchd -v` to pouchd command line.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes https://github.com/alibaba/pouch/issues/43

**3.Describe how you did it**
Add a flag there

**4.Describe how to verify it**
```
root@ubuntu:~/go/src/github.com/alibaba/pouch# pouchd --version
0.1.0-dev
root@ubuntu:~/go/src/github.com/alibaba/pouch# pouchd -v
0.1.0-dev
```

**5.Special notes for reviews**
NONE


