### PR TITLE
refatcor: make test case write much easier

### DIFF
--- a/test/api_container_create_test.go
+++ b/test/api_container_create_test.go
@@ -34,22 +34,18 @@ func (suite *APIContainerCreateSuite) TestCreateOk(c *check.C) {
 		"HostConfig": map[string]interface{}{},
 	}
 
-	path := "/containers/create"
 	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
-	resp, err := request.Post(path, query, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
 	// Decode response
 	got := types.ContainerCreateResp{}
-	request.DecodeBody(&got, resp.Body)
-	c.Assert(err, check.IsNil)
-	c.Assert(got.ID, check.NotNil)
+	request.DecodeToStruct(c, resp.Body, &got)
 
-	resp, err = request.Delete("/containers/" + cname)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Delete(c, "/containers/"+cname)
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 }
 
 // TestNilName tests creating container without giving name should succeed.
@@ -59,22 +55,18 @@ func (suite *APIContainerCreateSuite) TestNilName(c *check.C) {
 		"HostConfig": map[string]interface{}{},
 	}
 
-	path := "/containers/create"
 	body := request.WithJSONBody(obj)
-	resp, err := request.Post(path, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	resp, err := request.Post(c, "/containers/create", body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
 	// Decode response
 	got := types.ContainerCreateResp{}
-	request.DecodeBody(&got, resp.Body)
-	c.Assert(err, check.IsNil)
+	request.DecodeToStruct(c, resp.Body, &got)
 	c.Assert(got.ID, check.NotNil)
 	c.Assert(got.Name, check.NotNil)
 
-	resp, err = request.Delete("/containers/" + got.Name)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Delete(c, "/containers/"+got.Name)
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 }
 
 // TestDupContainer tests create a duplicate container, return 409.
@@ -86,22 +78,19 @@ func (suite *APIContainerCreateSuite) TestDupContainer(c *check.C) {
 		"Image":      busyboxImage,
 		"HostConfig": map[string]interface{}{},
 	}
-	path := "/containers/create"
+
 	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
 
-	resp, err := request.Post(path, query, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
 	// Create a duplicate container
-	resp, err = request.Post(path, query, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 409)
+	resp, err = request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 409, err.Error())
 
-	resp, err = request.Delete("/containers/" + cname)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Delete(c, "/containers/"+cname)
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 }
 
 // TestBadParam tests using bad parameter return 400.
@@ -118,11 +107,9 @@ func (suite *APIContainerCreateSuite) TestNonExistingImg(c *check.C) {
 		"Image":      "non-existing",
 		"HostConfig": map[string]interface{}{},
 	}
-	path := "/containers/create"
 	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
 
-	resp, err := request.Post(path, query, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 404, err.Error())
 }

--- a/test/api_container_delete_test.go
+++ b/test/api_container_delete_test.go
@@ -24,9 +24,8 @@ func (suite *APIContainerDeleteSuite) SetUpTest(c *check.C) {
 // TestDeleteNonExisting tests deleting a non-existing container return error.
 func (suite *APIContainerDeleteSuite) TestDeleteNonExisting(c *check.C) {
 	cname := "TestDeleteNonExisting"
-	resp, err := request.Delete("/containers/" + cname)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	resp, err := request.Delete(c, "/containers/"+cname)
+	c.Assert(resp.StatusCode, check.Equals, 404, err.Error())
 }
 
 // TestDeleteRunningCon test deleting running container return 500.
@@ -41,28 +40,23 @@ func (suite *APIContainerDeleteSuite) TestDeleteRunningCon(c *check.C) {
 		"HostConfig": map[string]interface{}{},
 	}
 
-	path := "/containers/create"
 	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
-	resp, err := request.Post(path, query, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/start")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Delete("/containers/" + cname)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 500)
+	resp, err = request.Delete(c, "/containers/"+cname)
+	c.Assert(resp.StatusCode, check.Equals, 500, err.Error())
 
 	q = url.Values{}
 	q.Add("force", "true")
 	query = request.WithQuery(q)
 
-	resp, err = request.Delete("/containers/"+cname, query)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Delete(c, "/containers/"+cname, query)
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 }
 
 // TestDeletePausedCon test deleting paused container return 500.
@@ -77,32 +71,26 @@ func (suite *APIContainerDeleteSuite) TestDeletePausedCon(c *check.C) {
 		"HostConfig": map[string]interface{}{},
 	}
 
-	path := "/containers/create"
 	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
-	resp, err := request.Post(path, query, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/start")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/pause")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/pause")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Delete("/containers/" + cname)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 500)
+	resp, err = request.Delete(c, "/containers/"+cname)
+	c.Assert(resp.StatusCode, check.Equals, 500, err.Error())
 
 	q = url.Values{}
 	q.Add("force", "true")
 	query = request.WithQuery(q)
 
-	resp, err = request.Delete("/containers/"+cname, query)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Delete(c, "/containers/"+cname, query)
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 }
 
 // TestDeleteStoppedCon test deleting stopped container return 204.
