### PR TITLE
fix: make network create body compatible with Moby

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1681,12 +1681,12 @@ definitions:
   NetworkCreateConfig:
     type: "object"
     description: "contains the request for the remote API: POST /networks/create"
-    properties:
-      Name:
-        description: "Name is the name of the network."
-        type: "string"
-      NetworkCreate:
-        $ref: "#/definitions/NetworkCreate"
+    allOf:
+      - properties:
+          Name:
+            description: "Name is the name of the network."
+            type: "string"
+      - $ref: "#/definitions/NetworkCreate"
 
   NetworkCreateResp:
     type: "object"

--- a/apis/types/network_create_config.go
+++ b/apis/types/network_create_config.go
@@ -20,45 +20,66 @@ type NetworkCreateConfig struct {
 	// Name is the name of the network.
 	Name string `json:"Name,omitempty"`
 
-	// network create
-	NetworkCreate *NetworkCreate `json:"NetworkCreate,omitempty"`
+	NetworkCreate
 }
 
-/* polymorph NetworkCreateConfig Name false */
+// UnmarshalJSON unmarshals this object from a JSON structure
+func (m *NetworkCreateConfig) UnmarshalJSON(raw []byte) error {
 
-/* polymorph NetworkCreateConfig NetworkCreate false */
+	var data struct {
+		Name string `json:"Name,omitempty"`
+	}
+	if err := swag.ReadJSON(raw, &data); err != nil {
+		return err
+	}
+
+	m.Name = data.Name
+
+	var aO1 NetworkCreate
+	if err := swag.ReadJSON(raw, &aO1); err != nil {
+		return err
+	}
+	m.NetworkCreate = aO1
+
+	return nil
+}
+
+// MarshalJSON marshals this object to a JSON structure
+func (m NetworkCreateConfig) MarshalJSON() ([]byte, error) {
+	var _parts [][]byte
+
+	var data struct {
+		Name string `json:"Name,omitempty"`
+	}
+
+	data.Name = m.Name
+
+	jsonData, err := swag.WriteJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	_parts = append(_parts, jsonData)
+
+	aO1, err := swag.WriteJSON(m.NetworkCreate)
+	if err != nil {
+		return nil, err
+	}
+	_parts = append(_parts, aO1)
+
+	return swag.ConcatJSON(_parts...), nil
+}
 
 // Validate validates this network create config
 func (m *NetworkCreateConfig) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateNetworkCreate(formats); err != nil {
-		// prop
+	if err := m.NetworkCreate.Validate(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *NetworkCreateConfig) validateNetworkCreate(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.NetworkCreate) { // not required
-		return nil
-	}
-
-	if m.NetworkCreate != nil {
-
-		if err := m.NetworkCreate.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("NetworkCreate")
-			}
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/cli/network.go
+++ b/cli/network.go
@@ -100,7 +100,7 @@ func (n *NetworkCreateCommand) runNetworkCreate(args []string) error {
 	if n.driver == "" {
 		return fmt.Errorf("network driver cannot be empty")
 	}
-	networkCreate := &types.NetworkCreate{
+	networkCreate := types.NetworkCreate{
 		Driver: n.driver,
 	}
 

--- a/network/bridge/bridge.go
+++ b/network/bridge/bridge.go
@@ -42,7 +42,7 @@ func New(ctx context.Context, config network.BridgeConfig, manager mgr.NetworkMg
 		Config: []*types.IPAMConfig{ipamV4Conf},
 	}
 
-	networkCreate := &types.NetworkCreate{
+	networkCreate := types.NetworkCreate{
 		Driver:     "bridge",
 		EnableIPV6: false,
 		Options: map[string]string{


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**
Moby has a networkCreate config with:
```
// NetworkCreateRequest is the request message sent to the server for network create call.
type NetworkCreateRequest struct {
	NetworkCreate
	Name string
}
```

While Pouch has : 
```
type NetworkCreateConfig struct {

	// Name is the name of the network.
	Name string `json:"Name,omitempty"`

	// network create
	NetworkCreate *NetworkCreate `json:"NetworkCreate,omitempty"`
}
```

This PR fixes this.

**2.Does this pull request fix one issue?** 
fix #460 

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
/cc @rudyfly 


