### PR TITLE
feature: move snapshot management to container's create and remove

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -157,7 +157,7 @@ func (c *Client) RecoverContainer(ctx context.Context, id string, io *containeri
 			return errors.Wrap(err, "failed to get task")
 		}
 		// not found task, delete container directly.
-		lc.Delete(ctx, containerd.WithSnapshotCleanup)
+		lc.Delete(ctx)
 		return errors.Wrap(errtypes.ErrNotfound, "task")
 	}
 
@@ -221,7 +221,7 @@ func (c *Client) DestroyContainer(ctx context.Context, id string) (*Message, err
 		return nil, err
 	}
 
-	if err := pack.container.Delete(ctx, containerd.WithSnapshotCleanup); err != nil {
+	if err := pack.container.Delete(ctx); err != nil {
 		if !errdefs.IsNotFound(err) {
 			return msg, errors.Wrap(err, "failed to delete container")
 		}
@@ -281,8 +281,8 @@ func (c *Client) UnpauseContainer(ctx context.Context, id string) error {
 // CreateContainer create container and start process.
 func (c *Client) CreateContainer(ctx context.Context, container *Container) error {
 	var (
-		ref = container.Info.Config.Image
-		id  = container.Info.ID
+		ref = container.Image
+		id  = container.ID
 	)
 
 	if !c.lock.Trylock(id) {
@@ -314,26 +314,18 @@ func (c *Client) createContainer(ctx context.Context, ref, id string, container 
 		specOptions = append(specOptions, oci.WithProcessArgs(args...))
 	}
 
-	config := container.Info.HostConfig
-
 	options := []containerd.NewContainerOpts{
-		// containerd.WithNewSnapshot(id, img),
 		containerd.WithSpec(container.Spec, specOptions...),
 		containerd.WithRuntime(fmt.Sprintf("io.containerd.runtime.v1.%s", runtime.GOOS), &runctypes.RuncOptions{
-			Runtime: config.Runtime,
+			Runtime: container.Runtime,
 		}),
 	}
 
 	// check snaphost exist or not.
-	if _, err = c.GetSnapshot(ctx, id); err != nil {
-		if errdefs.IsNotFound(err) {
-			options = append(options, containerd.WithNewSnapshot(id, img))
-		} else {
-			return errors.Wrapf(err, "failed to create container, id: %s", id)
-		}
-	} else {
-		options = append(options, containerd.WithSnapshot(id))
+	if _, err := c.GetSnapshot(ctx, id); err != nil {
+		return errors.Wrapf(err, "failed to create container, id: %s", id)
 	}
+	options = append(options, containerd.WithSnapshot(id))
 
 	nc, err := c.client.NewContainer(ctx, id, options...)
 	if err != nil {

--- a/ctrd/container_types.go
+++ b/ctrd/container_types.go
@@ -1,7 +1,6 @@
 package ctrd
 
 import (
-	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/daemon/containerio"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -9,9 +8,11 @@ import (
 
 // Container wraps container's info.
 type Container struct {
-	Info *types.ContainerInfo
-	IO   *containerio.IO
-	Spec *specs.Spec
+	ID      string
+	Image   string
+	Runtime string
+	IO      *containerio.IO
+	Spec    *specs.Spec
 }
 
 // Process wraps exec process's info.

--- a/ctrd/snapshot.go
+++ b/ctrd/snapshot.go
@@ -3,10 +3,31 @@ package ctrd
 import (
 	"context"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/snapshots"
+	"github.com/opencontainers/image-spec/identity"
 )
 
 const defaultSnapshotterName = "overlayfs"
+
+// CreateSnapshot creates a active snapshot with image's name and id.
+func (c *Client) CreateSnapshot(ctx context.Context, id, ref string) error {
+	image, err := c.client.ImageService().Get(ctx, ref)
+	if err != nil {
+		return err
+	}
+
+	diffIDs, err := image.RootFS(ctx, c.client.ContentStore(), platforms.Default())
+	if err != nil {
+		return err
+	}
+
+	parent := identity.ChainID(diffIDs).String()
+	if _, err := c.client.SnapshotService(defaultSnapshotterName).Prepare(ctx, id, parent); err != nil {
+		return err
+	}
+	return nil
+}
 
 // GetSnapshot returns the snapshot's info by id.
 func (c *Client) GetSnapshot(ctx context.Context, id string) (snapshots.Info, error) {

--- a/ctrd/watch.go
+++ b/ctrd/watch.go
@@ -67,7 +67,7 @@ func (w *watch) add(pack containerPack) {
 			logrus.Errorf("failed to delete task, container id: %s: %v", pack.id, err)
 		}
 
-		if err := pack.container.Delete(context.Background(), containerd.WithSnapshotCleanup); err != nil {
+		if err := pack.container.Delete(context.Background()); err != nil {
 			logrus.Errorf("failed to delete container, container id: %s: %v", pack.id, err)
 		}
 

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -174,12 +174,17 @@ func (mgr *ContainerManager) Remove(ctx context.Context, name string, option *Co
 	mgr.NameToID.Remove(c.Name())
 
 	// remove meta data
-	if err := mgr.Store.Remove(c.ID()); err != nil {
-		logrus.Errorf("failed to remove container: %s meta store", c.ID())
+	if err := mgr.Store.Remove(c.meta.Key()); err != nil {
+		logrus.Errorf("failed to remove container: %s meta store, %v", c.ID(), err)
 	}
 
 	// remove container cache
 	mgr.cache.Remove(c.ID())
+
+	// remove snapshot
+	if err := mgr.Client.RemoveSnapshot(ctx, c.ID()); err != nil {
+		logrus.Errorf("failed to remove container: %s snapshot, %v", c.ID(), err)
+	}
 
 	return nil
 }
@@ -263,16 +268,18 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 	if err != nil {
 		return nil, err
 	}
-
-	// set container hostconfig
 	config.Image = image.Name
 
+	// set container runtime
 	if config.HostConfig.Runtime == "" {
 		config.HostConfig.Runtime = mgr.Config.DefaultRuntime
 	}
 
-	// TODO add more validation of parameter
-	// TODO check whether image exist
+	// create a snapshot with image.
+	if err := mgr.Client.CreateSnapshot(ctx, id, config.Image); err != nil {
+		return nil, err
+	}
+
 	containerMeta := &ContainerMeta{
 		State: &types.ContainerState{
 			StartedAt: strconv.FormatInt(time.Now().Unix(), 10),
@@ -345,9 +352,11 @@ func (mgr *ContainerManager) Start(ctx context.Context, id, detachKeys string) (
 	}
 
 	err = mgr.Client.CreateContainer(ctx, &ctrd.Container{
-		Info: c.meta.ToContainerInfo(),
-		Spec: s,
-		IO:   io,
+		ID:      c.ID(),
+		Image:   c.Image(),
+		Runtime: c.meta.HostConfig.Runtime,
+		Spec:    s,
+		IO:      io,
 	})
 	if err == nil {
 		c.meta.State.Status = types.StatusRunning

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -64,6 +64,11 @@ func (c *Container) ID() string {
 	return c.meta.ID
 }
 
+// Image returns container's image name.
+func (c *Container) Image() string {
+	return c.meta.Config.Image
+}
+
 // Name returns container's name.
 func (c *Container) Name() string {
 	return c.meta.Name


### PR DESCRIPTION


Signed-off-by: skoo87 <marckywu@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Now, when create a container, will create a snapshot with container's
id. After container be stopped, the snapshot will not be removed until
the container be removed.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


