### PR TITLE
fix: make create command accept slice command

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -39,6 +39,7 @@ func (cc *CreateCommand) Init(c *Cli) {
 // addFlags adds flags for specific command.
 func (cc *CreateCommand) addFlags() {
 	flagSet := cc.cmd.Flags()
+	flagSet.SetInterspersed(false)
 	flagSet.StringVar(&cc.name, "name", "", "Specify name of container")
 	flagSet.BoolVarP(&cc.tty, "tty", "t", false, "Allocate a tty device")
 	flagSet.StringSliceVarP(&cc.volume, "volume", "v", nil, "Bind mount volumes to container")
@@ -53,10 +54,10 @@ func (cc *CreateCommand) runCreate(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create container: %v", err)
 	}
-
 	config.Image = ref.String()
-	if len(args) == 2 {
-		config.Cmd = strings.Fields(args[1])
+
+	if len(args) > 1 {
+		config.Cmd = args[1:]
 	}
 	containerName := cc.name
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

**2.Does this pull request fix one issue?** 

Without this PR, pouch could only pass arg when creating container with quoted args, like `pouch create busybox:latest "sleep 10000"`.

With this PR, we can use `pouch create busybox:latest sleep 10000` without quote. This way is compatible with moby's way.

**3.Describe how you did it**
Make cli accept multiple args.

**4.Describe how to verify it**
```
root@ubuntu:~/go/src/github.com/alibaba/pouch# pouch create --name foo4 registry.hub.docker.com/library/busybox:latest sleep 123456
container ID: 8aaa6dcab51e32d8f107dd57ac8d87435443f708471773d73e660fb13f65c11e, name: foo4
root@ubuntu:~/go/src/github.com/alibaba/pouch# pouch start foo4
root@ubuntu:~/go/src/github.com/alibaba/pouch# ps aux | grep "sleep 123456"
root     15732  0.0  0.0   1204     4 ?        Ss   20:17   0:00 sleep 123456
root     15753  0.0  0.0  14224  1020 pts/0    S+   20:17   0:00 grep --color=auto sleep 123456
```

**5.Special notes for reviews**
/cc @skoo87 


