### PR TITLE
test: remove unstable case

### DIFF
--- a/test/pouch_cli_start_test.go
+++ b/test/pouch_cli_start_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"fmt"
 	"os/exec"
 	"strings"
 
@@ -68,43 +67,6 @@ func (suite *PouchStartSuite) TestStartInTTY(c *check.C) {
 	c.Assert(strings.TrimSpace(echo), check.Equals, msg)
 
 	command.PouchRun("stop", name)
-}
-
-// TestStartAttach tests "pouch start -a" work.
-func (suite *PouchStartSuite) TestStartAttach(c *check.C) {
-	_, tty, err := pty.Open()
-	c.Assert(err, check.IsNil)
-	defer tty.Close()
-
-	baseName := "start-attach"
-
-	for idx, tc := range []struct {
-		name     string
-		cmd      string
-		expected string
-		exitcode int
-	}{
-		{name: "echo 1", cmd: "echo 1", expected: "1\n", exitcode: 0},
-		{name: "pwd", cmd: "pwd", expected: "/\n", exitcode: 0},
-		{name: "true", cmd: "true", expected: "", exitcode: 0},
-
-		// FIXME: should add non-zero exitcode cases here
-		// {name: "false", cmd: "false", expected: "", exitcode: 1},
-	} {
-		name := fmt.Sprintf("%s-%d", baseName, idx)
-		command.PouchRun("create", "--name", name, busyboxImage, tc.cmd).Assert(c, icmd.Success)
-
-		// FIXME: The start command will close wait channel twice if
-		// the stdin meets EOF.
-		cmd := command.PouchCmd("start", "-a", name)
-		cmd.Stdin = tty
-
-		res := icmd.RunCmd(cmd)
-		c.Assert(res.Combined(), check.Equals, tc.expected, check.Commentf(tc.name))
-		c.Assert(res.ExitCode, check.Equals, tc.exitcode, check.Commentf(tc.name))
-
-		command.PouchRun("rm", name)
-	}
 }
 
 // TestStartInWrongWay runs start command in wrong way.


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

**1.Describe what this PR did**

Remove the unstable case

**2.Does this pull request fix one issue?** 

Yes. Someone's CI failed caused by the unstable case.

**3.Describe how you did it**

Remove the case.

**4.Describe how to verify it**

I found that "stopped" status was setting by hooked.
The task already exited but the state is still running and waiting for hook. If the ["rm" action](https://github.com/alibaba/pouch/blob/master/test/pouch_cli_start_test.go#L106) and the cleanup job reads the status before the hook, the CI will fail. 

Detail in: https://travis-ci.org/alibaba/pouch/builds/318601340#L614

The detail shows us `EOF` because the goroutine has paniced caused by https://github.com/alibaba/pouch/blob/master/ctrd/container.go#L199. If the task already exited, the err will be `NoTFOUND`. Then next call will use nil pointer and panic.....

I'm still thinking about how to avoid dirty read....


#346   

**5.Special notes for reviews**

It will take long time if add timeout to wait the status. So I decide to remove the case. What do you think?

ping @allencloud and @mozhuli 
