### PR TITLE
refactor: move createdTime function into pkg\utils 

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/alibaba/pouch/pkg/collect"
 	"github.com/alibaba/pouch/pkg/errtypes"
 	"github.com/alibaba/pouch/pkg/randomid"
+	"github.com/alibaba/pouch/pkg/utils"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -275,7 +275,7 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 	// TODO check whether image exist
 	containerMeta := &ContainerMeta{
 		State: &types.ContainerState{
-			StartedAt: strconv.FormatInt(time.Now().Unix(), 10),
+			StartedAt: time.Now().UTC().Format(utils.TimeLayout),
 			Status:    types.StatusCreated,
 		},
 		ID:         id,
@@ -351,7 +351,7 @@ func (mgr *ContainerManager) Start(ctx context.Context, id, detachKeys string) (
 	})
 	if err == nil {
 		c.meta.State.Status = types.StatusRunning
-		c.meta.State.StartedAt = time.Now().String()
+		c.meta.State.StartedAt = time.Now().UTC().Format(utils.TimeLayout)
 		pid, err := mgr.Client.ContainerPID(ctx, c.ID())
 		if err != nil {
 			return errors.Wrapf(err, "failed to get PID of container: %s", c.ID())

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,26 @@
 package utils
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// Common durations that is .
+// There are some definitions for units of Day and larger .
+const (
+	Second     = time.Second
+	Minute     = Second * 60
+	Hour       = Minute * 60
+	Day        = Hour * 24
+	Week       = Day * 7
+	Month      = Day * 30
+	Year       = Day * 365
+	TimeLayout = "2006-01-02 15:04:05"
+)
+
+var errInvalid = errors.New("invalid time")
 
 // If implements ternary operator. if cond is true return v1, or return v2 instead.
 func If(cond bool, v1, v2 interface{}) interface{} {
@@ -28,4 +48,74 @@ func FormatSize(size int64) string {
 	}
 
 	return fmt.Sprintf("%.2f %s", formattedSize, suffixes[count])
+}
+
+// FormatCreatedTime is used to show the time from creation to now.
+func FormatCreatedTime(created string) (formattedTime string, err error) {
+	start, err := time.Parse(TimeLayout, created)
+	if err != nil {
+		return "", errInvalid
+	}
+	diff := time.Now().Sub(start)
+
+	// That should not happen.
+	if diff < 0 {
+		formattedTime += "-"
+		diff = 0 - diff
+	}
+
+	if diff >= Year {
+		year := int(diff / Year)
+		formattedTime += strconv.Itoa(year) + " year"
+		if year > 1 {
+			formattedTime += "s"
+		}
+		formattedTime += " ago"
+	} else if diff >= Month {
+		month := int(diff / Month)
+		formattedTime += strconv.Itoa(month) + " month"
+		if month > 1 {
+			formattedTime += "s"
+		}
+		formattedTime += " ago"
+	} else if diff >= Week {
+		week := int(diff / Week)
+		formattedTime += strconv.Itoa(week) + " week"
+		if week > 1 {
+			formattedTime += "s"
+		}
+		formattedTime += " ago"
+	} else if diff >= Day {
+		day := int(diff / Day)
+		formattedTime += strconv.Itoa(day) + " day"
+		if day > 1 {
+			formattedTime += "s"
+		}
+		formattedTime += " ago"
+	} else if diff >= Hour {
+		hour := int(diff / Hour)
+		formattedTime += strconv.Itoa(hour) + " hour"
+		if hour > 1 {
+			formattedTime += "s"
+		}
+		formattedTime += " ago"
+	} else if diff >= Minute {
+		minute := int(diff / Minute)
+		formattedTime += strconv.Itoa(minute) + " minute"
+		if minute > 1 {
+			formattedTime += "s"
+		}
+		formattedTime += " ago"
+	} else if diff >= Second {
+		second := int(diff / Second)
+		formattedTime += strconv.Itoa(second) + " second"
+		if second > 1 {
+			formattedTime += "s"
+		}
+		formattedTime += " ago"
+	} else {
+		formattedTime += "0 second ago"
+	}
+
+	return formattedTime, nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2,9 +2,17 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+type tCase struct {
+	name     string
+	input    string
+	expected string
+	err      error
+}
 
 func TestFormatSize(t *testing.T) {
 	assert := assert.New(t)
@@ -20,4 +28,98 @@ func TestFormatSize(t *testing.T) {
 		size := FormatSize(k)
 		assert.Equal(v, size)
 	}
+}
+
+func TestFormatCreatedTime(t *testing.T) {
+
+	for _, tc := range []tCase{
+		{
+			name:     "second",
+			input:    time.Now().Add(0 - Second).UTC().Format(TimeLayout),
+			expected: "1 second ago",
+			err:      nil,
+		}, {
+			name:     "minute",
+			input:    time.Now().Add(0 - Minute).UTC().Format(TimeLayout),
+			expected: "1 minute ago",
+			err:      nil,
+		}, {
+			name:     "hour",
+			input:    time.Now().Add(0 - Hour).UTC().Format(TimeLayout),
+			expected: "1 hour ago",
+			err:      nil,
+		}, {
+			name:     "day",
+			input:    time.Now().Add(0 - Day).UTC().Format(TimeLayout),
+			expected: "1 day ago",
+			err:      nil,
+		}, {
+			name:     "week",
+			input:    time.Now().Add(0 - Week).UTC().Format(TimeLayout),
+			expected: "1 week ago",
+			err:      nil,
+		}, {
+			name:     "month",
+			input:    time.Now().Add(0 - Month).UTC().Format(TimeLayout),
+			expected: "1 month ago",
+			err:      nil,
+		}, {
+			name:     "year",
+			input:    time.Now().Add(0 - Year).UTC().Format(TimeLayout),
+			expected: "1 year ago",
+			err:      nil,
+		},
+		{
+			name:     "seconds",
+			input:    time.Now().Add(0 - Second*3).UTC().Format(TimeLayout),
+			expected: "3 seconds ago",
+			err:      nil,
+		}, {
+			name:     "minutes",
+			input:    time.Now().Add(0 - Minute*3).UTC().Format(TimeLayout),
+			expected: "3 minutes ago",
+			err:      nil,
+		}, {
+			name:     "hours",
+			input:    time.Now().Add(0 - Hour*3).UTC().Format(TimeLayout),
+			expected: "3 hours ago",
+			err:      nil,
+		}, {
+			name:     "days",
+			input:    time.Now().Add(0 - Day*3).UTC().Format(TimeLayout),
+			expected: "3 days ago",
+			err:      nil,
+		}, {
+			name:     "weeks",
+			input:    time.Now().Add(0 - Week*3).UTC().Format(TimeLayout),
+			expected: "3 weeks ago",
+			err:      nil,
+		}, {
+			name:     "months",
+			input:    time.Now().Add(0 - Month*3).UTC().Format(TimeLayout),
+			expected: "3 months ago",
+			err:      nil,
+		}, {
+			name:     "years",
+			input:    time.Now().Add(0 - Year*3).UTC().Format(TimeLayout),
+			expected: "3 years ago",
+			err:      nil,
+		}, {
+			name:     "notHappen",
+			input:    time.Now().Add(Second * 61).UTC().Format(TimeLayout),
+			expected: "-1 minute ago",
+			err:      nil,
+		},
+		{
+			name:     "invalid",
+			input:    "balabala",
+			expected: "",
+			err:      errInvalid,
+		},
+	} {
+		output, err := FormatCreatedTime(tc.input)
+		assert.Equal(t, tc.err, err, tc.name)
+		assert.Equal(t, tc.expected, output, tc.name)
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: zeppp <zeppp1995@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
move createdTime function into pkg\utils and fix the bug that the `pouch ps` shows wrong creation time when start a container.
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**
```
pouch ps
Name   ID       Status    Image                              Runtime   Created
foo    f3b6c4   created   docker.io/library/busybox:latest   runc      9 seconds ago

pouch create --name foo2 docker.io/library/busybox:latest
container ID: 632bc7535ec2e92ec8ad934c1a8cf2ba4490ae71764ff9ad6b2d93e45e833889, name: foo2 

 pouch create --name boo docker.io/library/busybox:latest
container ID: d7b841bd3011fb206c8c889c17dba9572f40d6f564a2b142a289eb1c68262a35, name: boo 

 pouch start foo2
 pouch ps
 Name   ID       Status    Image                              Runtime   Created
 foo2   632bc7   running   docker.io/library/busybox:latest   runc      5 seconds ago 
 boo    d7b841   created   docker.io/library/busybox:latest   runc      13 seconds ago
 foo    f3b6c4   created   docker.io/library/busybox:latest   runc      2 minutes ago
 
pouch start boo
pouch ps
Name   ID       Status    Image                              Runtime   Created
boo    d7b841   running   docker.io/library/busybox:latest   runc      5 seconds ago
foo2   632bc7   running   docker.io/library/busybox:latest   runc      40 seconds ago
foo    f3b6c4   created   docker.io/library/busybox:latest   runc      2 minutes ago

```
**5.Special notes for reviews**
In cli/ps.go I check the validity of c.Created.
```
for _, c := range containers {
		created, err := utils.FormatCreatedTime(c.Created)
		if err != nil {
			return err
		}
		display.AddRow([]string{c.Names[0], c.ID[:6], c.Status, c.Image, c.HostConfig.Runtime, created})
	}
```
Before this PR,the c.Created is a string that generated by `strconv.FormatInt(time.Now().Unix(), 10)`  which now is `time.Now().UTC().Format(utils.TimeLayout)`.
So,we need to **remove all containers first and then make install to apply this PR.** Otherwise, `pouch ps` will return an error.
ping @allencloud  @0x04C2 
