### PR TITLE
feature: add "pouch rm"

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -10,13 +10,27 @@ import (
 	"time"
 
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/daemon/mgr"
 	"github.com/alibaba/pouch/pkg/httputils"
 
 	"github.com/gorilla/mux"
 )
 
-// TODO
 func (s *Server) removeContainers(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
+	name := mux.Vars(req)["name"]
+
+	option := &mgr.ContainerRemoveOption{
+		Force: httputils.BoolValue(req, "force"),
+		// TODO Volume and Link will be supported in the future.
+		Volume: httputils.BoolValue(req, "v"),
+		Link:   httputils.BoolValue(req, "link"),
+	}
+
+	if err := s.ContainerMgr.Remove(ctx, name, option); err != nil {
+		return err
+	}
+
+	resp.WriteHeader(http.StatusNoContent)
 	return nil
 }
 

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -298,7 +298,24 @@ paths:
           schema:
            $ref: "#/definitions/Error"
       tags: ["Container"]
-
+  /containers/{name}:
+    delete:
+      summary: "Remove one container"
+      operationId: "ContainerRemove"
+      parameters:
+        - name: "name"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          type: "string"
+      responses:
+        204:
+          description: "no error"
+        500:
+          description: "server error"
+          schema:
+           $ref: "#/definitions/Error"
+      tags: ["Container"]
   /volumes:
     get:
       summary: "List volumes"

--- a/cli/main.go
+++ b/cli/main.go
@@ -19,6 +19,7 @@ func main() {
 	cli.AddCommand(base, &StartCommand{})
 	cli.AddCommand(base, &StopCommand{})
 	cli.AddCommand(base, &PsCommand{})
+	cli.AddCommand(base, &RmCommand{})
 	cli.AddCommand(base, &ExecCommand{})
 	cli.AddCommand(base, &VersionCommand{})
 	cli.AddCommand(base, &ImageCommand{})

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var rmDescription = `
+Remove a container object in Pouchd.
+If a container be stopped or created, you can remove it. 
+If the container be running, you can also remove it with flag force.
+When the container be removed, the all resource of the container will
+be released.
+`
+
+// RmCommand is used to implement 'rm' command.
+type RmCommand struct {
+	baseCommand
+	force bool
+}
+
+// Init initializes RmCommand command.
+func (r *RmCommand) Init(c *Cli) {
+	r.cli = c
+	r.cmd = &cobra.Command{
+		Use:   "rm container",
+		Short: "Remove one or more containers",
+		Long:  rmDescription,
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return r.runRm(args)
+		},
+		Example: rmExample(),
+	}
+	r.addFlags()
+}
+
+// addFlags adds flags for specific command.
+func (r *RmCommand) addFlags() {
+	r.cmd.Flags().BoolVarP(&r.force, "force", "f", false, "if the container is running, force to remove it")
+}
+
+// runRm is the entry of RmCommand command.
+func (r *RmCommand) runRm(args []string) error {
+	apiClient := r.cli.Client()
+
+	for _, name := range args {
+		if err := apiClient.ContainerRemove(name, r.force); err != nil {
+			return fmt.Errorf("failed to remove container: %v", err)
+		}
+		fmt.Printf("%s\n", name)
+	}
+
+	return nil
+}
+
+func rmExample() string {
+	return `$ pouch rm 5d3152
+5d3152
+
+$ pouch rm -f 493028
+493028`
+}

--- a/client/container.go
+++ b/client/container.go
@@ -46,12 +46,27 @@ func (client *APIClient) ContainerStart(name, detachKeys string) error {
 	return err
 }
 
-// ContainerStop stops a container
+// ContainerStop stops a container.
 func (client *APIClient) ContainerStop(name string) error {
 	resp, err := client.post("/containers/"+name+"/stop", nil, nil)
 	ensureCloseReader(resp)
 
 	return err
+}
+
+// ContainerRemove removes a container.
+func (client *APIClient) ContainerRemove(name string, force bool) error {
+	q := url.Values{}
+	if force {
+		q.Set("force", "true")
+	}
+
+	resp, err := client.delete("/containers/"+name, q)
+	if err != nil {
+		return err
+	}
+	ensureCloseReader(resp)
+	return nil
 }
 
 // ContainerList returns the list of containers.

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -132,8 +132,38 @@ func (mgr *ContainerManager) Restore(ctx context.Context) error {
 }
 
 // Remove removes a container, it may be running or stopped and so on.
-// TODO
 func (mgr *ContainerManager) Remove(ctx context.Context, name string, option *ContainerRemoveOption) error {
+	c, err := mgr.container(name)
+	if err != nil {
+		return err
+	}
+	c.Lock()
+	defer c.Unlock()
+
+	if !c.IsStopped() && !c.IsCreated() && !option.Force {
+		return fmt.Errorf("container: %s is not stopped, can't remove it without flag force", c.ID())
+	}
+
+	// if the container is running, force to stop it.
+	if c.IsRunning() && option.Force {
+		if _, err := mgr.Client.DestroyContainer(ctx, c.ID()); err != nil {
+			if cerr, ok := err.(ctrd.Error); !ok || cerr != ctrd.ErrContainerNotfound {
+				return errors.Wrapf(err, "failed to remove container: %s", c.ID())
+			}
+		}
+	}
+
+	// remove name
+	mgr.NameToID.Remove(c.Name())
+
+	// remove meta data
+	if err := mgr.Store.Remove(c.meta.Key()); err != nil {
+		logrus.Errorf("failed to remove container: %s meta store", c.ID())
+	}
+
+	// remove container cache
+	mgr.cache.Remove(c.ID())
+
 	return nil
 }
 
@@ -389,7 +419,15 @@ func (mgr *ContainerManager) List(ctx context.Context) ([]*types.ContainerInfo, 
 
 // Get the detailed information of container
 func (mgr *ContainerManager) Get(name string) (*types.ContainerInfo, error) {
-	return mgr.containerInfo(name)
+	c, err := mgr.container(name)
+	if err != nil {
+		return nil, err
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	return c.meta, nil
 }
 
 // Rename renames a container

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -32,6 +32,11 @@ func (c *Container) ID() string {
 	return c.meta.ID
 }
 
+// Name returns container's name.
+func (c *Container) Name() string {
+	return c.meta.Name
+}
+
 // IsRunning returns container is running or not.
 func (c *Container) IsRunning() bool {
 	return c.meta.Status == types.RUNNING
@@ -40,6 +45,11 @@ func (c *Container) IsRunning() bool {
 // IsStopped returns container is stopped or not.
 func (c *Container) IsStopped() bool {
 	return c.meta.Status == types.STOPPED
+}
+
+// IsCreated returns container is created or not.
+func (c *Container) IsCreated() bool {
+	return c.meta.Status == types.CREATED
 }
 
 // Write writes container's meta data into meta store.

--- a/pkg/httputils/http_utils.go
+++ b/pkg/httputils/http_utils.go
@@ -1,0 +1,12 @@
+package httputils
+
+import (
+	"net/http"
+	"strings"
+)
+
+// BoolValue transforms a form value in different formats into a boolean type.
+func BoolValue(r *http.Request, k string) bool {
+	s := strings.ToLower(strings.TrimSpace(r.FormValue(k)))
+	return !(s == "" || s == "0" || s == "no" || s == "false" || s == "none")
+}


### PR DESCRIPTION
"pouch rm" is used to remove a container which is stopped or created,
if a container is running, you can use "pouch rm -f" to force to remove
the container.

Signed-off-by: skoo87 <marckywu@gmail.com>



