### PR TITLE
refactor: use oci v1 reference to parse image name

### DIFF
--- a/cli/pull.go
+++ b/cli/pull.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/alibaba/pouch/ctrd"
+	"github.com/alibaba/pouch/pkg/reference"
 
 	"github.com/containerd/containerd/progress"
 	"github.com/spf13/cobra"
@@ -48,10 +48,13 @@ func (p *PullCommand) addFlags() {
 
 // runPull is the entry of pull command.
 func (p *PullCommand) runPull(args []string) error {
-	name, tag := parseNameTag(args[0])
+	ref, err := reference.Parse(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to pull image: %v", err)
+	}
 
 	apiClient := p.cli.Client()
-	responseBody, err := apiClient.ImagePull(name, tag)
+	responseBody, err := apiClient.ImagePull(ref.Name, ref.Tag)
 	if err != nil {
 		return fmt.Errorf("failed to pull image: %v", err)
 	}
@@ -135,23 +138,6 @@ func display(w io.Writer, statuses []ctrd.ProgressInfo, start time.Time) error {
 		progress.Bytes(total),
 		progress.NewBytesPerSecond(total, time.Since(start)))
 	return nil
-}
-
-// parseNameTag parses input arg and gets image name and image tag.
-func parseNameTag(input string) (string, string) {
-	fields := strings.SplitN(input, ":", 2)
-
-	var name, tag string
-
-	name = fields[0]
-
-	if len(fields) == 1 {
-		tag = "latest"
-	} else if len(fields) == 2 {
-		tag = fields[1]
-	}
-
-	return name, tag
 }
 
 // pullExample shows examples in pull command, and is used in auto-generated cli docs.

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -1,0 +1,38 @@
+package reference
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrInvalid is used to return error if reference is invalid
+	ErrInvalid = errors.New("invalid reference")
+
+	// defaultTag is latest if there is no tag
+	defaultTag = "latest"
+)
+
+// Ref represents image name.
+type Ref struct {
+	Name string
+	Tag  string
+}
+
+// String returns reference in string.
+func (r Ref) String() string {
+	return fmt.Sprintf("%s:%s", r.Name, r.Tag)
+}
+
+// Parse a string into reference.
+func Parse(s string) (Ref, error) {
+	if ok := regRef.MatchString(s); !ok {
+		return Ref{}, ErrInvalid
+	}
+
+	tag := defaultTag
+	if loc := regTag.FindStringIndex(s); loc != nil {
+		s, tag = s[:loc[0]], s[loc[0]+1:]
+	}
+	return Ref{Name: s, Tag: tag}, nil
+}

--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -1,0 +1,71 @@
+package reference
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	type tCase struct {
+		name     string
+		input    string
+		expected Ref
+		err      error
+	}
+
+	for _, tc := range []tCase{
+		{
+			name:  "Normal",
+			input: "docker.io/library/nginx:alpine",
+			expected: Ref{
+				Name: "docker.io/library/nginx",
+				Tag:  "alpine",
+			},
+			err: nil,
+		}, {
+			name:  "Localhost registry",
+			input: "localhost:80/nginx:alpine",
+			expected: Ref{
+				Name: "localhost:80/nginx",
+				Tag:  "alpine",
+			},
+			err: nil,
+		}, {
+			name:  " : in path",
+			input: "localhost:80/nginx:nginx/alpine",
+			expected: Ref{
+				Name: "localhost:80/nginx:nginx/alpine",
+				Tag:  "latest",
+			},
+			err: nil,
+		}, {
+			name:     "Contains scheme",
+			input:    "http://docker.io/library/nginx:alpine",
+			expected: Ref{},
+			err:      ErrInvalid,
+		}, {
+			name:     "Contains query",
+			input:    "docker.io/library/nginx?tag=alpine",
+			expected: Ref{},
+			err:      ErrInvalid,
+		}, {
+			name:     "Contains fragment",
+			input:    "docker.io/library/nginx#tag=alpine",
+			expected: Ref{},
+			err:      ErrInvalid,
+		}, {
+			name:  "Punycode",
+			input: "xn--bcher-kva.tld/redis:3",
+			expected: Ref{
+				Name: "xn--bcher-kva.tld/redis",
+				Tag:  "3",
+			},
+			err: nil,
+		},
+	} {
+		ref, err := Parse(tc.input)
+		assert.Equal(t, tc.err, err, tc.name)
+		assert.Equal(t, tc.expected, ref, tc.name)
+	}
+}

--- a/pkg/reference/regexp.go
+++ b/pkg/reference/regexp.go
@@ -1,0 +1,67 @@
+package reference
+
+import "regexp"
+
+//
+// v1 org.opencontainers.image.ref.name:
+//
+// 	ref       ::= component ("/" component)*
+// 	component ::= alphanum (separator alphanum)*
+// 	alphanum  ::= [A-Za-z0-9]+
+// 	separator ::= [-._:@+] | "--"
+//
+// In the image-spec, there is no definition about Tag.
+//
+// But, in fact, the Tag looks like:
+//
+//	:\w[\w.-]*$
+//
+var (
+	regAlphanum = expression(`[A-Za-z0-9]`)
+
+	regSeparator = expression(`([-._:@+]|--)`)
+
+	regComponent = group(
+		oneOrMore(regAlphanum),
+		zeroOrMore(regSeparator, oneOrMore(regAlphanum)))
+
+	regRef = entire(
+		regComponent,
+		zeroOrMore(expression("/"), regComponent))
+
+	regTag = expression(`:\w[\w.-]*$`)
+)
+
+// expression converts literal into regexp.
+func expression(literal string) *regexp.Regexp {
+	return regexp.MustCompile(literal)
+}
+
+// concat concats several expressions into one.
+func concat(exp ...*regexp.Regexp) *regexp.Regexp {
+	s := ""
+	for i := range exp {
+		s = s + exp[i].String()
+	}
+	return regexp.MustCompile(s)
+}
+
+// entire will match the whole line.
+func entire(exp ...*regexp.Regexp) *regexp.Regexp {
+	return regexp.MustCompile("^" + concat(exp...).String() + "$")
+}
+
+// zeroOrMore will group the expressions and match zero or more times.
+func zeroOrMore(exp ...*regexp.Regexp) *regexp.Regexp {
+	return regexp.MustCompile(group(concat(exp...)).String() + "*")
+}
+
+// zeroOrMore will group the expressions and match one or more times.
+func oneOrMore(exp ...*regexp.Regexp) *regexp.Regexp {
+	return regexp.MustCompile(group(concat(exp...)).String() + "+")
+}
+
+// group defines sub expression.
+func group(exp ...*regexp.Regexp) *regexp.Regexp {
+	return regexp.MustCompile("(?:" + concat(exp...).String() + ")")
+}


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

**1.Describe what this PR did**

The task to parse image name should be common task. 
It can be used in create/start container.

**2.Does this pull request fix one issue?** 
fixes #267 

**3.Describe how you did it**
Follow the image-spec to parse the image name into reference.

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE

