### PR TITLE
fix: make 'pouch ps' list containers orderly and show creation time.

### DIFF
--- a/cli/ps.go
+++ b/cli/ps.go
@@ -2,12 +2,19 @@ package main
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
+	"time"
 
+	"github.com/alibaba/pouch/apis/types"
 	"github.com/spf13/cobra"
 )
 
 // psDescription is used to describe ps command in detail and auto generate command doc.
-var psDescription = "\nList Containers with container name, ID, status, image reference and runtime."
+var psDescription = "\nList Containers with container name, ID, status, image reference, runtime and creation time."
+
+// containerList is used to save the container list.
+type containerList []*types.Container
 
 // PsCommand is used to implement 'ps' command.
 type PsCommand struct {
@@ -39,15 +46,18 @@ func (p *PsCommand) addFlags() {
 func (p *PsCommand) runPs(args []string) error {
 	apiClient := p.cli.Client()
 
+	var containers containerList
 	containers, err := apiClient.ContainerList()
 	if err != nil {
 		return fmt.Errorf("failed to get container list: %v", err)
 	}
 
+	sort.Sort(containers)
+
 	display := p.cli.NewTableDisplay()
-	display.AddRow([]string{"Name", "ID", "Status", "Image", "Runtime"})
+	display.AddRow([]string{"Name", "ID", "Status", "Image", "Runtime", "Created"})
 	for _, c := range containers {
-		display.AddRow([]string{c.Names[0], c.ID[:6], c.Status, c.Image, c.HostConfig.Runtime})
+		display.AddRow([]string{c.Names[0], c.ID[:6], c.Status, c.Image, c.HostConfig.Runtime, createdTime(c.Created)})
 	}
 	display.Flush()
 	return nil
@@ -56,7 +66,63 @@ func (p *PsCommand) runPs(args []string) error {
 // psExample shows examples in ps command, and is used in auto-generated cli docs.
 func psExample() string {
 	return `$ pouch ps
-Name     ID       Status    Image                              Runtime
-1dad17   1dad17   stopped   docker.io/library/busybox:latest   runv
-505571   505571   stopped   docker.io/library/busybox:latest   runc`
+Name     ID       Status    Image                              Runtime   Created
+1dad17   1dad17   stopped   docker.io/library/busybox:latest   runv      about 1 hour ago
+505571   505571   stopped   docker.io/library/busybox:latest   runc      about 1 hour ago
+`
+}
+
+// createdTime is used to show the time from creation to now.
+func createdTime(created string) (s string) {
+	start, _ := strconv.ParseInt(created, 10, 64)
+	now := time.Now().Unix()
+	diff := int(now - start)
+
+	if diff >= 3600*24 {
+		day := diff / (3600 * 24)
+		s = "about " + strconv.Itoa(day) + " day"
+		if day > 1 {
+			s += "s"
+		}
+		s += " ago"
+	} else if diff >= 3600 {
+		hour := diff / 3600
+		s = "about " + strconv.Itoa(hour) + " hour"
+		if hour > 1 {
+			s += "s"
+		}
+		s += " ago"
+	} else if diff >= 60 {
+		minute := diff / 60
+		s = "about " + strconv.Itoa(minute) + " minute"
+		if minute > 1 {
+			s += "s"
+		}
+		s += " ago"
+	} else {
+		s = "about " + strconv.Itoa(diff) + " second"
+		if diff > 1 {
+			s += "s"
+		}
+		s += " ago"
+	}
+
+	return s
+}
+
+// Len implements the sort interface.
+func (c containerList) Len() int {
+	return len(c)
+}
+
+// Swap implements the sort interface.
+func (c containerList) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+// Less implements the sort interface.
+func (c containerList) Less(i, j int) bool {
+	ivalue, _ := strconv.ParseInt(c[i].Created, 10, 64)
+	jvalue, _ := strconv.ParseInt(c[j].Created, 10, 64)
+	return ivalue > jvalue
 }

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -260,7 +261,8 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 	// TODO check whether image exist
 	meta := &types.ContainerInfo{
 		ContainerState: &types.ContainerState{
-			Status: types.StatusCreated,
+			Status:    types.StatusCreated,
+			StartedAt: strconv.FormatInt(time.Now().Unix(), 10),
 		},
 		ID:     id,
 		Name:   name,


### PR DESCRIPTION
Signed-off-by: zeppp <zeppp1995@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
make `pouch ps` list containers ordered by its creating time instead randomly and show creation time.
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**
```
pouch ps
Name   ID       Status    Image                              Runtime   Created
2      f93a25   created   docker.io/library/busybox:latest   runc      about 1 hour ago
1      4ddedc   created   docker.io/library/busybox:latest   runc      about 1 hour ago

pouch create --name 3 docker.io/library/busybox:latest 
container ID: bd618e450eb9f25d101211b6c306c2292b4a01402dbef7f249cc53a9fbc921d2, name: 3 

pouch ps
Name   ID       Status    Image                              Runtime   Created
3      bd618e   created   docker.io/library/busybox:latest   runc      about 4 seconds ago
2      f93a25   created   docker.io/library/busybox:latest   runc      about 1 hour ago
1      4ddedc   created   docker.io/library/busybox:latest   runc      about 1 hour ago
```
Waiting 2 minutes
```
pouch ps
Name   ID       Status    Image                              Runtime   Created
3      bd618e   created   docker.io/library/busybox:latest   runc      about 2 minutes ago
2      f93a25   created   docker.io/library/busybox:latest   runc      about 1 hour ago
1      4ddedc   created   docker.io/library/busybox:latest   runc      about 1 hour ago

```
**5.Special notes for reviews**


