### PR TITLE
feature: use reference to parse name before rmi

### DIFF
--- a/cli/rmi.go
+++ b/cli/rmi.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/alibaba/pouch/pkg/reference"
 	"github.com/spf13/cobra"
 )
 
@@ -40,10 +41,15 @@ func (rmi *RmiCommand) runRmi(args []string) error {
 	apiClient := rmi.cli.Client()
 
 	for _, name := range args {
-		if err := apiClient.ImageRemove(name, rmi.force); err != nil {
+		ref, err := reference.Parse(name)
+		if err != nil {
 			return fmt.Errorf("failed to remove image: %v", err)
 		}
-		fmt.Printf("%s\n", name)
+
+		if err := apiClient.ImageRemove(ref.String(), rmi.force); err != nil {
+			return fmt.Errorf("failed to remove image: %v", err)
+		}
+		fmt.Printf("%s\n", ref.String())
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

**1.Describe what this PR did**

This PR is to use reference package to parse name before `rmi ` command.

The pros are here:

- we can do evaluate the image name before remove. 
- use `latest` tag if user doesn't specify 

**2.Does this pull request fix one issue?** 
None

**3.Describe how you did it**

Use existing `pkg/reference` package to parse name. 

**4.Describe how to verify it**

There are several cases:
```
➜  pouch images
IMAGE ID       IMAGE NAME                                      SIZE
3b1a65e9a05f   registry.hub.docker.com/library/centos:latest   70.03 MB

➜  pouch rmi registry.hub.docker.com/library/centos
registry.hub.docker.com/library/centos:latest

➜  pouch images
IMAGE ID   IMAGE NAME   SIZE

➜  pouch rmi registry.hub.docker.com/library/centos:3
Error: failed to remove image: {"message":"image: registry.hub.docker.com/library/centos:3: not found"}

➜  pouch rmi http://registry.hub.docker.com/library/centos
Error: failed to remove image: invalid reference
```

**5.Special notes for reviews**
NONE

