### PR TITLE
bugfix: fix pouch pull panic : unexpected format character

### DIFF
--- a/cli/pull.go
+++ b/cli/pull.go
@@ -170,20 +170,20 @@ func formatProgressInfo(info ctrd.ProgressInfo, isTerminal bool) string {
 		if info.Total > 0.0 {
 			bar = progress.Bar(float64(info.Offset) / float64(info.Total))
 		}
-		return fmt.Sprintf("%s:\t%s\t%40f\t%8.8s/%s\t\n",
+		return fmt.Sprintf("%s:\t%s\t%40r\t%8.8s/%s\t\n",
 			info.Ref,
 			info.Status,
 			bar,
 			progress.Bytes(info.Offset), progress.Bytes(info.Total))
 
 	case "resolving", "waiting":
-		return fmt.Sprintf("%s:\t%s\t%40f\t\n",
+		return fmt.Sprintf("%s:\t%s\t%40r\t\n",
 			info.Ref,
 			info.Status,
 			progress.Bar(0.0))
 
 	default:
-		return fmt.Sprintf("%s:\t%s\t%40f\t\n",
+		return fmt.Sprintf("%s:\t%s\t%40r\t\n",
 			info.Ref,
 			info.Status,
 			progress.Bar(1.0))


### PR DESCRIPTION
Signed-off-by: HusterWan <zirenwan@gmail.com>

**1.Describe what this PR did**
pull pull image panic:
```
[root@docker-registry github.com]# pouch pull registry.hub.docker.com/library/busybox:latest
registry.hub.docker.com/library/busybox:latest:                                   resolved       %!f(PANIC=1: unexpected format character)
index-sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0:    done           %!f(PANIC=1: unexpected format character)
manifest-sha256:91ef6c1c52b166be02645b8efee30d1ee65362024f7da41c404681561734c465: done           %!f(PANIC=1: unexpected format character)
layer-sha256:0ffadd58f2a61468f527cc4f0fc45272ee4a1a428abe014546c89de2aa6a0eb5:    done           %!f(PANIC=1: unexpected format character)
config-sha256:6ad733544a6317992a6fac4eb19fe1df577d4dec7529efec28a5bd0edad0fd30:   done           %!f(PANIC=1: unexpected format character)
elapsed: 1.4 s                                                                    total:   0.0 B (0.0 B/s)
```

**2.Does this pull request fix one issue?** 

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


