### PR TITLE
bugfix: fix can not build pouch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ build: pre server client
 
 .PHONY: pre
 pre:
+	@ git submodule update --init
 	@ mkdir -p $(ORIG_GOPATH)/src/github.com/docker
 	@ - [ -L $(ORIG_GOPATH)/src/github.com/docker/libnetwork ] && rm -f $(ORIG_GOPATH)/src/github.com/docker/libnetwork
 	@ - ln -s $(shell pwd)/extra/libnetwork $(ORIG_GOPATH)/src/github.com/docker/libnetwork
@@ -38,7 +39,7 @@ clean:
 	./module --clean
 
 .PHONY: check
-check: fmt lint vet validate-swagger
+check: pre fmt lint vet validate-swagger
 
 .PHONY: fmt
 fmt: ## run go fmt


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
fix can't build pouch without libnetwork submodule.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #430 
fix #428 

**3.Describe how you did it**
use 'git submodule update --init' to pull libnetwork source code before
build.

**4.Describe how to verify it**
make can build pouch/pouchd.

**5.Special notes for reviews**

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
