### PR TITLE
fix: make container create API 404 be image not found

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -292,12 +292,12 @@ paths:
           schema:
             $ref: "#/definitions/Error"
         404:
-          description: "no such container"
+          description: "no such image"
           schema:
             $ref: "#/definitions/Error"
           examples:
             application/json:
-              message: "No such container: c2ada9df5af8"
+              message: "image: xxx:latest: not found"
         409:
           description: "conflict"
           schema:


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

`POST /containers/create` will return status code 404, but not because no such container.
There is one reason that no such image. I try to fix this in swagger.yml.

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


