### PR TITLE
feature: support multiple runtime

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -5,9 +5,10 @@ import (
 )
 
 type container struct {
-	name   string
-	tty    bool
-	volume []string
+	name    string
+	tty     bool
+	volume  []string
+	runtime string
 }
 
 func (c *container) config() *types.ContainerConfigWrapper {

--- a/cli/create.go
+++ b/cli/create.go
@@ -41,11 +41,18 @@ func (cc *CreateCommand) addFlags() {
 	flagSet.StringVar(&cc.name, "name", "", "Specify name of container")
 	flagSet.BoolVarP(&cc.tty, "tty", "t", false, "Allocate a tty device")
 	flagSet.StringSliceVarP(&cc.volume, "volume", "v", nil, "Bind mount volumes to container")
+	flagSet.StringVar(&cc.runtime, "runtime", "", "Specify oci runtime")
 }
 
 // runCreate is the entry of create command.
 func (cc *CreateCommand) runCreate(args []string) error {
 	config := cc.config()
+
+	// set flags for container
+	if cc.runtime != "" {
+		config.HostConfig.Runtime = cc.runtime
+	}
+
 	config.Image = args[0]
 	if len(args) == 2 {
 		config.Cmd = strings.Fields(args[1])

--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -2,6 +2,8 @@ package ctrd
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/linux/runctypes"
 	"github.com/containerd/containerd/oci"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -267,9 +270,14 @@ func (c *Client) createContainer(ctx context.Context, ref, id string, container 
 		specOptions = append(specOptions, oci.WithProcessArgs(args...))
 	}
 
+	config := container.Info.Config
+
 	options := []containerd.NewContainerOpts{
 		// containerd.WithNewSnapshot(id, img),
 		containerd.WithSpec(container.Spec, specOptions...),
+		containerd.WithRuntime(fmt.Sprintf("io.containerd.runtime.v1.%s", runtime.GOOS), &runctypes.RuncOptions{
+			Runtime: config.HostConfig.Runtime,
+		}),
 	}
 
 	// check snaphost exist or not.

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -34,4 +34,7 @@ type Config struct {
 
 	// TLS configuration
 	TLS utils.TLSConfig
+
+	// Default OCI Runtime
+	DefaultRuntime string
 }

--- a/internal/generator.go
+++ b/internal/generator.go
@@ -20,7 +20,7 @@ type DaemonProvider interface {
 
 // GenContainerMgr generates a ContainerMgr instance according to config cfg.
 func GenContainerMgr(ctx context.Context, d DaemonProvider) (mgr.ContainerMgr, error) {
-	return mgr.NewContainerManager(ctx, d.MetaStore(), d.Containerd(), d.ImgMgr(), d.VolMgr())
+	return mgr.NewContainerManager(ctx, d.MetaStore(), d.Containerd(), d.ImgMgr(), d.VolMgr(), d.Config())
 }
 
 // GenSystemMgr generates a SystemMgr instance according to config cfg.

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func setupFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.TLS.CA, "tlscacert", "", "Specify CA file of TLS")
 	flagSet.BoolVar(&cfg.TLS.VerifyRemote, "tlsverify", false, "Use TLS and verify remote")
 	flagSet.BoolVarP(&printVersion, "version", "v", false, "Print daemon version")
+	flagSet.StringVar(&cfg.DefaultRuntime, "default-runtime", "runc", "Default OCI Runtime")
 }
 
 // runDaemon prepares configs, setups essential details and runs pouchd daemon.


### PR DESCRIPTION
Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
add default runtime for pouchd, runtime set in containerd's config will
be never used.

```
./pouchd --default-runtime=runc(default will be runc)
```

add platform and runtime parameter in create container, platform means
os version, runtime means oci runtime use for container.


test:
```
$ sudo ./pouch create --runtime runc docker.io/library/busybox:latest
[sudo] password for ace: 
container ID: 5884e535ced5cb0aa228d036b18a43f15ef6d975381d5423ef0462094ac09fcf, name: 5884e5 
ace@www:~/go/src/github.com/alibaba/pouch time-> 二 12月 12 13:33:24
$ sudo ./pouch start -i 5884e5
/ # exit
```

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


