### PR TITLE
fix: make GET /containers/json return an array in swagger.yml

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -351,7 +351,9 @@ paths:
         200:
           description: "Summary containers that matches the query"
           schema:
-            $ref: "#/definitions/Container"
+            type: "array"
+            items:
+              $ref: "#/definitions/Container"
         500:
           description: "Server error"
           schema:


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

This PR fixes API `GET /containers/json` in swagger.yml, since this API returns an array from pouch daemon.

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


