### PR TITLE
feature: add run cli command

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -30,6 +30,7 @@ func main() {
 	cli.AddCommand(base, &RenameCommand{})
 	cli.AddCommand(base, &PauseCommand{})
 	cli.AddCommand(base, &UnpauseCommand{})
+	cli.AddCommand(base, &RunCommand{})
 
 	// add generate doc command
 	cli.AddCommand(base, &GenDocCommand{})

--- a/cli/run.go
+++ b/cli/run.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/alibaba/pouch/pkg/reference"
+
+	"github.com/spf13/cobra"
+)
+
+// runDescription is used to describe run command in detail and auto generate command doc.
+var runDescription = "Create a container object in Pouchd, and start the container. " +
+	"This is useful when you just want to use one command to start a container. "
+
+// RunCommand use to implement 'run' command, it creates and starts a container.
+type RunCommand struct {
+	baseCommand
+	container
+	detachKeys string
+	attach     bool
+	stdin      bool
+}
+
+// Init initialize run command.
+func (rc *RunCommand) Init(c *Cli) {
+	rc.cli = c
+	rc.cmd = &cobra.Command{
+		Use:   "run a container",
+		Short: "Create a new container and start it",
+		Long:  runDescription,
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return rc.runRun(args)
+		},
+		Example: runExample(),
+	}
+	rc.addFlags()
+}
+
+// addFlags adds flags for specific command.
+func (rc *RunCommand) addFlags() {
+	flagSet := rc.cmd.Flags()
+	flagSet.SetInterspersed(false)
+	flagSet.StringVar(&rc.name, "name", "", "Specify name of container")
+	flagSet.BoolVarP(&rc.tty, "tty", "t", false, "Allocate a tty device")
+	flagSet.StringSliceVarP(&rc.volume, "volume", "v", nil, "Bind mount volumes to container")
+	flagSet.StringVar(&rc.runtime, "runtime", "", "Specify oci runtime")
+	flagSet.StringVar(&rc.detachKeys, "detach-keys", "", "Override the key sequence for detaching a container")
+	flagSet.BoolVarP(&rc.attach, "attach", "a", false, "Attach container's STDOUT and STDERR")
+	flagSet.BoolVarP(&rc.stdin, "interactive", "i", false, "Attach container's STDIN")
+}
+
+// runRun is the entry of run command.
+func (rc *RunCommand) runRun(args []string) error {
+	config := rc.config()
+
+	ref, err := reference.Parse(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to run container: %v", err)
+	}
+
+	config.Image = ref.String()
+	if len(args) > 1 {
+		config.Cmd = args[1:]
+	}
+	containerName := rc.name
+
+	apiClient := rc.cli.Client()
+	result, err := apiClient.ContainerCreate(config.ContainerConfig, config.HostConfig, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to run container: %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		fmt.Printf("WARNING: %s \n", strings.Join(result.Warnings, "\n"))
+	}
+
+	// pouch run not specify --name
+	if containerName == "" {
+		containerName = result.Name
+	}
+
+	var wg sync.WaitGroup
+	var waitDisplayID chan struct{}
+
+	if rc.attach || rc.stdin {
+		in, out, err := setRawMode(rc.stdin, false)
+		if err != nil {
+			return fmt.Errorf("failed to set raw mode")
+		}
+		defer func() {
+			if err := restoreMode(in, out); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to restore term mode")
+			}
+		}()
+
+		conn, br, err := apiClient.ContainerAttach(containerName, rc.stdin)
+		if err != nil {
+			return fmt.Errorf("failed to attach container: %v", err)
+		}
+
+		wg.Add(2)
+		go func() {
+			io.Copy(os.Stdout, br)
+			wg.Done()
+		}()
+		go func() {
+			io.Copy(conn, os.Stdin)
+			wg.Done()
+		}()
+	} else { // detach mode, print Container ID
+		waitDisplayID = make(chan struct{})
+		go func() {
+			defer close(waitDisplayID)
+			fmt.Fprintf(os.Stdout, "%s\n", result.ID)
+		}()
+	}
+
+	// start container
+	if err := apiClient.ContainerStart(containerName, rc.detachKeys); err != nil {
+		return fmt.Errorf("failed to run container %s: %v", containerName, err)
+	}
+
+	// wait the io to finish
+	if rc.attach || rc.stdin {
+		wg.Wait()
+	} else {
+		<-waitDisplayID
+	}
+	return nil
+}
+
+// runExample shows examples in run command, and is used in auto-generated cli docs.
+func runExample() string {
+	return `$ pouch run --name test registry.hub.docker.com/library/busybox:latest echo "hi"
+23f8529fddf7c8bbea70e2c12353e47dbfa5eacda9d58ff8665269614456424b
+$ pouch ps
+Name   ID       Status    Image                                            Runtime   Created
+test   23f852   stopped   registry.hub.docker.com/library/busybox:latest   runc      4 seconds ago
+pouch run -i --name test registry.hub.docker.com/library/busybox:latest echo "hi"
+hi
+$ pouch ps
+Name   ID       Status    Image                                            Runtime   Created
+test   883ea9   stopped   registry.hub.docker.com/library/busybox:latest   runc      5 seconds ago
+	`
+}

