### PR TITLE
fix: make request body and response have consistent name rule

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -100,7 +100,7 @@ func (s *Server) startContainerExec(ctx context.Context, rw http.ResponseWriter,
 }
 
 func (s *Server) createContainer(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
-	var config types.ContainerConfigWrapper
+	var config types.ContainerCreateConfig
 
 	if err := json.NewDecoder(req.Body).Decode(&config); err != nil {
 		return httputils.NewHTTPError(err, http.StatusBadRequest)

--- a/apis/server/network_bridge.go
+++ b/apis/server/network_bridge.go
@@ -9,20 +9,20 @@ import (
 )
 
 func (s *Server) createNetwork(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
-	var networkCreateReq types.NetworkCreateRequest
+	var config types.NetworkCreateConfig
 
-	if err := json.NewDecoder(req.Body).Decode(&networkCreateReq); err != nil {
+	if err := json.NewDecoder(req.Body).Decode(&config); err != nil {
 		resp.WriteHeader(http.StatusBadRequest)
 		return err
 	}
 
-	network, err := s.NetworkMgr.NetworkCreate(ctx, networkCreateReq)
+	network, err := s.NetworkMgr.NetworkCreate(ctx, config)
 	if err != nil {
 		resp.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
 
-	networkCreateResp := types.NetworkCreateResponse{
+	networkCreateResp := types.NetworkCreateResp{
 		ID: network.ID,
 	}
 

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -255,7 +255,7 @@ paths:
           in: "body"
           description: "Container to create"
           schema:
-            $ref: "#/definitions/ContainerConfigWrapper"
+            $ref: "#/definitions/ContainerCreateConfig"
           required: true
       responses:
         201:
@@ -577,7 +577,7 @@ paths:
         201:
           description: "The network was created successfully"
           schema:
-            $ref: "#/definitions/NetworkCreateResponse"
+            $ref: "#/definitions/NetworkCreateResp"
         400:
           description: "bad parameter"
           schema:
@@ -585,12 +585,12 @@ paths:
         500:
           $ref: "#/responses/500ErrorResponse"
       parameters:
-        - name: "NetworkCreateRequest"
+        - name: "NetworkCreateConfig"
           in: "body"
           required: true
           description: "Network configuration"
           schema:
-            $ref: "#/definitions/NetworkCreateRequest"
+            $ref: "#/definitions/NetworkCreateConfig"
       tags: ["Network"]
 
 definitions:
@@ -650,9 +650,9 @@ definitions:
       ContainersPaused:
         type: "integer"
 
-  ContainerConfigWrapper:
+  ContainerCreateConfig:
     description: | 
-      ContainerConfigWrapper is used for API "POST /containers/create".
+      ContainerCreateConfig is used for API "POST /containers/create".
       It wraps all kinds of config used in container creation.
       It can be used to encode client params in client and unmarshal request body in daemon side.
     allOf:
@@ -1533,7 +1533,7 @@ definitions:
         type: "string"
         example: "4443"
 
-  NetworkCreateRequest:
+  NetworkCreateConfig:
     type: "object"
     description: "contains the request for the remote API: POST /networks/create"
     properties:
@@ -1543,7 +1543,7 @@ definitions:
       NetworkCreate:
         $ref: "#/definitions/NetworkCreate"
 
-  NetworkCreateResponse:
+  NetworkCreateResp:
     type: "object"
     description: "contains the response for the remote API: POST /networks/create"
     properties:

--- a/apis/types/container_create_config.go
+++ b/apis/types/container_create_config.go
@@ -12,13 +12,13 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// ContainerConfigWrapper ContainerConfigWrapper is used for API "POST /containers/create".
+// ContainerCreateConfig ContainerCreateConfig is used for API "POST /containers/create".
 // It wraps all kinds of config used in container creation.
 // It can be used to encode client params in client and unmarshal request body in daemon side.
 //
-// swagger:model ContainerConfigWrapper
+// swagger:model ContainerCreateConfig
 
-type ContainerConfigWrapper struct {
+type ContainerCreateConfig struct {
 	ContainerConfig
 
 	// host config
@@ -29,7 +29,7 @@ type ContainerConfigWrapper struct {
 }
 
 // UnmarshalJSON unmarshals this object from a JSON structure
-func (m *ContainerConfigWrapper) UnmarshalJSON(raw []byte) error {
+func (m *ContainerCreateConfig) UnmarshalJSON(raw []byte) error {
 
 	var aO0 ContainerConfig
 	if err := swag.ReadJSON(raw, &aO0); err != nil {
@@ -54,7 +54,7 @@ func (m *ContainerConfigWrapper) UnmarshalJSON(raw []byte) error {
 }
 
 // MarshalJSON marshals this object to a JSON structure
-func (m ContainerConfigWrapper) MarshalJSON() ([]byte, error) {
+func (m ContainerCreateConfig) MarshalJSON() ([]byte, error) {
 	var _parts [][]byte
 
 	aO0, err := swag.WriteJSON(m.ContainerConfig)
@@ -82,8 +82,8 @@ func (m ContainerConfigWrapper) MarshalJSON() ([]byte, error) {
 	return swag.ConcatJSON(_parts...), nil
 }
 
-// Validate validates this container config wrapper
-func (m *ContainerConfigWrapper) Validate(formats strfmt.Registry) error {
+// Validate validates this container create config
+func (m *ContainerCreateConfig) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.ContainerConfig.Validate(formats); err != nil {
@@ -100,7 +100,7 @@ func (m *ContainerConfigWrapper) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *ContainerConfigWrapper) validateNetworkingConfig(formats strfmt.Registry) error {
+func (m *ContainerCreateConfig) validateNetworkingConfig(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.NetworkingConfig) { // not required
 		return nil
@@ -120,7 +120,7 @@ func (m *ContainerConfigWrapper) validateNetworkingConfig(formats strfmt.Registr
 }
 
 // MarshalBinary interface implementation
-func (m *ContainerConfigWrapper) MarshalBinary() ([]byte, error) {
+func (m *ContainerCreateConfig) MarshalBinary() ([]byte, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -128,8 +128,8 @@ func (m *ContainerConfigWrapper) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary interface implementation
-func (m *ContainerConfigWrapper) UnmarshalBinary(b []byte) error {
-	var res ContainerConfigWrapper
+func (m *ContainerCreateConfig) UnmarshalBinary(b []byte) error {
+	var res ContainerCreateConfig
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/apis/types/network_create_config.go
+++ b/apis/types/network_create_config.go
@@ -12,10 +12,10 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// NetworkCreateRequest contains the request for the remote API: POST /networks/create
-// swagger:model NetworkCreateRequest
+// NetworkCreateConfig contains the request for the remote API: POST /networks/create
+// swagger:model NetworkCreateConfig
 
-type NetworkCreateRequest struct {
+type NetworkCreateConfig struct {
 
 	// Name is the name of the network.
 	Name string `json:"Name,omitempty"`
@@ -24,12 +24,12 @@ type NetworkCreateRequest struct {
 	NetworkCreate *NetworkCreate `json:"NetworkCreate,omitempty"`
 }
 
-/* polymorph NetworkCreateRequest Name false */
+/* polymorph NetworkCreateConfig Name false */
 
-/* polymorph NetworkCreateRequest NetworkCreate false */
+/* polymorph NetworkCreateConfig NetworkCreate false */
 
-// Validate validates this network create request
-func (m *NetworkCreateRequest) Validate(formats strfmt.Registry) error {
+// Validate validates this network create config
+func (m *NetworkCreateConfig) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateNetworkCreate(formats); err != nil {
@@ -43,7 +43,7 @@ func (m *NetworkCreateRequest) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *NetworkCreateRequest) validateNetworkCreate(formats strfmt.Registry) error {
+func (m *NetworkCreateConfig) validateNetworkCreate(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.NetworkCreate) { // not required
 		return nil
@@ -63,7 +63,7 @@ func (m *NetworkCreateRequest) validateNetworkCreate(formats strfmt.Registry) er
 }
 
 // MarshalBinary interface implementation
-func (m *NetworkCreateRequest) MarshalBinary() ([]byte, error) {
+func (m *NetworkCreateConfig) MarshalBinary() ([]byte, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -71,8 +71,8 @@ func (m *NetworkCreateRequest) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary interface implementation
-func (m *NetworkCreateRequest) UnmarshalBinary(b []byte) error {
-	var res NetworkCreateRequest
+func (m *NetworkCreateConfig) UnmarshalBinary(b []byte) error {
+	var res NetworkCreateConfig
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/apis/types/network_create_resp.go
+++ b/apis/types/network_create_resp.go
@@ -12,10 +12,10 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// NetworkCreateResponse contains the response for the remote API: POST /networks/create
-// swagger:model NetworkCreateResponse
+// NetworkCreateResp contains the response for the remote API: POST /networks/create
+// swagger:model NetworkCreateResp
 
-type NetworkCreateResponse struct {
+type NetworkCreateResp struct {
 
 	// ID is the id of the network.
 	ID string `json:"ID,omitempty"`
@@ -24,12 +24,12 @@ type NetworkCreateResponse struct {
 	Warning string `json:"Warning,omitempty"`
 }
 
-/* polymorph NetworkCreateResponse ID false */
+/* polymorph NetworkCreateResp ID false */
 
-/* polymorph NetworkCreateResponse Warning false */
+/* polymorph NetworkCreateResp Warning false */
 
-// Validate validates this network create response
-func (m *NetworkCreateResponse) Validate(formats strfmt.Registry) error {
+// Validate validates this network create resp
+func (m *NetworkCreateResp) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if len(res) > 0 {
@@ -39,7 +39,7 @@ func (m *NetworkCreateResponse) Validate(formats strfmt.Registry) error {
 }
 
 // MarshalBinary interface implementation
-func (m *NetworkCreateResponse) MarshalBinary() ([]byte, error) {
+func (m *NetworkCreateResp) MarshalBinary() ([]byte, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -47,8 +47,8 @@ func (m *NetworkCreateResponse) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary interface implementation
-func (m *NetworkCreateResponse) UnmarshalBinary(b []byte) error {
-	var res NetworkCreateResponse
+func (m *NetworkCreateResp) UnmarshalBinary(b []byte) error {
+	var res NetworkCreateResp
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/cli/container.go
+++ b/cli/container.go
@@ -11,8 +11,8 @@ type container struct {
 	runtime string
 }
 
-func (c *container) config() *types.ContainerConfigWrapper {
-	config := &types.ContainerConfigWrapper{
+func (c *container) config() *types.ContainerCreateConfig {
+	config := &types.ContainerCreateConfig{
 		HostConfig: &types.HostConfig{},
 	}
 

--- a/cli/network.go
+++ b/cli/network.go
@@ -93,7 +93,7 @@ func (n *NetworkCreateCommand) runNetworkCreate(args []string) error {
 		return fmt.Errorf("network name cannot be empty")
 	}
 
-	networkRequest := &types.NetworkCreateRequest{
+	networkRequest := &types.NetworkCreateConfig{
 		Name: name,
 	}
 

--- a/client/container.go
+++ b/client/container.go
@@ -25,7 +25,7 @@ type ContainerAPIClient interface {
 
 // ContainerCreate creates a new container based in the given configuration.
 func (client *APIClient) ContainerCreate(config types.ContainerConfig, hostConfig *types.HostConfig, containerName string) (*types.ContainerCreateResp, error) {
-	createConfig := types.ContainerConfigWrapper{
+	createConfig := types.ContainerCreateConfig{
 		ContainerConfig: config,
 		HostConfig:      hostConfig,
 	}

--- a/client/network.go
+++ b/client/network.go
@@ -3,13 +3,13 @@ package client
 import "github.com/alibaba/pouch/apis/types"
 
 // NetworkCreate creates a network.
-func (client *APIClient) NetworkCreate(req *types.NetworkCreateRequest) (*types.NetworkCreateResponse, error) {
+func (client *APIClient) NetworkCreate(req *types.NetworkCreateConfig) (*types.NetworkCreateResp, error) {
 	resp, err := client.post("/networks/create", nil, req)
 	if err != nil {
 		return nil, err
 	}
 
-	network := &types.NetworkCreateResponse{}
+	network := &types.NetworkCreateResp{}
 
 	err = decodeBody(network, resp.Body)
 	ensureCloseReader(resp)

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -25,7 +25,7 @@ import (
 //ContainerMgr as an interface defines all operations against container.
 type ContainerMgr interface {
 	// Create a new container.
-	Create(ctx context.Context, name string, config *types.ContainerConfigWrapper) (*types.ContainerCreateResp, error)
+	Create(ctx context.Context, name string, config *types.ContainerCreateConfig) (*types.ContainerCreateResp, error)
 
 	// Start a container.
 	Start(ctx context.Context, id, detachKeys string) error
@@ -246,7 +246,7 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, confi
 }
 
 // Create checks passed in parameters and create a Container object whose status is set at Created.
-func (mgr *ContainerManager) Create(ctx context.Context, name string, config *types.ContainerConfigWrapper) (*types.ContainerCreateResp, error) {
+func (mgr *ContainerManager) Create(ctx context.Context, name string, config *types.ContainerCreateConfig) (*types.ContainerCreateResp, error) {
 	// TODO: check request validate.
 	if config.HostConfig == nil {
 		return nil, fmt.Errorf("host config and network config can not be nil")
@@ -654,7 +654,7 @@ func (mgr *ContainerManager) exitedAndRelease(id string, m *ctrd.Message) error 
 	return nil
 }
 
-func (mgr *ContainerManager) parseVolumes(ctx context.Context, c *types.ContainerConfigWrapper) error {
+func (mgr *ContainerManager) parseVolumes(ctx context.Context, c *types.ContainerCreateConfig) error {
 	logrus.Debugf("bind volumes: %v", c.HostConfig.Binds)
 	// TODO: parse c.HostConfig.VolumesFrom
 

--- a/daemon/mgr/network.go
+++ b/daemon/mgr/network.go
@@ -23,7 +23,7 @@ import (
 // NetworkMgr defines interface to manage container network.
 type NetworkMgr interface {
 	// NetworkCreate is used to create network.
-	NetworkCreate(ctx context.Context, create apitypes.NetworkCreateRequest) (*types.Network, error)
+	NetworkCreate(ctx context.Context, create apitypes.NetworkCreateConfig) (*types.Network, error)
 
 	// NetworkRemove is used to delete an existing network.
 	NetworkRemove(ctx context.Context, name string) error
@@ -75,7 +75,7 @@ func NewNetworkManager(cfg *config.Config, store *meta.Store) (*NetworkManager, 
 }
 
 // NetworkCreate is used to create network.
-func (nm *NetworkManager) NetworkCreate(ctx context.Context, create apitypes.NetworkCreateRequest) (*types.Network, error) {
+func (nm *NetworkManager) NetworkCreate(ctx context.Context, create apitypes.NetworkCreateConfig) (*types.Network, error) {
 	name := create.Name
 	driver := create.NetworkCreate.Driver
 	id := randomid.Generate()
@@ -185,7 +185,7 @@ func bridgeDriverOptions() nwconfig.Option {
 	return nwconfig.OptionDriverConfig("bridge", bridgeOption)
 }
 
-func networkOptions(create apitypes.NetworkCreateRequest) ([]libnetwork.NetworkOption, error) {
+func networkOptions(create apitypes.NetworkCreateConfig) ([]libnetwork.NetworkOption, error) {
 	// TODO: parse network config.
 	networkCreate := create.NetworkCreate
 	nwOptions := []libnetwork.NetworkOption{

--- a/network/bridge/bridge.go
+++ b/network/bridge/bridge.go
@@ -55,7 +55,7 @@ func New(ctx context.Context, config network.BridgeConfig, manager mgr.NetworkMg
 		IPAM: ipam,
 	}
 
-	create := types.NetworkCreateRequest{
+	create := types.NetworkCreateConfig{
 		Name:          "bridge",
 		NetworkCreate: networkCreate,
 	}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

This PR makes HTTP POST request body have same name rules.

For a request body, we have rule of ObjectActionConfig, like: `NetworkCreateConfig`, `ContainerCreateConfig`, `VolumeCreateConfig`, `ExecCreateConfig` and `ExecStartConfig`.

For a response struct, we have a rule of `ObjectCreateResp`, like `ContainerCreateResp`, `NetworkCreateResp`. 

However, `VolumeCreateResp` in not in the scope, since `POST /volumes/create` API returns `VolumeInfo` which is a inconsistency in Moby's API.

/cc @rudyfly @skoo87 @Letty5411 

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


