### PR TITLE
bugfix: make sure HostConfig is not nil

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -242,6 +242,11 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, confi
 
 // Create checks passed in parameters and create a Container object whose status is set at Created.
 func (mgr *ContainerManager) Create(ctx context.Context, name string, config *types.ContainerConfigWrapper) (*types.ContainerCreateResp, error) {
+	// TODO: check request validate.
+	if config.HostConfig == nil {
+		return nil, fmt.Errorf("host config and network config can not be nil")
+	}
+
 	id, err := mgr.generateID()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Make sure ContainerConfig and HostConfig is not nil, when post
/containers/create with body is nil, ContainerConfig and HostConfig will
be nil, it causes pouchd panic.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #352 

**3.Describe how you did it**
Check ContainerConfig and HostConfig is nil or not.

**4.Describe how to verify it**
Send POST /containers/create with null body and pouchd doesn't panic.

**5.Special notes for reviews**

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
