### PR TITLE
bugfix: Fix exec and stop

### DIFF
--- a/ctrd/watch.go
+++ b/ctrd/watch.go
@@ -68,6 +68,7 @@ func (w *watch) add(pack containerPack) {
 			exitCode: status.ExitCode(),
 			exitTime: status.ExitTime(),
 		}
+		pack.ch <- msg
 
 		for _, hook := range w.hooks {
 			if err := hook(pack.id, msg); err != nil {
@@ -75,8 +76,6 @@ func (w *watch) add(pack containerPack) {
 				break
 			}
 		}
-
-		pack.ch <- msg
 
 	}(pack)
 

--- a/ctrd/watch.go
+++ b/ctrd/watch.go
@@ -14,6 +14,12 @@ type Message struct {
 	exitCode uint32
 	exitTime time.Time
 	err      error
+	startErr error
+}
+
+// StartError returns the error of start exec process or container.
+func (m *Message) StartError() error {
+	return m.startErr
 }
 
 // Error returns the error contained in Message.

--- a/daemon/containerio/container_io.go
+++ b/daemon/containerio/container_io.go
@@ -170,8 +170,10 @@ func (io *ContainerIO) Write(data []byte) (int, error) {
 // Close implements the standard Close interface.
 func (io *ContainerIO) Close() error {
 	for name, b := range io.backends {
-		b.backend.Close()
+		// we need to close ringbuf before close backend, because close ring will flush
+		// the remain data into backend.
 		b.ring.Close()
+		b.backend.Close()
 
 		logrus.Infof("close containerio backend: %s, id: %s", name, io.id)
 	}

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -473,8 +473,12 @@ func (cm *ContainerManager) stoppedAndRelease(id string, m *ctrd.Message) error 
 }
 
 func (cm *ContainerManager) exitedAndRelease(id string, m *ctrd.Message) error {
-	// release io.
 	if io := cm.IOs.Get(id); io != nil {
+		if err := m.StartError(); err != nil {
+			fmt.Fprintf(io.Stdout, "%v\n", err)
+		}
+
+		// close io
 		io.Stderr.Close()
 		io.Stdout.Close()
 		io.Stdin.Close()


### PR DESCRIPTION
the pr contain two commits, one fix exec, another fix stop.

1. fix the timeout error of "pouch stop"

e.g.
    pouch stop d56e78b
    Error: failed to stop container d56e78: {"message":"failed to destroy container: d56e78b56a79846d77d6d5f4d16260715e30dd7ebb118dbef91f7c639485a3a9: time out"}

2. fix "pouch exec"

when pouch exec a process that not found in $PATH in container, the
    pouch cli will hang forever, don't print any error. the patch will fix
    it, and print error on STDOUT.

fix #187 

 Signed-off-by: skoo87 <marckywu@gmail.com>