### PR TITLE
feature: when image is being used, must use --force to delete the image

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -199,7 +199,9 @@ func (s *Server) attachContainer(ctx context.Context, rw http.ResponseWriter, re
 }
 
 func (s *Server) getContainers(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
-	metas, err := s.ContainerMgr.List(ctx)
+	metas, err := s.ContainerMgr.List(ctx, func(meta *mgr.ContainerMeta) bool {
+		return true
+	})
 	if err != nil {
 		return err
 	}

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -220,6 +220,11 @@ paths:
       description: "Remove an image by reference."
       parameters:
         - $ref: "#/parameters/imageid"
+        - name: "force"
+          in: "query"
+          description: "Remove the image even if it is being used"
+          type: "boolean"
+          default: false
       responses:
         204:
           description: "No error"

--- a/cli/rmi.go
+++ b/cli/rmi.go
@@ -7,7 +7,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rmiDescription = "Remove one or more images by reference"
+var rmiDescription = "Remove one or more images by reference." +
+	"When the image is being used by a container, you must specify -f to delete it." +
+	"But it is strongly discouraged, because the container will be in abnormal status."
 
 // RmiCommand use to implement 'rmi' command, it remove one or more images by reference
 type RmiCommand struct {
@@ -57,6 +59,11 @@ func (rmi *RmiCommand) runRmi(args []string) error {
 
 // rmiExample shows examples in rmi command, and is used in auto-generated cli docs.
 func rmiExample() string {
-	return `$ pouch rmi docker.io/library/busybox:latest
-docker.io/library/busybox:latest`
+	return `$ pouch rmi registry.hub.docker.com/library/busybox:latest
+registry.hub.docker.com/library/busybox:latest
+$ pouch create --name test registry.hub.docker.com/library/busybox:latest
+container ID: e5952417f9ee94621bbeaec532be1803ae2dedeb11a80f578a6d621e04a95afd, name: test
+$ pouch rmi registry.hub.docker.com/library/busybox:latest
+Error: failed to remove image: {"message":"Unable to remove the image \"registry.hub.docker.com/library/busybox:latest\" (must force) - container e5952417f9ee94621bbeaec532be1803ae2dedeb11a80f578a6d621e04a95afd is using this image"}
+`
 }

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -13,6 +13,10 @@ const (
 	DefaultStopTimeout = 10
 )
 
+// ContainerFilter defines a function to filter
+// container in the store.
+type ContainerFilter func(*ContainerMeta) bool
+
 type containerExecConfig struct {
 	types.ExecCreateConfig
 

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -33,7 +33,7 @@ type ImageMgr interface {
 	GetImage(ctx context.Context, idOrRef string) (*types.ImageInfo, error)
 
 	// RemoveImage deletes an image by reference.
-	RemoveImage(ctx context.Context, name string, option *ImageRemoveOption) error
+	RemoveImage(ctx context.Context, image *types.ImageInfo, option *ImageRemoveOption) error
 }
 
 // ImageManager is an implementation of interface ImageMgr.
@@ -129,12 +129,7 @@ func (mgr *ImageManager) GetImage(ctx context.Context, idOrRef string) (*types.I
 }
 
 // RemoveImage deletes an image by reference.
-func (mgr *ImageManager) RemoveImage(ctx context.Context, name string, option *ImageRemoveOption) error {
-	image, err := mgr.cache.get(name)
-	if err != nil {
-		return err
-	}
-
+func (mgr *ImageManager) RemoveImage(ctx context.Context, image *types.ImageInfo, option *ImageRemoveOption) error {
 	if err := mgr.client.RemoveImage(ctx, image.Name); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: HusterWan <zirenwan@gmail.com>

**1.Describe what this PR did**
when image is being used, must use --force to delete the image

**2.Does this pull request fix one issue?** 

**3.Describe how you did it**

**4.Describe how to verify it**
```
[root@docker-registry github.com]# pouch ps
Name    ID       Status    Image
nginx   fa3c18   stopped   docker.io/library/nginx:latest
[root@docker-registry github.com]# pouch rmi docker.io/library/nginx:latest
Error: failed to remove image: {"message":"Unable to remove the image \"docker.io/library/nginx:latest\" (must force) - container fa3c182fb492e7a630002c19ed9fcdf1f18dcb19896f9c186f2881dae67cde31 is using this image"}

[root@docker-registry github.com]# pouch rmi -f docker.io/library/nginx:latest
docker.io/library/nginx:latest
```

**5.Special notes for reviews**