--- a/test/pouch_cli_run_test.go
+++ b/test/pouch_cli_run_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// PouchRunSuite is the test suite for help CLI.
+type PouchRunSuite struct{}
+
+func init() {
+	check.Suite(&PouchRunSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each test suite.
+func (suite *PouchRunSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+
+	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
+}
+
+// TearDownTest does cleanup work in the end of each test.
+func (suite *PouchRunSuite) TearDownTest(c *check.C) {
+	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+}
+
+// TestRun is to verify the correctness of run container with specified name.
+func (suite *PouchRunSuite) TestRun(c *check.C) {
+	name := "test-run"
+
+	_ = command.PouchRun("run", "--name", name, busyboxImage).Assert(c, icmd.Success)
+
+	res := command.PouchRun("ps").Assert(c, icmd.Success)
+	if out := res.Combined(); !strings.Contains(out, name) {
+		c.Fatalf("unexpected output %s: should contains container %s\n", out, name)
+	}
+}
+
+// TestRunInWrongWay tries to run create in wrong way.
+func (suite *PouchRunSuite) TestRunInWrongWay(c *check.C) {
+	for _, tc := range []struct {
+		name string
+		args string
+	}{
+		{name: "unknown flag", args: "-a"},
+
+		// TODO: should add the following cases if ready
+		// {name: "missing image name", args: ""},
+	} {
+		res := command.PouchRun("run", tc.args)
+		c.Assert(res.Error, check.NotNil, check.Commentf(tc.name))
+	}
+}


### PR DESCRIPTION
Signed-off-by: HusterWan <zirenwan@gmail.com>

**1.Describe what this PR did**
add `pouch run` command

**2.Does this pull request fix one issue?** 
fixed #351 

**3.Describe how you did it**

**4.Describe how to verify it**
```
[root@docker-registry github.com]# pouch run -i --rm --name test-rm registry.hub.docker.com/library/busybox:latest
/ # exit
[root@docker-registry github.com]#
[root@docker-registry github.com]#
[root@docker-registry github.com]# pouch ps
Name   ID   Status   Image   Runtime   Created
[root@docker-registry github.com]# pouch run -i --name test-rm registry.hub.docker.com/library/busybox:latest
/ # exit
[root@docker-registry github.com]#
[root@docker-registry github.com]#
[root@docker-registry github.com]# pouch ps
Name      ID       Status    Image                                            Runtime   Created
test-rm   2f80b1   stopped   registry.hub.docker.com/library/busybox:latest   runc      4 seconds ago
```

**5.Special notes for reviews**
```
[root@docker-registry pouch]#  go test test/command/command.go  test/main_test.go test/environment/cleanup.go test/environment/cleanup.go test/pouch_cli_run_test.go
named files must all be in one directory; have test/command/ and test/
```
i can not test my code it my compute, maybe @Letty5411  you can give me some advices, thanks
