### PR TITLE
fix: avoid entering the endless loop

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -50,7 +50,11 @@ function main ()
 	# wait until pouch daemon is ready
 	while true;
 	do
-		if [ -S /var/run/pouchd.sock ];then
+		COUNT=`ps -ef | grep pouchd | grep -v grep | wc -l`
+		if [ $COUNT = 0 ];then
+			echo "failed to start pouch daemon."
+			return 1
+		elif [ -S /var/run/pouchd.sock ];then
 			break
 		else
 			sleep 1


### PR DESCRIPTION
**1.Describe what this PR did**
If pouchd exits and does not generate `/var/run/pouchd.sock`, it will go into an endless loop

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
Check pouchd process exists, if not exist then return an error


