### PR TITLE
test: add codecov to stat unit test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,6 @@ before_install:
 
 script:
   - sudo make test
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,14 @@ vet: # run go vet
 .PHONY: unit-test
 unit-test: pre ## run go test
 	@echo $@
-	@go test `go list ./... | grep -v 'github.com/alibaba/pouch/test' | grep -v 'github.com/alibaba/pouch/extra'`
+	@for d in $$(go list ./... | grep -v 'github.com/alibaba/pouch/test' | grep -v 'github.com/alibaba/pouch/extra'); \
+	do \
+		go test -coverprofile=profile.out -covermode=atomic $${d} ; \
+		if [ -f profile.out ] ; then \
+			cat profile.out >> coverage.txt ;\
+			rm profile.out >/dev/null 2>&1 ; \
+		fi \
+	done
 
 .PHONY: validate-swagger
 validate-swagger: ## run swagger validate


### PR DESCRIPTION
Signed-off-by: letty <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Add [Codecov](https://codecov.io/) to stat unit test coverage.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #439 

**3.Describe how you did it**
First, add coverage statistic in each `go test` in Makefile, then add an entry in .travis.yml.
Codecov has be well integrated with travisCI.

**4.Describe how to verify it**

**5.Special notes for reviews**