@@ -117,24 +105,19 @@ func (suite *APIContainerDeleteSuite) TestDeleteStoppedCon(c *check.C) {
 		"HostConfig": map[string]interface{}{},
 	}
 
-	path := "/containers/create"
 	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
-	resp, err := request.Post(path, query, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/start")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/stop")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/stop")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Delete("/containers/" + cname)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Delete(c, "/containers/"+cname)
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
 }
 
@@ -150,14 +133,11 @@ func (suite *APIContainerDeleteSuite) TestDeleteCreatedCon(c *check.C) {
 		"HostConfig": map[string]interface{}{},
 	}
 
-	path := "/containers/create"
 	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
-	resp, err := request.Post(path, query, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
-	resp, err = request.Delete("/containers/" + cname)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Delete(c, "/containers/"+cname)
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 }

--- a/test/api_container_list_test.go
+++ b/test/api_container_list_test.go
@@ -21,7 +21,6 @@ func (suite *APIContainerListSuite) SetUpTest(c *check.C) {
 
 // TestListOk test api is ok with default parameters.
 func (suite *APIContainerListSuite) TestListOk(c *check.C) {
-	resp, err := request.Get("/containers/json")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err := request.Get(c, "/containers/json")
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 }

--- a/test/api_container_pause_test.go
+++ b/test/api_container_pause_test.go
@@ -34,58 +34,49 @@ func (suite *APIContainerPauseSuite) TestPauseUnpauseOk(c *check.C) {
 		"HostConfig": map[string]interface{}{},
 	}
 
-	resp, err := request.Post("/containers/create", request.WithQuery(q),
-		request.WithJSONBody(obj), request.WithHeader("Content-Type", "application/json"))
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	query := request.WithQuery(q)
+	body := request.WithJSONBody(obj)
 
-	resp, err = request.Get("/containers/" + cname + "/json")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Get(c, "/containers/"+cname+"/json")
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/pause")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/start")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
+
+	resp, err = request.Post(c, "/containers/"+cname+"/pause")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
 	// TODO: Add state check
-	//resp, err = request.Get("/containers/" + cname + "/json")
-	//c.Assert(err, check.IsNil)
+	//resp = request.Get(c, "/containers/" + cname + "/json")
 	//c.Assert(resp.StatusCode, check.Equals, 200)
 	//got := types.ContainerJSON{}
-	//err = request.DecodeBody(&got, resp.Body)
-	//c.Assert(err, check.IsNil)
+	//err = request.DecodeBody(c, resp.Body, &got)
 	//c.Assert(got.State.Status, check.Equals, "paused")
 
-	resp, err = request.Post("/containers/" + cname + "/unpause")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/unpause")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	//resp, err = request.Get("/containers/" + cname + "/json")
-	//c.Assert(err, check.IsNil)
+	//resp = request.Get(c,"/containers/" + cname + "/json")
 	//c.Assert(resp.StatusCode, check.Equals, 200)
 	//got = types.ContainerJSON{}
