### PR TITLE
fix: make server return json in http response

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -16,7 +15,7 @@ import (
 )
 
 // pullImage will pull an image from a specified registry.
-func (s *Server) pullImage(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
+func (s *Server) pullImage(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	image := req.FormValue("fromImage")
 	tag := req.FormValue("tag")
 
@@ -34,7 +33,7 @@ func (s *Server) pullImage(ctx context.Context, resp http.ResponseWriter, req *h
 	}(time.Now())
 
 	// Error information has be sent to client, so no need call resp.Write
-	if err := s.ImageMgr.PullImage(ctx, image, tag, resp); err != nil {
+	if err := s.ImageMgr.PullImage(ctx, image, tag, rw); err != nil {
 		logrus.Errorf("failed to pull image %s:%s: %v", image, tag, err)
 		return nil
 	}
@@ -42,7 +41,7 @@ func (s *Server) pullImage(ctx context.Context, resp http.ResponseWriter, req *h
 	return nil
 }
 
-func (s *Server) listImages(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
+func (s *Server) listImages(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	filters := req.FormValue("failters")
 
 	imageList, err := s.ImageMgr.ListImages(ctx, filters)
@@ -50,36 +49,35 @@ func (s *Server) listImages(ctx context.Context, resp http.ResponseWriter, req *
 		logrus.Errorf("failed to list images: %v", err)
 		return err
 	}
-	return json.NewEncoder(resp).Encode(imageList)
+	return EncodeResponse(rw, http.StatusOK, imageList)
 }
 
-func (s *Server) getImage(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
+func (s *Server) getImage(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	idOrRef := mux.Vars(req)["name"]
 
-	image, err := s.ImageMgr.GetImage(ctx, idOrRef)
+	imageInfo, err := s.ImageMgr.GetImage(ctx, idOrRef)
 	if err != nil {
 		logrus.Errorf("failed to get image: %v", err)
 		return err
 	}
 
-	resp.WriteHeader(http.StatusOK)
-	return json.NewEncoder(resp).Encode(image)
+	return EncodeResponse(rw, http.StatusOK, imageInfo)
 }
 
-func (s *Server) searchImages(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
+func (s *Server) searchImages(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	searchPattern := req.FormValue("term")
 	registry := req.FormValue("registry")
 
-	response, err := s.ImageMgr.SearchImages(ctx, searchPattern, registry)
+	searchResultItem, err := s.ImageMgr.SearchImages(ctx, searchPattern, registry)
 	if err != nil {
 		logrus.Errorf("failed to search images from resgitry: %v", err)
 		return err
 	}
-	return json.NewEncoder(resp).Encode(response)
+	return EncodeResponse(rw, http.StatusOK, searchResultItem)
 }
 
 // removeImage deletes an image by reference
-func (s *Server) removeImage(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
+func (s *Server) removeImage(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	name := mux.Vars(req)["name"]
 
 	option := &mgr.ImageRemoveOption{}
@@ -88,6 +86,6 @@ func (s *Server) removeImage(ctx context.Context, resp http.ResponseWriter, req 
 		return err
 	}
 
-	resp.WriteHeader(http.StatusNoContent)
+	rw.WriteHeader(http.StatusNoContent)
 	return nil
 }

--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -111,6 +111,13 @@ func (s *Server) filter(handler handler) http.HandlerFunc {
 	}
 }
 
+// EncodeResponse encodes reponse in json.
+func EncodeResponse(rw http.ResponseWriter, statusCode int, data interface{}) error {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(statusCode)
+	return json.NewEncoder(rw).Encode(data)
+}
+
 // HandleErrorResponse handles err from daemon side and constructs response for client side.
 func HandleErrorResponse(w http.ResponseWriter, err error) {
 	var (

--- a/apis/server/system_bridge.go
+++ b/apis/server/system_bridge.go
@@ -2,30 +2,27 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 )
 
-func (s *Server) ping(context context.Context, resp http.ResponseWriter, req *http.Request) (err error) {
-	resp.WriteHeader(http.StatusOK)
-	resp.Write([]byte{'O', 'K'})
+func (s *Server) ping(context context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
+	rw.WriteHeader(http.StatusOK)
+	rw.Write([]byte{'O', 'K'})
 	return
 }
 
-func (s *Server) info(ctx context.Context, resp http.ResponseWriter, req *http.Request) (err error) {
+func (s *Server) info(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
 	info, err := s.SystemMgr.Info()
 	if err != nil {
 		return err
 	}
-	resp.WriteHeader(http.StatusOK)
-	return json.NewEncoder(resp).Encode(info)
+	return EncodeResponse(rw, http.StatusOK, info)
 }
 
-func (s *Server) version(ctx context.Context, resp http.ResponseWriter, req *http.Request) (err error) {
-	info, err := s.SystemMgr.Version()
+func (s *Server) version(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
+	version, err := s.SystemMgr.Version()
 	if err != nil {
 		return err
 	}
-	resp.WriteHeader(http.StatusOK)
-	return json.NewEncoder(resp).Encode(info)
+	return EncodeResponse(rw, http.StatusOK, version)
 }

--- a/apis/server/volume_bridge.go
+++ b/apis/server/volume_bridge.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *Server) createVolume(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
+func (s *Server) createVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	var volumeCreateReq types.VolumeCreateRequest
 
 	if err := json.NewDecoder(req.Body).Decode(&volumeCreateReq); err != nil {
@@ -41,16 +41,15 @@ func (s *Server) createVolume(ctx context.Context, resp http.ResponseWriter, req
 		Driver: driver,
 		Labels: volumeCreateReq.Labels,
 	}
-	resp.WriteHeader(http.StatusCreated)
-	return json.NewEncoder(resp).Encode(volume)
+	return EncodeResponse(rw, http.StatusCreated, volume)
 }
 
-func (s *Server) removeVolume(ctx context.Context, resp http.ResponseWriter, req *http.Request) (err error) {
+func (s *Server) removeVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
 	name := mux.Vars(req)["name"]
 
 	if err := s.VolumeMgr.Remove(ctx, name); err != nil {
 		return err
 	}
-	resp.WriteHeader(http.StatusOK)
+	rw.WriteHeader(http.StatusOK)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

I found that in almost every API, the data returned is not in type of json:

![notjson](https://user-images.githubusercontent.com/9465626/34250897-3be87b80-e679-11e7-8761-238a55a2c695.jpeg)


This PR fixes this issue, and explicitly set `rw.Header().Set("Content-Type", "application/json")`

In addition, this PR changed some variable naming to be more clear.

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
Encapsulate a func named by `EncodeReponse` to set json explicitly.

**4.Describe how to verify it**

<img width="798" alt="2017-12-21 7 22 50" src="https://user-images.githubusercontent.com/9465626/34253867-5ef310e4-e684-11e7-9edf-06306ad3fa42.png">




**5.Special notes for reviews**


