### PR TITLE
refactor: move runtime flag into "container.config()" in cli

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -25,5 +25,10 @@ func (c *container) config() *types.ContainerConfigWrapper {
 		config.HostConfig.Binds = c.volume
 	}
 
+	// set runtime
+	if c.runtime != "" {
+		config.HostConfig.Runtime = c.runtime
+	}
+
 	return config
 }

--- a/cli/create.go
+++ b/cli/create.go
@@ -48,11 +48,6 @@ func (cc *CreateCommand) addFlags() {
 func (cc *CreateCommand) runCreate(args []string) error {
 	config := cc.config()
 
-	// set flags for container
-	if cc.runtime != "" {
-		config.HostConfig.Runtime = cc.runtime
-	}
-
 	config.Image = args[0]
 	if len(args) == 2 {
 		config.Cmd = strings.Fields(args[1])

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -372,7 +372,7 @@ func (mgr *ContainerManager) Stop(ctx context.Context, name string, timeout time
 	defer c.Unlock()
 
 	if !c.IsRunning() {
-		return fmt.Errorf("container's status is not running: %d", c.meta.Status)
+		return fmt.Errorf("container's status is not running: %v", c.meta.Status)
 	}
 
 	if _, err := mgr.Client.DestroyContainer(ctx, c.ID()); err != nil {


### PR DESCRIPTION
Signed-off-by: skoo87 <marckywu@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
move the runtime flag into the common function "container.config()".

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


