### PR TITLE
bugfix: make cli to output the detail error info, when the error is notfound.

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -123,10 +123,6 @@ func (client *APIClient) sendRequest(method, path string, query url.Values, obj 
 		return nil, err
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, ErrHTTPNotfound
-	}
-
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
 		data, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Signed-off-by: skoo87 <marckywu@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
make cli to output the detail error info, when the error is notfound. 

root@ubuntu:/media/psf/Home/sk/src/github.com/alibaba/pouch# ./pouch create registry.hub.docker.com/libraryaaaaaaaaaa/busybox:latest "/bin/echo 1111"
Error: failed to create container: {"message":"failed to create container: image: registry.hub.docker.com/libraryaaaaaaaaaa/busybox:latest: not found"}

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix #310 

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


