### PR TITLE
refactor: remove container start config object

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -104,13 +104,11 @@ func (s *Server) createContainer(ctx context.Context, resp http.ResponseWriter, 
 }
 
 func (s *Server) startContainer(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
-	name := mux.Vars(req)["name"]
-	config := types.ContainerStartConfig{
-		ID:         name,
-		DetachKeys: req.FormValue("detachKeys"),
-	}
+	id := mux.Vars(req)["name"]
 
-	if err := s.ContainerMgr.Start(ctx, config); err != nil {
+	detachKeys := req.FormValue("detachKeys")
+
+	if err := s.ContainerMgr.Start(ctx, id, detachKeys); err != nil {
 		return err
 	}
 

--- a/apis/types/container_start_config.go
+++ b/apis/types/container_start_config.go
@@ -1,7 +1,0 @@
-package types
-
-// ContainerStartConfig accommodates all parameters need by starting container
-type ContainerStartConfig struct {
-	ID         string
-	DetachKeys string
-}

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -28,7 +28,7 @@ type ContainerMgr interface {
 	Create(ctx context.Context, name string, config *types.ContainerConfigWrapper) (*types.ContainerCreateResp, error)
 
 	// Start a container.
-	Start(ctx context.Context, config types.ContainerStartConfig) error
+	Start(ctx context.Context, id, detachKeys string) error
 
 	// Stop a container.
 	Stop(ctx context.Context, name string, timeout time.Duration) error
@@ -264,13 +264,13 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 }
 
 // Start a pre created Container.
-func (mgr *ContainerManager) Start(ctx context.Context, cfg types.ContainerStartConfig) (err error) {
-	if cfg.ID == "" {
+func (mgr *ContainerManager) Start(ctx context.Context, id, detachKeys string) (err error) {
+	if id == "" {
 		err := fmt.Errorf("either container name or id is required")
 		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
 
-	c, err := mgr.container(cfg.ID)
+	c, err := mgr.container(id)
 	if err != nil {
 		return err
 	}
@@ -279,10 +279,10 @@ func (mgr *ContainerManager) Start(ctx context.Context, cfg types.ContainerStart
 	defer c.Unlock()
 
 	if c.meta.Config == nil || c.meta.ContainerState == nil {
-		err := fmt.Errorf("no container found by %s", cfg.ID)
+		err := fmt.Errorf("no container found by %s", id)
 		return httputils.NewHTTPError(err, http.StatusNotFound)
 	}
-	c.meta.DetachKeys = cfg.DetachKeys
+	c.meta.DetachKeys = detachKeys
 
 	// new a default spec.
 	s, err := ctrd.NewDefaultSpec(ctx, c.ID())


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

struct in apis/types is used for data wrap between client side and daemon side. While here ContainerStartConfig is only used in daemon side, then I think we need to remove this. When removing this struct, some codes in daemon side need updated as well.

This work is related to start API, while it is not in swagger.yml.

So I add this API in swagger.yml.

**2.Does this pull request fix one issue?** 
fixes one part of #256 

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
/cc @skoo87 


