### PR TITLE
feature: format image size

### DIFF
--- a/ctrd/image.go
+++ b/ctrd/image.go
@@ -3,12 +3,12 @@ package ctrd
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"sync"
 	"time"
 
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/pkg/jsonstream"
+	"github.com/alibaba/pouch/pkg/utils"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
@@ -48,7 +48,7 @@ func (c *Client) ListImages(ctx context.Context, filter ...string) ([]types.Imag
 			Name:   image.Name(),
 			ID:     string(digest[len(digestPrefix) : len(digestPrefix)+12]),
 			Digest: string(digest),
-			Size:   formatSize(size),
+			Size:   utils.FormatSize(size),
 		})
 	}
 	return images, nil
@@ -247,10 +247,6 @@ outer:
 			done = true // allow ui to update once more
 		}
 	}
-}
-
-func formatSize(size int64) string {
-	return strconv.FormatInt(size, 10)
 }
 
 type jobs struct {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,9 +1,31 @@
 package utils
 
+import "fmt"
+
 // If implements ternary operator. if cond is true return v1, or return v2 instead.
 func If(cond bool, v1, v2 interface{}) interface{} {
 	if cond {
 		return v1
 	}
 	return v2
+}
+
+// FormatSize format image size to B/KB/MB/GB
+func FormatSize(size int64) string {
+	if size <= 0 {
+		return "0.00 B"
+	}
+	// we consider image size less than 1024 GB
+	suffixes := []string{"B", "KB", "MB", "GB"}
+
+	var count int
+	formattedSize := float64(size)
+	for count = 0; count < 3; count++ {
+		if formattedSize < 1024 {
+			break
+		}
+		formattedSize /= 1024
+	}
+
+	return fmt.Sprintf("%.2f %s", formattedSize, suffixes[count])
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatSize(t *testing.T) {
+	assert := assert.New(t)
+	kvs := map[int64]string{
+		-1024:         "0.00 B",
+		0:             "0.00 B",
+		1024:          "1.00 KB",
+		1024000:       "1000.00 KB",
+		1024000000000: "953.67 GB",
+	}
+
+	for k, v := range kvs {
+		size := FormatSize(k)
+		assert.Equal(v, size)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

format image size

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

before image size format 
```
$ sudo ./pouch images 
IMAGE ID             IMAGE NAME                                               SIZE
bbc3a0323522         docker.io/library/busybox:latest                         2699
```

with this patch

```
$ sudo ./pouch images
IMAGE ID             IMAGE NAME                                               SIZE
bbc3a0323522         docker.io/library/busybox:latest                         2.64 KB
```

**4.Describe how to verify it**

**5.Special notes for reviews**


