### PR TITLE
bugfix: api_image_create_test duplicate image tag

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -326,7 +326,7 @@ func (c *Client) createContainer(ctx context.Context, ref, id string, container 
 		}),
 	}
 
-	// check snaphost exist or not.
+	// check snapshot exist or not.
 	if _, err := c.GetSnapshot(ctx, id); err != nil {
 		return errors.Wrapf(err, "failed to create container, id: %s", id)
 	}

--- a/test/api_image_create_test.go
+++ b/test/api_image_create_test.go
@@ -24,7 +24,8 @@ func (suite *APIImageCreateSuite) SetUpTest(c *check.C) {
 // TestImageCreateOk tests creating an image is OK.
 func (suite *APIImageCreateSuite) TestImageCreateOk(c *check.C) {
 	q := url.Values{}
-	q.Add("fromImage", busyboxImage)
+	q.Add("fromImage", "registry.hub.docker.com/library/busybox")
+	q.Add("tag", "latest")
 	path := "/images/create"
 	query := request.WithQuery(q)
 	resp, err := request.Post(path, query)


### PR DESCRIPTION
Signed-off-by: HusterWan <zirenwan@gmail.com>

**1.Describe what this PR did**
api_image_create_test fromImage not split image name and tag, so in daemon, the image ref is `registry.hub.docker.com/library/busybox:latest:latest`
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


