### PR TITLE
fix: ps command display removed container

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -589,6 +589,14 @@ func (mgr *ContainerManager) stoppedAndRelease(id string, m *ctrd.Message) error
 		mgr.IOs.Remove(id)
 	}
 
+	// lookup again, avoid container already removed
+	if _, err := mgr.container(id); err != nil {
+		if errtypes.IsNotfound(err) {
+			err = nil
+		}
+		return err
+	}
+
 	// update meta
 	if err := c.Write(mgr.Store); err != nil {
 		logrus.Errorf("failed to update meta: %v", err)


### PR DESCRIPTION
Signed-off-by: Wendell Sun <iwendellsun@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
As title.
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**
In container stopped hook, lookup container again, avoid container already removed. 

**4.Describe how to verify it**
before:
```
# pouch create --name test registry.hub.docker.com/library/busybox:latest
container ID: d6a3c03c8a3d0cd4620fa28054653a8225c0975c5a5d85086e0ac01e0aa430f8, name: test
# pouch start test
# pouch rm -f test
test
# pouch ps
Name   ID       Status    Image                                            Runtime
test   c76149   stopped   registry.hub.docker.com/library/busybox:latest   runc
```
after:
```
# pouch create --name test registry.hub.docker.com/library/busybox:latest
container ID: d6a3c03c8a3d0cd4620fa28054653a8225c0975c5a5d85086e0ac01e0aa430f8, name: test
# pouch start test
# pouch rm -f test
test
# pouch ps
Name   ID   Status   Image   Runtime
```

**5.Special notes for reviews**