### PR TITLE
feature: validate request body at the beginning of bridge layer handlers

### DIFF
--- a/apis/server/network_bridge.go
+++ b/apis/server/network_bridge.go
@@ -6,17 +6,23 @@ import (
 	"net/http"
 
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/pkg/httputils"
+
+	"github.com/go-openapi/strfmt"
 )
 
 func (s *Server) createNetwork(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
-	var config types.NetworkCreateConfig
-
-	if err := json.NewDecoder(req.Body).Decode(&config); err != nil {
-		resp.WriteHeader(http.StatusBadRequest)
-		return err
+	config := &types.NetworkCreateConfig{}
+	// decode request body
+	if err := json.NewDecoder(req.Body).Decode(config); err != nil {
+		return httputils.NewHTTPError(err, http.StatusBadRequest)
+	}
+	// validate request body
+	if err := config.Validate(strfmt.NewFormats()); err != nil {
+		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
 
-	network, err := s.NetworkMgr.NetworkCreate(ctx, config)
+	network, err := s.NetworkMgr.NetworkCreate(ctx, *config)
 	if err != nil {
 		resp.WriteHeader(http.StatusInternalServerError)
 		return err

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -667,6 +667,7 @@ definitions:
   ContainerConfig:
     type: "object"
     description: "Configuration for a container that is portable between hosts"
+    required: [Image]
     properties:
       Hostname:
         description: "The hostname to use for the container, as a valid RFC 1123 hostname."
@@ -726,6 +727,7 @@ definitions:
       Image:
         description: "The name of the image to use when creating the container"
         type: "string"
+        x-nullable: false
       Volumes:
         description: "An object mapping mount point paths inside the container to empty objects."
         type: "object"

--- a/apis/types/container_config.go
+++ b/apis/types/container_config.go
@@ -54,7 +54,8 @@ type ContainerConfig struct {
 	Hostname string `json:"Hostname,omitempty"`
 
 	// The name of the image to use when creating the container
-	Image string `json:"Image,omitempty"`
+	// Required: true
+	Image string `json:"Image"`
 
 	// User-defined key/value metadata.
 	Labels map[string]string `json:"Labels,omitempty"`
@@ -168,6 +169,11 @@ func (m *ContainerConfig) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateImage(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateOnBuild(formats); err != nil {
 		// prop
 		res = append(res, err)
@@ -251,6 +257,15 @@ func (m *ContainerConfig) validateExposedPorts(formats strfmt.Registry) error {
 			continue
 		}
 
+	}
+
+	return nil
+}
+
+func (m *ContainerConfig) validateImage(formats strfmt.Registry) error {
+
+	if err := validate.RequiredString("Image", "body", string(m.Image)); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

We need add a validation layer in bridge level to validate the request body's validness. 
While swagger supports to add type of struct. 
For example, `Image` in `ContainerConfig` is a required field. 

* Then we can add `required: [Image]` in `ContainerConfig`'s definition.
* And we need to auto generate structs in container_config.go;
* add validation code block in container_bridge.go.

This PR just added validation function in bridge layer of daemon side. In the future, we can only add restriction condition in swagger.yml and generate validation func in apis/types/xxx.go.

More attention, we cannot list all the validation in swagger.yml, but may be majority of that. Sometimes we still need to add validation manually after `config.Validate(....)`

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


