### PR TITLE
feature: add ExecConfig validation rule in swagger

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -59,10 +59,6 @@ func (s *Server) createContainerExec(ctx context.Context, rw http.ResponseWriter
 
 	name := mux.Vars(req)["name"]
 
-	if len(config.Cmd) == 0 {
-		return fmt.Errorf("no exec process specified")
-	}
-
 	id, err := s.ContainerMgr.CreateExec(ctx, name, config)
 	if err != nil {
 		return err

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1241,6 +1241,7 @@ definitions:
       User:
         type: "string"
         description: "User that will run the command"
+        x-nullable: false
       Privileged:
         type: "boolean"
         description: "Is the container in privileged mode"
@@ -1264,7 +1265,8 @@ definitions:
         description: "Escape keys for detach"
       Cmd:
         type: "array"
-        description:  "Execution commands and args"
+        description: "Execution commands and args"
+        minItems: 1
         items:
           type: "string"
 

--- a/apis/types/exec_create_config.go
+++ b/apis/types/exec_create_config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // ExecCreateConfig exec create config
@@ -27,6 +28,7 @@ type ExecCreateConfig struct {
 	AttachStdout bool `json:"AttachStdout,omitempty"`
 
 	// Execution commands and args
+	// Min Items: 1
 	Cmd []string `json:"Cmd"`
 
 	// Execute in detach mode
@@ -82,6 +84,12 @@ func (m *ExecCreateConfig) validateCmd(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Cmd) { // not required
 		return nil
+	}
+
+	iCmdSize := int64(len(m.Cmd))
+
+	if err := validate.MinItems("Cmd", "body", iCmdSize, 1); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

This PR restricts the validate type Post request config body. 

* I add ExecCreateConfig field restriction in swagger.yml;
* generate structs in apis/types, in this struct file, there are validation funcs which takes restriction into consideration:

```
func (m *ExecCreateConfig) validateCmd(formats strfmt.Registry) error {

	if swag.IsZero(m.Cmd) { // not required
		return nil
	}

	iCmdSize := int64(len(m.Cmd))

	if err := validate.MinItems("Cmd", "body", iCmdSize, 1); err != nil {
		return err
	}

	return nil
}
```

When the above two aspects has been done, codes in https://github.com/alibaba/pouch/blob/master/apis/server/container_bridge.go#L56 will work.

```
	config := &types.ExecCreateConfig{}
	// decode request body
	if err := json.NewDecoder(req.Body).Decode(config); err != nil {
		return httputils.NewHTTPError(err, http.StatusBadRequest)
	}
	// validate request body
	if err := config.Validate(strfmt.NewFormats()); err != nil {
		return httputils.NewHTTPError(err, http.StatusBadRequest)
	}
```

**2.Does this pull request fix one issue?** 
none, this is related to issue https://github.com/alibaba/pouch/issues/443.

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
We need to add test cases according to this PR in API `POST /containers/{id}/exec` test.
/cc @Letty5411 


**5.Special notes for reviews**


