### PR TITLE
remove the commit number in generate-swagger-models.sh

### DIFF
--- a/hack/generate-swagger-models.sh
+++ b/hack/generate-swagger-models.sh
@@ -3,7 +3,6 @@
 # Here is details of the swagger binary we use.
 # $ swagger version
 # version: 0.12.0
-# commit: 8135eb6728e43b73489e80f94426e6d387809502
 
 # Get the absolute path of this file
 DIR="$( cd "$( dirname "$0"  )" && pwd  )"


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Actually it is a bug of swagger.

The commit number of swagger 0.12.0 should be :
"68ea41dcf206410c74d397d3bbff42aedff35e4d"

But the output of command `swagger version` is:
version: 0.12.0
commit: 8135eb6728e43b73489e80f94426e6d387809502

And "8135eb6728e43b73489e80f94426e6d387809502" is the commit number of swagger 0.11.0.

It's really confusing, so remove it to avoid misleading other contributors.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


