### PR TITLE
feature: make 'pouch ps' show running time and add flags in ps command.

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -87,7 +87,7 @@ func (s *Server) removeImage(ctx context.Context, rw http.ResponseWriter, req *h
 
 	containers, err := s.ContainerMgr.List(ctx, func(meta *mgr.ContainerMeta) bool {
 		return meta.Image == image.Name
-	})
+	}, &mgr.ContainerListOption{All: true})
 	if err != nil {
 		return err
 	}

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1467,7 +1467,7 @@ definitions:
       NetworkSettings:
         type: "object"
         properties:
-          etworks:
+          networks:
             additionalProperties:
               $ref: "#/definitions/EndpointSettings"
               x-nullable: true

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -323,6 +323,12 @@ paths:
               $ref: "#/definitions/Container"
         500:
           $ref: "#/responses/500ErrorResponse"
+      parameters:
+        - name: "all"
+          in: "query"
+          description: "Return all containers. By default, only running containers are shown"
+          type: "boolean"
+          default: false
 
   /containers/{id}/rename:
     post:
@@ -1427,8 +1433,9 @@ definitions:
       Command:
         type: "string"
       Created:
-        description: "Created time of container in daemon. !! Incompatibility !! Moby has a type of int64."
-        type: "string"
+        description: "Created time of container in daemon."
+        type: "integer"
+        format: "int64"
       SizeRw:
         type: "integer"
         format: "int64"
@@ -1458,9 +1465,12 @@ definitions:
         items:
           $ref: "#/definitions/MountPoint"
       NetworkSettings:
-        additionalProperties:
-          $ref: "#/definitions/EndpointSettings"
-          x-nullable: true
+        type: "object"
+        properties:
+          etworks:
+            additionalProperties:
+              $ref: "#/definitions/EndpointSettings"
+              x-nullable: true
 
 
   NetworkingConfig:

