### PR TITLE
test: add test to images quiet flag

### DIFF
--- a/test/pouch_cli_images_test.go
+++ b/test/pouch_cli_images_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os/exec"
+	"regexp"
 
 	"github.com/go-check/check"
 )
@@ -36,6 +37,20 @@ func (suite *PouchImagesSuite) TearDownSuite(c *check.C) {
 // TearDownTest does cleanup work in the end of each test.
 func (suite *PouchImagesSuite) TearDownTest(c *check.C) {
 	// TODO add cleanup work
+}
+
+// TestImagesQuietOption is to verify the quiet flag.
+func (suite *PouchImagesSuite) TestImagesQuietFlag(c *check.C) {
+	qOut, _, err := runCmd(exec.Command("pouch", "images", "-q"))
+	c.Assert(err, check.IsNil)
+
+	quietOut, _, err := runCmd(exec.Command("pouch", "images", "--quiet"))
+	c.Assert(err, check.IsNil)
+
+	c.Assert(qOut, check.Equals, quietOut)
+	if match, _ := regexp.MatchString("^[0-9a-f]+\n$", qOut); !match {
+		c.Fatalf("should return numeric ID, but got %s", qOut)
+	}
 }
 
 // TestImagesWorks tests "pouch image" work.


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

**1.Describe what this PR did**

Add test case for `pouch images -q|--quiet`.

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
For now, we're missing `pouch rm` functionality. In local testing, I did hack-thing to `rm -rf /var/lib/pouch/containers` to make the clean env. It's killing me.

I think the `hack/make.sh` can run pouchd in other scope before we have `pouch rm` functionality.

