### PR TITLE
refactor: make the two operations (stop container and modify meta data) to execute in one goroutine

### DIFF
--- a/ctrd/client.go
+++ b/ctrd/client.go
@@ -75,7 +75,7 @@ func NewClient(cfg Config) (*Client, error) {
 			ids: make(map[string]struct{}),
 		},
 		watch: &watch{
-			containers: make(map[string]containerPack),
+			containers: make(map[string]*containerPack),
 			client:     cli,
 		},
 	}, nil

--- a/ctrd/watch.go
+++ b/ctrd/watch.go
@@ -47,17 +47,17 @@ func (m *Message) ExitTime() time.Time {
 type watch struct {
 	sync.Mutex
 	client     *containerd.Client
-	containers map[string]containerPack
+	containers map[string]*containerPack
 	hooks      []func(string, *Message) error
 }
 
-func (w *watch) add(pack containerPack) {
+func (w *watch) add(pack *containerPack) {
 	w.Lock()
 	defer w.Unlock()
 
 	w.containers[pack.id] = pack
 
-	go func(pack containerPack) {
+	go func(pack *containerPack) {
 		status := <-pack.sch
 
 		logrus.Infof("the task has quit, id: %s, err: %v, exitcode: %d, time: %v",
@@ -76,14 +76,17 @@ func (w *watch) add(pack containerPack) {
 			exitCode: status.ExitCode(),
 			exitTime: status.ExitTime(),
 		}
-		pack.ch <- msg
 
-		for _, hook := range w.hooks {
-			if err := hook(pack.id, msg); err != nil {
-				logrus.Errorf("failed to execute the exit hooks: %v", err)
-				break
+		if !pack.skipStopHooks {
+			for _, hook := range w.hooks {
+				if err := hook(pack.id, msg); err != nil {
+					logrus.Errorf("failed to execute the exit hooks: %v", err)
+					break
+				}
 			}
 		}
+
+		pack.ch <- msg
 
 	}(pack)
 
@@ -98,7 +101,7 @@ func (w *watch) remove(ctx context.Context, id string) error {
 	return nil
 }
 
-func (w *watch) get(id string) (containerPack, error) {
+func (w *watch) get(id string) (*containerPack, error) {
 	w.Lock()
 	defer w.Unlock()
 


### PR DESCRIPTION
…a) to execute in one goroutine

Signed-off-by: skoo87 <marckywu@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
make the two operations (stop container and modify meta data) to execute in one goroutine

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**

