### PR TITLE
fix: unify indent in hack/build script

### DIFF
--- a/hack/build
+++ b/hack/build
@@ -19,13 +19,13 @@ function pre()
 
     git submodule update --init
 
-	mkdir -p $BUILDPATH/src/github.com/docker
-	[ -L $BUILDPATH/src/github.com/docker/libnetwork ] && rm -f $BUILDPATH/src/github.com/docker/libnetwork
-	ln -s $DIR/extra/libnetwork $BUILDPATH/src/github.com/docker/libnetwork
+    mkdir -p $BUILDPATH/src/github.com/docker
+    [ -L $BUILDPATH/src/github.com/docker/libnetwork ] && rm -f $BUILDPATH/src/github.com/docker/libnetwork
+    ln -s $DIR/extra/libnetwork $BUILDPATH/src/github.com/docker/libnetwork
 
-	mkdir -p $BUILDPATH/src/github.com/alibaba
-	[ -L $BUILDPATH/src/github.com/alibaba/pouch ] && rm -f $BUILDPATH/src/github.com/alibaba/pouch
-	ln -s $DIR $BUILDPATH/src/github.com/alibaba/pouch
+    mkdir -p $BUILDPATH/src/github.com/alibaba
+    [ -L $BUILDPATH/src/github.com/alibaba/pouch ] && rm -f $BUILDPATH/src/github.com/alibaba/pouch
+    ln -s $DIR $BUILDPATH/src/github.com/alibaba/pouch
 }
 
 function server()
@@ -53,13 +53,13 @@ function unit-test()
 {
     cd $BUILDPATH/src/github.com/alibaba/pouch
     for d in `go list ./... | grep -v 'github.com/alibaba/pouch/test' | grep -v 'github.com/alibaba/pouch/extra'`
-	do
-		go test -coverprofile=profile.out -covermode=atomic $d
-		if [ -f profile.out ] ; then
-			cat profile.out >> coverage.txt
-			rm profile.out >/dev/null 2>&1
-		fi
-	done
+    do
+        go test -coverprofile=profile.out -covermode=atomic $d
+        if [ -f profile.out ] ; then
+            cat profile.out >> coverage.txt
+            rm profile.out >/dev/null 2>&1
+        fi
+    done
 }
 
 function clean()
@@ -71,15 +71,15 @@ function clean()
 
 function main ()
 {
-	if [[ $# < 1 ]]; then
-		targets="pre"
-	else
-		targets=($@)
-	fi
+    if [[ $# < 1 ]]; then
+        targets="pre"
+    else
+        targets=($@)
+    fi
 
-	for target in ${targets[@]}; do
-		$target
-	done
+    for target in ${targets[@]}; do
+        $target
+    done
 }
 
 main "$@"


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

Unify indent in hack/build script

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

**3.Describe how you did it**

Use 4-space as indent instead of tab

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
Maybe we can unify shell indent standard in pouch project.

ping @allencloud  


