### PR TITLE
fix: make: go: Command not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo apt-get install -y -qq autoconf automake
 
 script:
-  - sudo make test
+  - sudo make -e test
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"


### PR DESCRIPTION
Signed-off-by: Yuan Sun <yile.sy@alibaba-inc.com>

**1.Describe what this PR did**
Fix "make: go: Command not found" error.

**2.Does this pull request fix one issue?** 
Yes.

**3.Describe how you did it**
make -e means that make uses host environment variable.

**4.Describe how to verify it**
make -e test

**5.Special notes for reviews**
None

