### PR TITLE
fix: not specify image tag when creating container

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alibaba/pouch/pkg/reference"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +49,11 @@ func (cc *CreateCommand) addFlags() {
 func (cc *CreateCommand) runCreate(args []string) error {
 	config := cc.config()
 
-	config.Image = args[0]
+	ref, err := reference.Parse(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to create container: %v", err)
+	}
+	config.Image = ref.String()
 	if len(args) == 2 {
 		config.Cmd = strings.Fields(args[1])
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
As title.
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**
Set `latest` tag if image name does not contain a colon.
**4.Describe how to verify it**
before:
```
# pouch create --name busybox docker.io/library/busybox
Error: failed to create container: 404: not found
```
after:
```
# pouch create --name busybox docker.io/library/busybox
container ID: fb88e3a9108c3c8c94f1513e1b385975f3de99ebc30a1723d3bf5d11545846ae, name: busybox
```
**5.Special notes for reviews**