### PR TITLE
fix: hostconfig and networkconfig can be nil

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -121,6 +121,14 @@ func (s *Server) createContainer(ctx context.Context, rw http.ResponseWriter, re
 
 	name := req.FormValue("name")
 
+	// to do compensation to potential nil pointer after validation
+	if config.HostConfig == nil {
+		config.HostConfig = &types.HostConfig{}
+	}
+	if config.NetworkingConfig == nil {
+		config.NetworkingConfig = &types.NetworkingConfig{}
+	}
+
 	container, err := s.ContainerMgr.Create(ctx, name, config)
 	if err != nil {
 		return err

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -247,7 +247,10 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, confi
 func (mgr *ContainerManager) Create(ctx context.Context, name string, config *types.ContainerCreateConfig) (*types.ContainerCreateResp, error) {
 	// TODO: check request validate.
 	if config.HostConfig == nil {
-		return nil, fmt.Errorf("host config and network config can not be nil")
+		return nil, fmt.Errorf("HostConfig cannot be nil")
+	}
+	if config.NetworkingConfig == nil {
+		return nil, fmt.Errorf("NetworkingConfig cannot be nil")
 	}
 
 	id, err := mgr.generateID()

--- a/test/api_container_create_test.go
+++ b/test/api_container_create_test.go
@@ -123,27 +123,6 @@ func (suite *APIContainerCreateSuite) TestBadParam(c *check.C) {
 	// 2. Invalid Parameters
 }
 
-// TestHostConfigNil tests using bad parameter return 500.
-func (suite *APIContainerCreateSuite) TestHostConfigNil(c *check.C) {
-	cname := "TestHostConfigNil"
-	q := url.Values{}
-	q.Add("name", cname)
-	query := request.WithQuery(q)
-
-	// HostConfig is nil.
-	obj := map[string]interface{}{
-		"Image":      busyboxImage,
-		"HostConfig": nil,
-	}
-
-	body := request.WithJSONBody(obj)
-
-	resp, err := request.Post("/containers/create", query, body)
-	c.Assert(err, check.IsNil)
-
-	CheckRespStatus(c, resp, 500)
-}
-
 // TestAllocateTTY tests allocating tty is OK.
 func (suite *APIContainerCreateSuite) TestAllocateTTY(c *check.C) {
 	cname := "TestAllocateTTY"


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>


**1.Describe what this PR did**

HostConfig and NetworkConfig both can be nil in client's side's request, and this should be compatible with moby's API. 

While in Daemon side, when creating with ContainerCreateConfig, function Create does not allow they to be nil, then we should do some compasation in bridge layer to meet the daemon's requirement.

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
/cc @rudyfly 


