### PR TITLE
fix: add force query in swagger.yml when container removal

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -486,6 +486,11 @@ paths:
           required: true
           description: "ID or name of the container"
           type: "string"
+        - name: "force"
+          in: "query"
+          description: "If the container is running, force query is used to kill it and remove it forcefully."
+          type: "boolean"
+          default: false
       responses:
         204:
           description: "no error"


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
We have already implemented `force` query in `DELETE /containers/{name}`, but we misses this part. This PR tries to add this.

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
Add force query in `DELETE /containers/{name}`

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
/cc @Letty5411 


