### PR TITLE
fix: fix error use in new spec

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -266,11 +266,7 @@ func (c *Client) createContainer(ctx context.Context, ref, id string, container 
 
 	options := []containerd.NewContainerOpts{
 		containerd.WithNewSnapshot(id, img),
-	}
-	if container.Spec != nil {
-		options = append(options, containerd.WithSpec(container.Spec, specOptions...))
-	} else {
-		options = append(options, containerd.WithNewSpec(specOptions...))
+		containerd.WithSpec(container.Spec, specOptions...),
 	}
 
 	nc, err := c.client.NewContainer(ctx, id, options...)


### PR DESCRIPTION
Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

containerd.WithNewSpec need context with namespace key, in function
createContainer, ctx does not have such key, which will cause
containerd.WithSpec() fail

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