--- a/cli/image_list.go
+++ b/cli/image_list.go
@@ -100,7 +100,7 @@ func (i *ImagesCommand) runImages(args []string) error {
 
 // imagesExample shows examples in images command, and is used in auto-generated cli docs.
 func imagesExample() string {
-	return `$ pouch images ls
+	return `$ pouch images
 IMAGE ID             IMAGE NAME                                               SIZE
 bbc3a0323522         docker.io/library/busybox:latest                         703.14 KB
 b81f317384d7         docker.io/library/nginx:latest                           42.39 MB`

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -120,7 +120,7 @@ func (c containerList) Swap(i, j int) {
 
 // Less implements the sort interface.
 func (c containerList) Less(i, j int) bool {
-	iValue, _ := time.Parse(utils.TimeLayout, c[i].Created)
-	jValue, _ := time.Parse(utils.TimeLayout, c[j].Created)
+	iValue := time.Unix(0, c[i].Created)
+	jValue := time.Unix(0, c[j].Created)
 	return iValue.After(jValue)
 }

--- a/client/container.go
+++ b/client/container.go
@@ -14,7 +14,7 @@ type ContainerAPIClient interface {
 	ContainerStart(name, detachKeys string) error
 	ContainerStop(name, timeout string) error
 	ContainerRemove(name string, force bool) error
-	ContainerList() ([]*types.Container, error)
+	ContainerList(all bool) ([]*types.Container, error)
 	ContainerAttach(name string, stdin bool) (net.Conn, *bufio.Reader, error)
 	ContainerCreateExec(name string, config *types.ExecCreateConfig) (*types.ExecCreateResp, error)
 	ContainerStartExec(execid string, config *types.ExecStartConfig) (net.Conn, *bufio.Reader, error)
@@ -88,8 +88,13 @@ func (client *APIClient) ContainerRemove(name string, force bool) error {
 }
 
 // ContainerList returns the list of containers.
-func (client *APIClient) ContainerList() ([]*types.Container, error) {
-	resp, err := client.get("/containers/json", nil)
+func (client *APIClient) ContainerList(all bool) ([]*types.Container, error) {
+	q := url.Values{}
+	if all {
+		q.Set("all", "true")
+	}
+
+	resp, err := client.get("/containers/json", q)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -44,7 +44,7 @@ type ContainerMgr interface {
 	Attach(ctx context.Context, name string, attach *AttachConfig) error
 
 	// List returns the list of containers.
-	List(ctx context.Context, filter ContainerFilter) ([]*ContainerMeta, error)
+	List(ctx context.Context, filter ContainerFilter, option *ContainerListOption) ([]*ContainerMeta, error)
 
 	// CreateExec creates exec process's environment.
 	CreateExec(ctx context.Context, name string, config *types.ExecCreateConfig) (string, error)
@@ -295,13 +295,13 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 
 	meta := &ContainerMeta{
 		State: &types.ContainerState{
-			StartedAt: time.Now().UTC().Format(utils.TimeLayout),
-			Status:    types.StatusCreated,
+			Status: types.StatusCreated,
 		},
 		ID:         id,
 		Image:      image.Name,
 		Name:       name,
 		Config:     &config.ContainerConfig,
+		Created:    time.Now().UTC().Format(utils.TimeLayout),
 		HostConfig: config.HostConfig,
 	}
 
@@ -388,7 +388,7 @@ func (mgr *ContainerManager) Start(ctx context.Context, id, detachKeys string) (
 		}
 		c.meta.State.Pid = int64(pid)
 	} else {
-		c.meta.State.FinishedAt = time.Now().String()
+		c.meta.State.FinishedAt = time.Now().UTC().Format(utils.TimeLayout)
 		c.meta.State.Error = err.Error()
 		c.meta.State.Pid = 0
 		//TODO get and set exit code
@@ -509,7 +509,7 @@ func (mgr *ContainerManager) Attach(ctx context.Context, name string, attach *At
 }
 
 // List returns the container's list.
-func (mgr *ContainerManager) List(ctx context.Context, filter ContainerFilter) ([]*ContainerMeta, error) {
+func (mgr *ContainerManager) List(ctx context.Context, filter ContainerFilter, option *ContainerListOption) ([]*ContainerMeta, error) {
 	metas := []*ContainerMeta{}
 
 	list, err := mgr.Store.List()
@@ -523,7 +523,11 @@ func (mgr *ContainerManager) List(ctx context.Context, filter ContainerFilter) (
 			return nil, fmt.Errorf("failed to get container list, invalid meta type")
 		}
 		if filter != nil && filter(m) {
-			metas = append(metas, m)
+			if option.All {
+				metas = append(metas, m)
+			} else if m.State.Status == types.StatusRunning || m.State.Status == types.StatusPaused {
+				metas = append(metas, m)
+			}
 		}
 	}
 
@@ -613,7 +617,7 @@ func (mgr *ContainerManager) openIO(id string, attach *AttachConfig, exec bool) 
 func (mgr *ContainerManager) markStoppedAndRelease(c *Container, m *ctrd.Message) error {
 	c.meta.State.Pid = -1
 	c.meta.State.ExitCode = int64(m.ExitCode())
-	c.meta.State.FinishedAt = time.Now().String()
+	c.meta.State.FinishedAt = time.Now().UTC().Format(utils.TimeLayout)
 	c.meta.State.Status = types.StatusStopped
 
 	if err := m.RawError(); err != nil {

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -42,6 +42,11 @@ type ContainerRemoveOption struct {
 	Link   bool
 }
 
+// ContainerListOption wraps the container list interface params.
+type ContainerListOption struct {
+	All bool
+}
+
 // ContainerMeta represents the container's meta data.
 type ContainerMeta struct {
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -50,9 +50,9 @@ func FormatSize(size int64) string {
 	return fmt.Sprintf("%.2f %s", formattedSize, suffixes[count])
 }
 
-// FormatCreatedTime is used to show the time from creation to now.
-func FormatCreatedTime(created string) (formattedTime string, err error) {
-	start, err := time.Parse(TimeLayout, created)
+// FormatTimeInterval is used to show the time interval from input time to now.
+func FormatTimeInterval(input string) (formattedTime string, err error) {
+	start, err := time.Parse(TimeLayout, input)
 	if err != nil {
 		return "", errInvalid
 	}
@@ -70,51 +70,44 @@ func FormatCreatedTime(created string) (formattedTime string, err error) {
 		if year > 1 {
 			formattedTime += "s"
 		}
-		formattedTime += " ago"
 	} else if diff >= Month {
 		month := int(diff / Month)
 		formattedTime += strconv.Itoa(month) + " month"
 		if month > 1 {
 			formattedTime += "s"
 		}
-		formattedTime += " ago"
 	} else if diff >= Week {
 		week := int(diff / Week)
 		formattedTime += strconv.Itoa(week) + " week"
 		if week > 1 {
 			formattedTime += "s"
 		}
-		formattedTime += " ago"
 	} else if diff >= Day {
 		day := int(diff / Day)
 		formattedTime += strconv.Itoa(day) + " day"
 		if day > 1 {
 			formattedTime += "s"
 		}
-		formattedTime += " ago"
 	} else if diff >= Hour {
 		hour := int(diff / Hour)
 		formattedTime += strconv.Itoa(hour) + " hour"
 		if hour > 1 {
 			formattedTime += "s"
 		}
-		formattedTime += " ago"
 	} else if diff >= Minute {
 		minute := int(diff / Minute)
 		formattedTime += strconv.Itoa(minute) + " minute"
 		if minute > 1 {
 			formattedTime += "s"
 		}
-		formattedTime += " ago"
 	} else if diff >= Second {
 		second := int(diff / Second)
 		formattedTime += strconv.Itoa(second) + " second"
 		if second > 1 {
 			formattedTime += "s"
 		}
-		formattedTime += " ago"
 	} else {
-		formattedTime += "0 second ago"
+		formattedTime += "0 second"
 	}
 
 	return formattedTime, nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -51,17 +51,13 @@ func FormatSize(size int64) string {
 }
 
 // FormatTimeInterval is used to show the time interval from input time to now.
-func FormatTimeInterval(input string) (formattedTime string, err error) {
-	start, err := time.Parse(TimeLayout, input)
-	if err != nil {
-		return "", errInvalid
-	}
+func FormatTimeInterval(input int64) (formattedTime string, err error) {
+	start := time.Unix(0, input)
 	diff := time.Now().Sub(start)
 
 	// That should not happen.
 	if diff < 0 {
-		formattedTime += "-"
-		diff = 0 - diff
+		return "", errInvalid
 	}
 
 	if diff >= Year {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -9,7 +9,7 @@ import (
 
 type tCase struct {
 	name     string
-	input    string
+	input    int64
 	expected string
 	err      error
 }
@@ -35,84 +35,78 @@ func TestFormatTimeInterval(t *testing.T) {
 	for _, tc := range []tCase{
 		{
 			name:     "second",
-			input:    time.Now().Add(0 - Second).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Second).UnixNano(),
 			expected: "1 second",
 			err:      nil,
 		}, {
 			name:     "minute",
-			input:    time.Now().Add(0 - Minute).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Minute).UnixNano(),
 			expected: "1 minute",
 			err:      nil,
 		}, {
 			name:     "hour",
-			input:    time.Now().Add(0 - Hour).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Hour).UnixNano(),
 			expected: "1 hour",
 			err:      nil,
 		}, {
 			name:     "day",
-			input:    time.Now().Add(0 - Day).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Day).UnixNano(),
 			expected: "1 day",
 			err:      nil,
 		}, {
 			name:     "week",
-			input:    time.Now().Add(0 - Week).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Week).UnixNano(),
 			expected: "1 week",
 			err:      nil,
 		}, {
 			name:     "month",
-			input:    time.Now().Add(0 - Month).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Month).UnixNano(),
 			expected: "1 month",
 			err:      nil,
 		}, {
 			name:     "year",
-			input:    time.Now().Add(0 - Year).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Year).UnixNano(),
 			expected: "1 year",
 			err:      nil,
 		},
 		{
 			name:     "seconds",
-			input:    time.Now().Add(0 - Second*3).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Second*3).UnixNano(),
 			expected: "3 seconds",
 			err:      nil,
 		}, {
 			name:     "minutes",
-			input:    time.Now().Add(0 - Minute*3).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Minute*3).UnixNano(),
 			expected: "3 minutes",
 			err:      nil,
 		}, {
 			name:     "hours",
-			input:    time.Now().Add(0 - Hour*3).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Hour*3).UnixNano(),
 			expected: "3 hours",
 			err:      nil,
 		}, {
 			name:     "days",
-			input:    time.Now().Add(0 - Day*3).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Day*3).UnixNano(),
 			expected: "3 days",
 			err:      nil,
 		}, {
 			name:     "weeks",
-			input:    time.Now().Add(0 - Week*3).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Week*3).UnixNano(),
 			expected: "3 weeks",
 			err:      nil,
 		}, {
 			name:     "months",
-			input:    time.Now().Add(0 - Month*3).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Month*3).UnixNano(),
 			expected: "3 months",
 			err:      nil,
 		}, {
 			name:     "years",
-			input:    time.Now().Add(0 - Year*3).UTC().Format(TimeLayout),
+			input:    time.Now().Add(0 - Year*3).UnixNano(),
 			expected: "3 years",
 			err:      nil,
 		}, {
-			name:     "notHappen",
-			input:    time.Now().Add(Second * 61).UTC().Format(TimeLayout),
-			expected: "-1 minute",
-			err:      nil,
-		},
-		{
 			name:     "invalid",
-			input:    "balabala",
+			input:    time.Now().Add(Second).UnixNano(),
 			expected: "",
 			err:      errInvalid,
 		},

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -30,84 +30,84 @@ func TestFormatSize(t *testing.T) {
 	}
 }
 
-func TestFormatCreatedTime(t *testing.T) {
+func TestFormatTimeInterval(t *testing.T) {
 
 	for _, tc := range []tCase{
 		{
 			name:     "second",
 			input:    time.Now().Add(0 - Second).UTC().Format(TimeLayout),
-			expected: "1 second ago",
+			expected: "1 second",
 			err:      nil,
 		}, {
 			name:     "minute",
 			input:    time.Now().Add(0 - Minute).UTC().Format(TimeLayout),
-			expected: "1 minute ago",
+			expected: "1 minute",
 			err:      nil,
 		}, {
 			name:     "hour",
 			input:    time.Now().Add(0 - Hour).UTC().Format(TimeLayout),
-			expected: "1 hour ago",
+			expected: "1 hour",
 			err:      nil,
 		}, {
 			name:     "day",
 			input:    time.Now().Add(0 - Day).UTC().Format(TimeLayout),
-			expected: "1 day ago",
+			expected: "1 day",
 			err:      nil,
 		}, {
 			name:     "week",
 			input:    time.Now().Add(0 - Week).UTC().Format(TimeLayout),
-			expected: "1 week ago",
+			expected: "1 week",
 			err:      nil,
 		}, {
 			name:     "month",
 			input:    time.Now().Add(0 - Month).UTC().Format(TimeLayout),
-			expected: "1 month ago",
+			expected: "1 month",
 			err:      nil,
 		}, {
 			name:     "year",
 			input:    time.Now().Add(0 - Year).UTC().Format(TimeLayout),
-			expected: "1 year ago",
+			expected: "1 year",
 			err:      nil,
 		},
 		{
 			name:     "seconds",
 			input:    time.Now().Add(0 - Second*3).UTC().Format(TimeLayout),
-			expected: "3 seconds ago",
+			expected: "3 seconds",
 			err:      nil,
 		}, {
 			name:     "minutes",
 			input:    time.Now().Add(0 - Minute*3).UTC().Format(TimeLayout),
-			expected: "3 minutes ago",
+			expected: "3 minutes",
 			err:      nil,
 		}, {
 			name:     "hours",
 			input:    time.Now().Add(0 - Hour*3).UTC().Format(TimeLayout),
-			expected: "3 hours ago",
+			expected: "3 hours",
 			err:      nil,
 		}, {
 			name:     "days",
 			input:    time.Now().Add(0 - Day*3).UTC().Format(TimeLayout),
-			expected: "3 days ago",
+			expected: "3 days",
 			err:      nil,
 		}, {
 			name:     "weeks",
 			input:    time.Now().Add(0 - Week*3).UTC().Format(TimeLayout),
-			expected: "3 weeks ago",
+			expected: "3 weeks",
 			err:      nil,
 		}, {
 			name:     "months",
 			input:    time.Now().Add(0 - Month*3).UTC().Format(TimeLayout),
-			expected: "3 months ago",
+			expected: "3 months",
 			err:      nil,
 		}, {
 			name:     "years",
 			input:    time.Now().Add(0 - Year*3).UTC().Format(TimeLayout),
-			expected: "3 years ago",
+			expected: "3 years",
 			err:      nil,
 		}, {
 			name:     "notHappen",
 			input:    time.Now().Add(Second * 61).UTC().Format(TimeLayout),
-			expected: "-1 minute ago",
+			expected: "-1 minute",
 			err:      nil,
 		},
 		{
@@ -117,7 +117,7 @@ func TestFormatCreatedTime(t *testing.T) {
 			err:      errInvalid,
 		},
 	} {
-		output, err := FormatCreatedTime(tc.input)
+		output, err := FormatTimeInterval(tc.input)
 		assert.Equal(t, tc.err, err, tc.name)
 		assert.Equal(t, tc.expected, output, tc.name)
 	}

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -39,7 +39,7 @@ func (suite *PouchStopSuite) TestStopWorks(c *check.C) {
 
 	command.PouchRun("stop", name).Assert(c, icmd.Success)
 
-	res := command.PouchRun("ps")
+	res := command.PouchRun("ps", "-a")
 
 	// FIXME: It's better if we use inspect to filter status.
 	if out := res.Combined(); !strings.Contains(out, "stopped") {
@@ -50,7 +50,7 @@ func (suite *PouchStopSuite) TestStopWorks(c *check.C) {
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 	command.PouchRun("stop", name, "3").Assert(c, icmd.Success)
 
-	res = command.PouchRun("ps")
+	res = command.PouchRun("ps", "-a")
 
 	// FIXME: It's better if we use inspect to filter status.
 	if out := res.Combined(); !strings.Contains(out, "stopped") {

--- a/test/environment/cleanup.go
+++ b/test/environment/cleanup.go
@@ -25,7 +25,7 @@ func PruneAllImages(apiClient client.ImageAPIClient) error {
 
 // PruneAllContainers deletes all containers from pouchd.
 func PruneAllContainers(apiClient client.ContainerAPIClient) error {
-	containers, err := apiClient.ContainerList()
+	containers, err := apiClient.ContainerList(true)
 	if err != nil {
 		return errors.Wrap(err, "fail to list images")
 	}


### PR DESCRIPTION
Signed-off-by: zeppp <zeppp1995@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
1. make 'pouch ps' show running time.
2. fix a bug that the 'Created' shows wrong time when start a container.
3. add flags "quiet" and "all" in ps command because **now `pouch ps` only shows running and paused containers by default.**
4. refactor FormatTimeInterval fuction in utils.go.

**2.Does this pull request fix one issue?** 
NONE. It is a follow-up PR of #358.

**3.Describe how you did it**


**4.Describe how to verify it**
```
→ pouch ps
Name   ID       Status          Created          Image                              Runtime
2      e42c68   Up 26 minutes   27 minutes ago   docker.io/library/busybox:latest   runc
1      a8c2ea   Up 27 minutes   28 minutes ago   docker.io/library/busybox:latest   runc

→ pouch ps -a
Name   ID       Status          Created          Image                              Runtime
3      faf132   created         11 minutes ago   docker.io/library/busybox:latest   runc
2      e42c68   Up 27 minutes   27 minutes ago   docker.io/library/busybox:latest   runc
1      a8c2ea   Up 28 minutes   28 minutes ago   docker.io/library/busybox:latest   runc

→ pouch pause 1
→ pouch ps 
Name   ID       Status                  Created          Image                              Runtime
2      e42c68   Up 38 minutes           39 minutes ago   docker.io/library/busybox:latest   runc
1      a8c2ea   Up 39 minutes(paused)   40 minutes ago   docker.io/library/busybox:latest   runc

→ pouch ps -q
e42c68
a8c2ea

→ pouch ps -q -a
faf132
e42c68
a8c2ea

→ pouch unpause 1
→ pouch stop 1
→ pouch start 1
→ pouch ps
Name   ID       Status          Created          Image                              Runtime
2      e42c68   Up 41 minutes   42 minutes ago   docker.io/library/busybox:latest   runc
1      a8c2ea   Up 8 seconds    43 minutes ago   docker.io/library/busybox:latest   runc


```
**5.Special notes for reviews**
**Please remove all containers first and then make install to apply this PR.**


  