### PR TITLE
feature: Add detachKeys in start command and add start api in swagger.yaml

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -126,7 +126,7 @@ func (s *Server) startContainer(ctx context.Context, resp http.ResponseWriter, r
 		return err
 	}
 
-	resp.WriteHeader(http.StatusOK)
+	resp.WriteHeader(http.StatusNoContent)
 	return nil
 }
 

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -337,6 +337,35 @@ paths:
           schema:
            $ref: "#/definitions/Error"
       tags: ["Container"]
+  /containers/{id}/start:
+    post:
+      summary: "Start a container"
+      operationId: "ContainerStart"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          type: "string"
+        - name: "detachKeys"
+          in: "query"
+          description: "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`."
+          type: "string"
+      responses:
+        204:
+          description: "no error"
+        404:
+          description: "no such container"
+          schema:
+            $ref: "#/definitions/Error"
+          examples:
+            application/json:
+              message: "No such container: c2ada9df5af8"
+        500:
+          description: "server error"
+          schema:
+            $ref: "#/definitions/Error"
+      tags: ["Container"]
   /containers/{id}/pause:
     post:
       summary: "Pause a container"

--- a/cli/start.go
+++ b/cli/start.go
@@ -18,8 +18,9 @@ var startDescription = "Start a created container object in Pouchd. " +
 // StartCommand use to implement 'start' command, it start a container.
 type StartCommand struct {
 	baseCommand
-	attach bool
-	stdin  bool
+	detachKeys string
+	attach     bool
+	stdin      bool
 }
 
 // Init initialize start command.
@@ -41,6 +42,7 @@ func (s *StartCommand) Init(c *Cli) {
 // addFlags adds flags for specific command.
 func (s *StartCommand) addFlags() {
 	flagSet := s.cmd.Flags()
+	flagSet.StringVar(&s.detachKeys, "detach-keys", "", "Override the key sequence for detaching a container")
 	flagSet.BoolVarP(&s.attach, "attach", "a", false, "Attach container's STDOUT and STDERR")
 	flagSet.BoolVarP(&s.stdin, "interactive", "i", false, "Attach container's STDIN")
 }
@@ -81,7 +83,7 @@ func (s *StartCommand) runStart(args []string) error {
 	}
 
 	// start container
-	if err := apiClient.ContainerStart(container, ""); err != nil {
+	if err := apiClient.ContainerStart(container, s.detachKeys); err != nil {
 		return fmt.Errorf("failed to start container %s: %v", container, err)
 	}
 


### PR DESCRIPTION
Add detachKeys in start command and add start api in swagger.yaml

Signed-off-by: mozhuli <21621232@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