-	//err = request.DecodeBody(&got, resp.Body)
-	//c.Assert(err, check.IsNil)
+	//err = request.DecodeBody(c, resp.Body, &got)
 	//c.Assert(got.State.Status, check.Equals, "running")
 
 	// Need to set force=true in url.rawquery, as container's state is running
 	q = url.Values{}
 	q.Add("force", "true")
-	resp, err = request.Delete("/containers/"+cname, request.WithQuery(q))
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Delete(c, "/containers/"+cname, request.WithQuery(q))
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 }
 
 // TestNonExistingContainer tests pause a non-existing container return 404.
 func (suite *APIContainerPauseSuite) TestNonExistingContainer(c *check.C) {
 	cname := "TestNonExistingContainer"
-	resp, err := request.Post("/containers/" + cname + "/pause")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	resp, err := request.Post(c, "/containers/"+cname+"/pause")
+	c.Assert(resp.StatusCode, check.Equals, 404, err.Error())
 }
 
 // TestNotRunningContainer tests pausing a non-running container will return error.
@@ -100,15 +91,13 @@ func (suite *APIContainerPauseSuite) TestNotRunningContainer(c *check.C) {
 		"Cmd":        [1]string{"top"},
 		"HostConfig": map[string]interface{}{},
 	}
+	query := request.WithQuery(q)
+	body := request.WithJSONBody(obj)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
-	resp, err := request.Post("/containers/create", request.WithQuery(q),
-		request.WithJSONBody(obj), request.WithHeader("Content-Type", "application/json"))
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
-
-	resp, err = request.Post("/containers/" + cname + "/pause")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 500)
+	resp, err = request.Post(c, "/containers/"+cname+"/pause")
+	c.Assert(resp.StatusCode, check.Equals, 500, err.Error())
 
 	//resp, err = request.Get("/containers/" + cname + "/json")
 	//c.Assert(err, check.IsNil)
@@ -118,17 +107,14 @@ func (suite *APIContainerPauseSuite) TestNotRunningContainer(c *check.C) {
 	//c.Assert(err, check.IsNil)
 	//c.Assert(got.State.Status, check.Equals, "created")
 
-	resp, err = request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/start")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/pause")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/pause")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/pause")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 500)
+	resp, err = request.Post(c, "/containers/"+cname+"/pause")
+	c.Assert(resp.StatusCode, check.Equals, 500, err.Error())
 
 	//resp, err = request.Get("/containers/" + cname + "/json")
 	//c.Assert(err, check.IsNil)
