### PR TITLE
feature: Use reference parse Image name before create container

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alibaba/pouch/pkg/reference"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +49,12 @@ func (cc *CreateCommand) addFlags() {
 func (cc *CreateCommand) runCreate(args []string) error {
 	config := cc.config()
 
-	config.Image = args[0]
+	ref, err := reference.Parse(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to create container: %v", err)
+	}
+
+	config.Image = ref.String()
 	if len(args) == 2 {
 		config.Cmd = strings.Fields(args[1])
 	}


### PR DESCRIPTION
Fix #233

Signed-off-by: Wei Fu <fhfuwei@163.com>

**1.Describe what this PR did**

Use reference package to parse image name before we create container.

We can evaluate image name and use latest as default tag if user doesn't add the tag.

**2.Does this pull request fix one issue?** 

Fixes #233 

**3.Describe how you did it**

Use existing package to parse image name.

**4.Describe how to verify it**

```
➜  pouch images
IMAGE ID       IMAGE NAME                                       SIZE
bbc3a0323522   registry.hub.docker.com/library/busybox:latest   703.14 KB

➜  pouch create --name foo registry.hub.docker.com/library/busybox ls
container ID: df1a6eb52ff1d53825a65e1ce6b0f4564352c339131e92bbb0f80c52758f0f83, name: foo

➜ pouch ps
Name   ID       Status    Image                                            Runtime
foo    df1a6e   created   registry.hub.docker.com/library/busybox:latest   runc

➜  pouch start -a foo
bin
dev
etc
home
proc
root
run
sys
tmp
usr
var

➜  pouch create --name foo1 registry.hub.docker.com/library/busybox:3
Error: failed to create container: {"message":"image: registry.hub.docker.com/library/busybox:3: not found"}
```

**5.Special notes for reviews**
NONE

