### PR TITLE
fix: make network response return json

### DIFF
--- a/apis/server/network_bridge.go
+++ b/apis/server/network_bridge.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-func (s *Server) createNetwork(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
+func (s *Server) createNetwork(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	config := &types.NetworkCreateConfig{}
 	// decode request body
 	if err := json.NewDecoder(req.Body).Decode(config); err != nil {
@@ -24,7 +24,6 @@ func (s *Server) createNetwork(ctx context.Context, resp http.ResponseWriter, re
 
 	network, err := s.NetworkMgr.NetworkCreate(ctx, *config)
 	if err != nil {
-		resp.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
 
@@ -32,10 +31,9 @@ func (s *Server) createNetwork(ctx context.Context, resp http.ResponseWriter, re
 		ID: network.ID,
 	}
 
-	resp.WriteHeader(http.StatusCreated)
-	return json.NewEncoder(resp).Encode(networkCreateResp)
+	return EncodeResponse(rw, http.StatusCreated, networkCreateResp)
 }
 
-func (s *Server) deleteNetwork(ctx context.Context, resp http.ResponseWriter, req *http.Request) error {
+func (s *Server) deleteNetwork(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**
In pouch's bridge layer, we should always return a Content-Type of json. While current code in network_bridge.go `json.NewEncoder(resp).Encode(networkCreateResp)` will not automatically return json, see https://github.com/alibaba/pouch/pull/379.

**2.Does this pull request fix one issue?** 
fixes #431 

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