@@ -138,8 +124,7 @@ func (suite *APIContainerPauseSuite) TestNotRunningContainer(c *check.C) {
 	//c.Assert(err, check.IsNil)
 	//c.Assert(got.State.Status, check.Equals, "paused")
 
-	resp, err = request.Post("/containers/" + cname + "/unpause")
-	c.Assert(err, check.IsNil)
+	resp, err = request.Post(c, "/containers/"+cname+"/unpause")
 	c.Assert(resp.StatusCode, check.Equals, 204)
 
 	//resp, err = request.Get("/containers/" + cname + "/json")
@@ -150,12 +135,10 @@ func (suite *APIContainerPauseSuite) TestNotRunningContainer(c *check.C) {
 	//c.Assert(err, check.IsNil)
 	//c.Assert(got.State.Status, check.Equals, "running")
 
-	resp, err = request.Post("/containers/" + cname + "/stop")
-	c.Assert(err, check.IsNil)
+	resp, err = request.Post(c, "/containers/"+cname+"/stop")
 	c.Assert(resp.StatusCode, check.Equals, 204)
 
-	resp, err = request.Post("/containers/" + cname + "/pause")
-	c.Assert(err, check.IsNil)
+	resp, err = request.Post(c, "/containers/"+cname+"/pause")
 	c.Assert(resp.StatusCode, check.Equals, 500)
 
 	//resp, err = request.Get("/containers/" + cname + "/json")
@@ -169,7 +152,7 @@ func (suite *APIContainerPauseSuite) TestNotRunningContainer(c *check.C) {
 	// Need to set force=true in url.rawquery, as container's state is running
 	q = url.Values{}
 	q.Add("force", "true")
-	resp, err = request.Delete("/containers/"+cname, request.WithQuery(q))
-	c.Assert(err, check.IsNil)
+	query = request.WithQuery(q)
+	resp, err = request.Delete(c, "/containers/"+cname, query)
 	c.Assert(resp.StatusCode, check.Equals, 204)
 }

--- a/test/api_container_rename_test.go
+++ b/test/api_container_rename_test.go
@@ -36,22 +36,21 @@ func (suite *APIContainerRenameSuite) TestRenameOk(c *check.C) {
 		"HostConfig": map[string]interface{}{},
 	}
 
-	resp, err := request.Post("/containers/create", request.WithQuery(q),
-		request.WithJSONBody(obj), request.WithHeader("Content-Type", "application/json"))
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	query := request.WithQuery(q)
+	body := request.WithJSONBody(obj)
 
-	resp, err = request.Get("/containers/" + oldname + "/json")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
+
+	resp, err = request.Get(c, "/containers/"+oldname+"/json")
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 
 	newq := url.Values{}
 	newq.Add("name", newname)
-	resp, err = request.Post("/containers/"+oldname+"/rename", request.WithQuery(newq))
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	query = request.WithQuery(newq)
+	resp, err = request.Post(c, "/containers/"+oldname+"/rename", query)
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Delete("/containers/" + newname)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Delete(c, "/containers/"+newname)
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 }

--- a/test/api_container_start_test.go
+++ b/test/api_container_start_test.go
@@ -35,21 +35,17 @@ func (suite *APIContainerStartSuite) TestStartOk(c *check.C) {
 
 	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
-	resp, err := request.Post("/containers/create", query, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
-	resp, err = request.Get("/containers/" + cname + "/json")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err = request.Get(c, "/containers/"+cname+"/json")
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/start")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Get("/containers/" + cname + "/json")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err = request.Get(c, "/containers/"+cname+"/json")
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 
 	// Comment until inspect interface returns this
 	//got := &types.ContainerJSON{}
@@ -62,8 +58,7 @@ func (suite *APIContainerStartSuite) TestStartOk(c *check.C) {
 	q.Add("force", "true")
 	query = request.WithQuery(q)
 
-	resp, err = request.Delete("/containers/"+cname, query)
-	c.Assert(err, check.IsNil)
+	resp, err = request.Delete(c, "/containers/"+cname, query)
 	c.Assert(resp.StatusCode, check.Equals, 204)
 }
 
@@ -71,9 +66,8 @@ func (suite *APIContainerStartSuite) TestStartOk(c *check.C) {
 func (suite *APIContainerStartSuite) TestNonExistingContainer(c *check.C) {
 	cname := "TestNonExistingContainer"
 
-	resp, err := request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	resp, err := request.Post(c, "/containers/"+cname+"/start")
+	c.Assert(resp.StatusCode, check.Equals, 404, err.Error())
 }
 
 // TestInvalidParam tests using invalid parameter return.

--- a/test/api_container_stop_test.go
+++ b/test/api_container_stop_test.go
@@ -34,34 +34,29 @@ func (suite *APIContainerStopSuite) TestStopOk(c *check.C) {
 		"HostConfig": map[string]interface{}{},
 	}
 
-	resp, err := request.Post("/containers/create", request.WithQuery(q),
-		request.WithJSONBody(obj), request.WithHeader("Content-Type", "application/json"))
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	query := request.WithQuery(q)
+	body := request.WithJSONBody(obj)
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
-	resp, err = request.Get("/containers/" + cname + "/json")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err = request.Get(c, "/containers/"+cname+"/json")
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/start")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Post("/containers/" + cname + "/stop")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Post(c, "/containers/"+cname+"/stop")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 
-	resp, err = request.Delete("/containers/" + cname)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	resp, err = request.Delete(c, "/containers/"+cname)
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
 }
 
 // TestNonExistingContainer tests stop a non-existing container return 404.
 func (suite *APIContainerStopSuite) TestNonExistingContainer(c *check.C) {
 	cname := "TestNonExistingContainer"
-	resp, err := request.Post("/containers/" + cname + "/stop")
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	resp, err := request.Post(c, "/containers/"+cname+"/stop")
+	c.Assert(resp.StatusCode, check.Equals, 404, err.Error())
 }
 
 // TestInvalidParam tests using invalid parameter return.

--- a/test/api_image_create_test.go
+++ b/test/api_image_create_test.go
@@ -25,9 +25,7 @@ func (suite *APIImageCreateSuite) SetUpTest(c *check.C) {
 func (suite *APIImageCreateSuite) TestImageCreateOk(c *check.C) {
 	q := url.Values{}
 	q.Add("fromImage", busyboxImage)
-	path := "/images/create"
 	query := request.WithQuery(q)
-	resp, err := request.Post(path, query)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err := request.Post(c, "/images/create", query)
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 }

--- a/test/api_image_delete_test.go
+++ b/test/api_image_delete_test.go
@@ -22,7 +22,6 @@ func (suite *APIImageDeleteSuite) SetUpTest(c *check.C) {
 // TestDeleteNonExisting tests deleting a non-existing image return error.
 func (suite *APIImageDeleteSuite) TestDeleteNonExisting(c *check.C) {
 	img := "TestDeleteNonExisting"
-	resp, err := request.Delete("/images/" + img)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	resp, err := request.Delete(c, "/images/"+img)
+	c.Assert(resp.StatusCode, check.Equals, 404, err.Error())
 }

--- a/test/api_image_inspect_test.go
+++ b/test/api_image_inspect_test.go
@@ -21,8 +21,6 @@ func (suite *APIImageInspectSuite) SetUpTest(c *check.C) {
 
 // TestImageInspectOk tests inspecting images is OK.
 func (suite *APIImageInspectSuite) TestImageInspectOk(c *check.C) {
-	path := "/images/" + busyboxImage + "/json"
-	resp, err := request.Get(path)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err := request.Get(c, "/images/"+busyboxImage+"/json")
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 }

--- a/test/api_image_list_test.go
+++ b/test/api_image_list_test.go
@@ -21,8 +21,6 @@ func (suite *APIImageListSuite) SetUpTest(c *check.C) {
 
 // TestImageListOk tests listing images is OK.
 func (suite *APIImageListSuite) TestImageListOk(c *check.C) {
-	path := "/images/json"
-	resp, err := request.Get(path)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err := request.Get(c, "/images/json")
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 }

--- a/test/api_system_test.go
+++ b/test/api_system_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"runtime"
 
 	"github.com/alibaba/pouch/apis/types"
@@ -28,15 +27,12 @@ func (suite *APISystemSuite) SetUpTest(c *check.C) {
 // TODO: the /info is still implementing.
 // If the /info is ready, we should create containers to test.
 func (suite *APISystemSuite) TestInfo(c *check.C) {
-	resp, err := request.Get("/info")
-	c.Assert(err, check.IsNil)
-	defer resp.Body.Close()
-
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err := request.Get(c, "/info")
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 
 	got := types.SystemInfo{}
-	err = json.NewDecoder(resp.Body).Decode(&got)
-	c.Assert(err, check.IsNil)
+	request.DecodeToStruct(c, resp.Body, &got)
+
 	c.Assert(got, check.Equals, types.SystemInfo{})
 }
 
@@ -45,15 +41,12 @@ func (suite *APISystemSuite) TestInfo(c *check.C) {
 // TODO: the /version is still implementing.
 // If the /info is ready, we need to check the GitCommit/Kernelinfo/BuildTime.
 func (suite *APISystemSuite) TestVersion(c *check.C) {
-	resp, err := request.Get("/version")
-	c.Assert(err, check.IsNil)
-	defer resp.Body.Close()
+	resp, err := request.Get(c, "/version")
 
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 
 	got := types.SystemVersion{}
-	err = json.NewDecoder(resp.Body).Decode(&got)
-	c.Assert(err, check.IsNil)
+	request.DecodeToStruct(c, resp.Body, &got)
 
 	// skip GitCommit/Kernelinfo/BuildTime
 	got.GitCommit = ""

--- a/test/api_volume_create_test.go
+++ b/test/api_volume_create_test.go
@@ -28,14 +28,10 @@ func (suite *APIVolumeCreateSuite) TestVolumeCreateOk(c *check.C) {
 		"Name":   vol,
 	}
 
-	path := "/volumes/create"
 	body := request.WithJSONBody(obj)
-	resp, err := request.Post(path, body)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	resp, err := request.Post(c, "/volumes/create", body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
 
-	path = "/volumes/" + vol
-	resp, err = request.Delete(path)
-	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	resp, err = request.Delete(c, "/volumes/"+vol)
+	c.Assert(resp.StatusCode, check.Equals, 200, err.Error())
 }

--- a/test/api_volume_delete_test.go
+++ b/test/api_volume_delete_test.go
@@ -22,9 +22,7 @@ func (suite *APIVolumeDeleteSuite) SetUpTest(c *check.C) {
 // TestDeleteNonExisting tests deleting a non-existing volume return error.
 func (suite *APIVolumeDeleteSuite) TestDeleteNonExisting(c *check.C) {
 	vol := "TestDeleteNonExisting"
-	path := "/volumes/" + vol
-	resp, err := request.Delete(path)
-	c.Assert(err, check.IsNil)
+	resp, err := request.Delete(c, "/volumes/"+vol)
 	// TODO: Now server return 500, should return 404
-	c.Assert(resp.StatusCode, check.Equals, 500)
+	c.Assert(resp.StatusCode, check.Equals, 500, err.Error())
 }

--- a/test/request/request.go
+++ b/test/request/request.go
@@ -3,14 +3,18 @@ package request
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 
+	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/client"
 	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/test/environment"
+
+	"github.com/go-check/check"
 )
 
 // Option defines a type used to update http.Request.
@@ -46,61 +50,49 @@ func WithJSONBody(obj interface{}) Option {
 		}
 		r.Body = ioutil.NopCloser(b)
 		return nil
-
 	}
 }
 
-// DecodeBody decodes body to obj.
-func DecodeBody(obj interface{}, body io.ReadCloser) error {
-	defer body.Close()
-	return json.NewDecoder(body).Decode(obj)
+// DecodeToStruct decodes body to obj.
+func DecodeToStruct(c *check.C, body io.ReadCloser, obj interface{}) {
+	err := json.NewDecoder(body).Decode(obj)
+	c.Assert(err, check.IsNil)
 }
 
 // Delete sends request to the default pouchd server with custom request options.
-func Delete(endpoint string, opts ...Option) (*http.Response, error) {
-	apiClient, err := newAPIClient(environment.PouchdAddress, environment.TLSConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := newRequest(http.MethodDelete, apiClient.BaseURL()+endpoint, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return apiClient.HTTPCli.Do(req)
+func Delete(c *check.C, endpoint string, opts ...Option) (*http.Response, error) {
+	return prepareClientAndInitRequest(c, http.MethodDelete, endpoint, opts...)
 }
 
 // Get sends request to the default pouchd server with custom request options.
-func Get(endpoint string, opts ...Option) (*http.Response, error) {
-	apiClient, err := newAPIClient(environment.PouchdAddress, environment.TLSConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := newRequest(http.MethodGet, apiClient.BaseURL()+endpoint, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return apiClient.HTTPCli.Do(req)
+func Get(c *check.C, endpoint string, opts ...Option) (*http.Response, error) {
+	return prepareClientAndInitRequest(c, http.MethodGet, endpoint, opts...)
 }
 
 // Post sends post request to pouchd.
-func Post(endpoint string, opts ...Option) (*http.Response, error) {
+func Post(c *check.C, endpoint string, opts ...Option) (*http.Response, error) {
+	return prepareClientAndInitRequest(c, http.MethodPost, endpoint, opts...)
+}
+
+func prepareClientAndInitRequest(c *check.C, method string, path string, opts ...Option) (*http.Response, error) {
 	apiClient, err := newAPIClient(environment.PouchdAddress, environment.TLSConfig)
-	if err != nil {
-		return nil, err
+	c.Assert(err, check.IsNil)
+
+	req, err := newRequest(method, apiClient.BaseURL()+path, opts...)
+	c.Assert(err, check.IsNil)
+
+	resp, err := apiClient.HTTPCli.Do(req)
+	c.Assert(err, check.IsNil)
+
+	// if status code is bigger than 400, error message is in response body
+	if resp.StatusCode >= 400 {
+		errMsg := types.Error{}
+		err := json.NewDecoder(resp.Body).Decode(&errMsg)
+		c.Assert(err, check.IsNil)
+		return resp, fmt.Errorf(errMsg.Message)
 	}
 
-	req, err := newRequest(http.MethodPost, apiClient.BaseURL()+endpoint, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	// By default, if Content-Type in header is not set, set it to application/json
-	if req.Header.Get("Content-Type") == "" {
-		WithHeader("Content-Type", "application/json")(req)
-	}
-	return apiClient.HTTPCli.Do(req)
+	return resp, fmt.Errorf("no error")
 }
 
 // newAPIClient return new HTTP client with tls.
@@ -123,7 +115,5 @@ func newRequest(method, url string, opts ...Option) (*http.Request, error) {
 			return nil, err
 		}
 	}
-	//fmt.Println(req)
-
 	return req, nil
 }

--- a/test/utils/api_utils.go
+++ b/test/utils/api_utils.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"net/url"
+
+	"github.com/alibaba/pouch/test/request"
+
+	"github.com/go-check/check"
+)
+
+// RunBusyboxContainer creates
+func RunBusyboxContainer(c *check.C, containerName string) {
+	CreateBusyboxContainer(c, containerName)
+	StartBusyboxContainer(c, containerName)
+}
+
+var busyboxImage = "registry.hub.docker.com/library/busybox:latest"
+
+// CreateBusyboxContainer creates
+func CreateBusyboxContainer(c *check.C, containerName string) {
+	q := url.Values{}
+	q.Add("name", containerName)
+
+	obj := map[string]interface{}{
+		"Image":      busyboxImage,
+		"Cmd":        []string{"sleep", "10000"},
+		"HostConfig": map[string]interface{}{},
+	}
+
+	query := request.WithQuery(q)
+	body := request.WithJSONBody(obj)
+
+	resp, err := request.Post(c, "/containers/create", query, body)
+	c.Assert(resp.StatusCode, check.Equals, 201, err.Error())
+}
+
+// StartBusyboxContainer start
+func StartBusyboxContainer(c *check.C, containerName string) {
+	resp, err := request.Post(c, "/containers/"+containerName+"/start")
+	c.Assert(resp.StatusCode, check.Equals, 204, err.Error())
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

I think we need to prepare to reduce the cost of contributors to write test case as much as we can. Maybe contributors are very familiar with your code, but not so familiar with your test case code. While I think test is the same important as the software implementation code.

In go's design, we need to always do error checking which has already evoked lots of debate in the community. This PR reduces lots of useful but redundant err checking and asserting.

In pkg request, I introduces a global checker to detect error in function's implementation. So in the detailed test cases, they do not need to assert error to be nil frequently.

When our test cases grows very fast. I think this way will reduce much test code in pouch.

WDYT? @Letty5411 @sunyuan3 @0x04C2 

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
In pkg request, I introduces a global checker to detect error in function's implementation. So in the detailed test cases, they do not need to assert error to be nil frequently.

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**


