### PR TITLE
feature: pull can run in non-terminal output

### DIFF
--- a/cli/pull.go
+++ b/cli/pull.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/containerd/containerd/progress"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // pullDescription is used to describe pull command in detail and auto generate command doc.
@@ -61,36 +63,62 @@ func (p *PullCommand) runPull(args []string) error {
 	}
 	defer responseBody.Close()
 
-	return renderOutput(responseBody)
+	return showProgress(responseBody)
 }
 
-// renderOutput draws the commandline output via api response.
-func renderOutput(responseBody io.ReadCloser) error {
+// bufwriter defines interface which has Write and Flush behaviors.
+type bufwriter interface {
+	Write([]byte) (int, error)
+	Flush() error
+}
+
+// showProgress shows pull progress status.
+func showProgress(body io.ReadCloser) error {
 	var (
-		start = time.Now()
-		fw    = progress.NewWriter(os.Stdout)
+		output bufwriter = bufio.NewWriter(os.Stdout)
+
+		start      = time.Now()
+		isTerminal = terminal.IsTerminal(int(os.Stdout.Fd()))
 	)
 
-	dec := json.NewDecoder(responseBody)
+	if isTerminal {
+		output = progress.NewWriter(os.Stdout)
+	}
+
+	dec := json.NewDecoder(body)
 	if _, err := dec.Token(); err != nil {
 		return fmt.Errorf("failed to read the opening token: %v", err)
 	}
 
+	refStatus := make(map[string]string)
 	for dec.More() {
-		var objs []ctrd.ProgressInfo
+		var infos []ctrd.ProgressInfo
 
-		tw := tabwriter.NewWriter(fw, 1, 8, 1, ' ', 0)
-
-		if err := dec.Decode(&objs); err != nil {
+		if err := dec.Decode(&infos); err != nil {
 			return fmt.Errorf("failed to decode: %v", err)
 		}
 
-		if err := display(tw, objs, start); err != nil {
-			return err
+		// only display the new status if the stdout is not terminal
+		if !isTerminal {
+			newInfos := make([]ctrd.ProgressInfo, 0)
+			for i, info := range infos {
+				old, ok := refStatus[info.Ref]
+				if !ok || info.Status != old {
+					refStatus[info.Ref] = info.Status
+					newInfos = append(newInfos, infos[i])
+				}
+			}
+
+			infos = newInfos
 		}
 
-		tw.Flush()
-		fw.Flush()
+		if err := displayProgressInfos(output, isTerminal, infos, start); err != nil {
+			return fmt.Errorf("failed to display progress: %v", err)
+		}
+
+		if err := output.Flush(); err != nil {
+			return fmt.Errorf("failed to display progress: %v", err)
+		}
 	}
 
 	if _, err := dec.Token(); err != nil {
@@ -99,46 +127,67 @@ func renderOutput(responseBody io.ReadCloser) error {
 	return nil
 }
 
-func display(w io.Writer, statuses []ctrd.ProgressInfo, start time.Time) error {
-	var total int64
-	for _, status := range statuses {
-		if status.ErrorMessage != "" {
-			return fmt.Errorf(status.ErrorMessage)
+// displayProgressInfos uses tabwriter to show current progress info.
+func displayProgressInfos(output io.Writer, isTerminal bool, infos []ctrd.ProgressInfo, start time.Time) error {
+	var (
+		tw    = tabwriter.NewWriter(output, 1, 8, 1, ' ', 0)
+		total = int64(0)
+	)
+
+	for _, info := range infos {
+		if info.ErrorMessage != "" {
+			return fmt.Errorf(info.ErrorMessage)
 		}
-		total += status.Offset
-		switch status.Status {
-		case "downloading", "uploading":
-			var bar progress.Bar
-			if status.Total > 0.0 {
-				bar = progress.Bar(float64(status.Offset) / float64(status.Total))
-			}
-			fmt.Fprintf(w, "%s:\t%s\t%40r\t%8.8s/%s\t\n",
-				status.Ref,
-				status.Status,
-				bar,
-				progress.Bytes(status.Offset), progress.Bytes(status.Total))
 
-		case "resolving", "waiting":
-			bar := progress.Bar(0.0)
-			fmt.Fprintf(w, "%s:\t%s\t%40r\t\n",
-				status.Ref,
-				status.Status,
-				bar)
-
-		default:
-			bar := progress.Bar(1.0)
-			fmt.Fprintf(w, "%s:\t%s\t%40r\t\n",
-				status.Ref,
-				status.Status,
-				bar)
+		total += info.Offset
+		if _, err := fmt.Fprint(tw, formatProgressInfo(info, isTerminal)); err != nil {
+			return err
 		}
 	}
 
-	fmt.Fprintf(w, "elapsed: %-4.1fs\ttotal: %7.6v\t(%v)\t\n",
-		time.Since(start).Seconds(),
-		progress.Bytes(total),
-		progress.NewBytesPerSecond(total, time.Since(start)))
-	return nil
+	// no need to show the total information if ther stdout is not terminal
+	if isTerminal {
+		_, err := fmt.Fprintf(tw, "elapsed: %-4.1fs\ttotal: %7.6v\t(%v)\t\n",
+			time.Since(start).Seconds(),
+			progress.Bytes(total),
+			progress.NewBytesPerSecond(total, time.Since(start)))
+		if err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// formatProgressInfo formats ProgressInfo into string.
+func formatProgressInfo(info ctrd.ProgressInfo, isTerminal bool) string {
+	if !isTerminal {
+		return fmt.Sprintf("%s:\t%s\n", info.Ref, info.Status)
+	}
+
+	switch info.Status {
+	case "downloading", "uploading":
+		var bar progress.Bar
+		if info.Total > 0.0 {
+			bar = progress.Bar(float64(info.Offset) / float64(info.Total))
+		}
+		return fmt.Sprintf("%s:\t%s\t%40r\t%8.8s/%s\t\n",
+			info.Ref,
+			info.Status,
+			bar,
+			progress.Bytes(info.Offset), progress.Bytes(info.Total))
+
+	case "resolving", "waiting":
+		return fmt.Sprintf("%s:\t%s\t%40r\t\n",
+			info.Ref,
+			info.Status,
+			progress.Bar(0.0))
+
+	default:
+		return fmt.Sprintf("%s:\t%s\t%40r\t\n",
+			info.Ref,
+			info.Status,
+			progress.Bar(1.0))
+	}
 }
 
 // pullExample shows examples in pull command, and is used in auto-generated cli docs.


### PR DESCRIPTION
Fix #313

Signed-off-by: Wei Fu <fhfuwei@163.com>

**1.Describe what this PR did**

Allow `pull` run in non-terminal mode. 

Before this commit, `pouch pull` must run in terminal console. If you run `pull` in non-terminal mode,  pouch will panic. 

The CI uses `exec` package to run `pull` command. Basically, the stdout of `exec.Cmd` is to `/dev/null`. Therefore if you pull images in `exec.Cmd`, the result will failed. 

Why CI of request is pass? Because the `busybox` is too small. `pull` command receives and renders the json stream fail, but the `busybox` image has been downloaded successfully. That is why the CI is green right now.

**2.Does this pull request fix one issue?** 
Fixed #313 

**3.Describe how you did it**
I uses `terminal` package to check if the `os.Stdout` is terminal or not. 

As we knows, the `progress.Writer` acts buffer IO writer which has `Write` and `Flush` methods. 
For the non-terminal case, we don't need the `progress.Writer`. But, to keep the logic simple, I create interface named by `bufwriter` and use `bufio.NewWriter` to wrap `os.Stdout`.  Therefore, the function can use `bufwriter` to output something without caring about the real instance.

For the non-terminal mode, we don't need to show the current status in time.
The caller just cares what has been done.  So I only show new status each loop iteration.

**4.Describe how to verify it**

For the terminal mode, the behaviour is the same to the previous.

For the non-terminal mode,  

```
➜  cat main.go
package main

import (
        "bufio"
        "bytes"
        "fmt"

        "github.com/gotestyourself/gotestyourself/icmd"
)

func main() {
        var b bytes.Buffer
        writer := bufio.NewWriter(&b)

        cmd := icmd.Cmd{Command: []string{"pouch", "pull", "registry.hub.docker.com/library/centos"}}
        cmd.Stdout = writer

        res := icmd.RunCmd(cmd)
        fmt.Println(res.Combined())
}

➜  go run main.go
registry.hub.docker.com/library/centos:latest: resolving
registry.hub.docker.com/library/centos:latest:                                 resolved
index-sha256:3b1a65e9a05f0a77b5e8a698d3359459904c2a354dc3b25ae2e2f5c95f0b3667: downloading
index-sha256:3b1a65e9a05f0a77b5e8a698d3359459904c2a354dc3b25ae2e2f5c95f0b3667:    done
manifest-sha256:3a32a170c945ffe18334b3f514fcb66f9c14001b2266c9ed8504c72db0acde11: downloading
manifest-sha256:3a32a170c945ffe18334b3f514fcb66f9c14001b2266c9ed8504c72db0acde11: done
layer-sha256:85432449fd0fabb6bef4772246d9b7948723275a4c7e4dee18728f28d79f1c2c:    downloading
config-sha256:3fa822599e10c5f2080dcf647068c72022b111d31bbec0c5adb8a96e7eb5379b:   downloading
config-sha256:3fa822599e10c5f2080dcf647068c72022b111d31bbec0c5adb8a96e7eb5379b: done
layer-sha256:85432449fd0fabb6bef4772246d9b7948723275a4c7e4dee18728f28d79f1c2c: done
```

**5.Special notes for reviews**


