### PR TITLE
feature: let pouch manage the snapshot

### DIFF
--- a/ctrd/snapshot.go
+++ b/ctrd/snapshot.go
@@ -1,0 +1,25 @@
+package ctrd
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/snapshots"
+)
+
+const defaultSnapshotterName = "overlayfs"
+
+// GetSnapshot returns the snapshot's info by id.
+func (c *Client) GetSnapshot(ctx context.Context, id string) (snapshots.Info, error) {
+	service := c.client.SnapshotService(defaultSnapshotterName)
+	defer service.Close()
+
+	return service.Stat(ctx, id)
+}
+
+// RemoveSnapshot removes the snapshot by id.
+func (c *Client) RemoveSnapshot(ctx context.Context, id string) error {
+	service := c.client.SnapshotService(defaultSnapshotterName)
+	defer service.Close()
+
+	return service.Remove(ctx, id)
+}


### PR DESCRIPTION

Signed-off-by: skoo87 <marckywu@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
this is a simple implement to manage snaphost, Now it's reuse a existed
snapshot only.

Now, when the container stopped, the snapshot will be removed, In the future, we don't remove the snapshot until the container be removed. If restart the container, can reuse its snapshot.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**
this is a simple PR only, avoid to create a big pr.

