### PR TITLE
fix: polish ContainerConfig in swagger.yml

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -810,11 +810,14 @@ definitions:
   ContainerConfig:
     type: "object"
     description: "Configuration for a container that is portable between hosts"
-    required: [Image]
+    required: 
+      - Image
     properties:
       Hostname:
         description: "The hostname to use for the container, as a valid RFC 1123 hostname."
         type: "string"
+        format: hostname
+        minLength: 1
       Domainname:
         description: "The domain name to use for the container."
         type: "string"
@@ -824,14 +827,16 @@ definitions:
       AttachStdin:
         description: "Whether to attach to `stdin`."
         type: "boolean"
-        default: false
+        x-nullable: false
       AttachStdout:
         description: "Whether to attach to `stdout`."
         type: "boolean"
+        x-nullable: false
         default: true
       AttachStderr:
         description: "Whether to attach to `stderr`."
         type: "boolean"
+        x-nullable: false
         default: true
       ExposedPorts:
         description: "An object mapping ports to an empty object in the form:`{<port>/<tcp|udp>: {}}`"
@@ -844,15 +849,15 @@ definitions:
       Tty:
         description: "Attach standard streams to a TTY, including `stdin` if it is not closed."
         type: "boolean"
-        default: false
+        x-nullable: false
       OpenStdin:
         description: "Open `stdin`"
         type: "boolean"
-        default: false
+        x-nullable: false
       StdinOnce:
         description: "Close `stdin` after one attached client disconnects"
         type: "boolean"
-        default: false
+        x-nullable: false
       Env:
         description: |
           A list of environment variables to set inside the container in the form `["VAR=value", ...]`. A variable without `=` is removed from the environment, rather than to have an empty value.
@@ -867,6 +872,7 @@ definitions:
       ArgsEscaped:
         description: "Command is already escaped (Windows only)"
         type: "boolean"
+        x-nullable: false
       Image:
         description: "The name of the image to use when creating the container"
         type: "string"
@@ -874,12 +880,11 @@ definitions:
       Volumes:
         description: "An object mapping mount point paths inside the container to empty objects."
         type: "object"
-        properties:
-          additionalProperties:
-            type: "object"
-            enum:
-              - {}
-            default: {}
+        additionalProperties:
+          type: "object"
+          enum:
+            - {}
+          default: {}
       WorkingDir:
         description: "The working directory for commands to run in."
         type: "string"
@@ -910,6 +915,7 @@ definitions:
         description: "Signal to stop a container as a string or unsigned integer."
         type: "string"
         default: "SIGTERM"
+        x-nullable: false
       StopTimeout:
         description: "Timeout to stop a container in seconds."
         type: "integer"
@@ -1628,8 +1634,10 @@ definitions:
     type: "object"
     properties:
       Detach:
+        description: ExecStart will first check if it's detached
         type: "boolean"
       Tty:
+        description: Check if there's a tty
         type: "boolean"
     example:
       Detach: false
@@ -1745,7 +1753,8 @@ definitions:
   Status:
     description: The status of the container. For example, "running" or "exited".
     type: "string"
-    enum: ["created", "running", "stopped","paused", "restarting", "removing", "exited", "dead"]
+    enum: ["created", "running", "stopped", "paused", "restarting", "removing", "exited", "dead"]
+
   GraphDriverData:
     description: "Information about a container's graph driver."
     type: "object"

--- a/apis/types/container_config.go
+++ b/apis/types/container_config.go
@@ -24,13 +24,13 @@ type ContainerConfig struct {
 	ArgsEscaped bool `json:"ArgsEscaped,omitempty"`
 
 	// Whether to attach to `stderr`.
-	AttachStderr *bool `json:"AttachStderr,omitempty"`
+	AttachStderr bool `json:"AttachStderr,omitempty"`
 
 	// Whether to attach to `stdin`.
-	AttachStdin *bool `json:"AttachStdin,omitempty"`
+	AttachStdin bool `json:"AttachStdin,omitempty"`
 
 	// Whether to attach to `stdout`.
-	AttachStdout *bool `json:"AttachStdout,omitempty"`
+	AttachStdout bool `json:"AttachStdout,omitempty"`
 
 	// Command to run specified an array of strings.
 	Cmd []string `json:"Cmd"`
@@ -51,7 +51,8 @@ type ContainerConfig struct {
 	ExposedPorts map[string]interface{} `json:"ExposedPorts,omitempty"`
 
 	// The hostname to use for the container, as a valid RFC 1123 hostname.
-	Hostname string `json:"Hostname,omitempty"`
+	// Min Length: 1
+	Hostname strfmt.Hostname `json:"Hostname,omitempty"`
 
 	// The name of the image to use when creating the container
 	// Required: true
@@ -70,28 +71,28 @@ type ContainerConfig struct {
 	OnBuild []string `json:"OnBuild"`
 
 	// Open `stdin`
-	OpenStdin *bool `json:"OpenStdin,omitempty"`
+	OpenStdin bool `json:"OpenStdin,omitempty"`
 
 	// Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell.
 	Shell []string `json:"Shell"`
 
 	// Close `stdin` after one attached client disconnects
-	StdinOnce *bool `json:"StdinOnce,omitempty"`
+	StdinOnce bool `json:"StdinOnce,omitempty"`
 
 	// Signal to stop a container as a string or unsigned integer.
-	StopSignal *string `json:"StopSignal,omitempty"`
+	StopSignal string `json:"StopSignal,omitempty"`
 
 	// Timeout to stop a container in seconds.
 	StopTimeout *int64 `json:"StopTimeout,omitempty"`
 
 	// Attach standard streams to a TTY, including `stdin` if it is not closed.
-	Tty *bool `json:"Tty,omitempty"`
+	Tty bool `json:"Tty,omitempty"`
 
 	// The user that commands are run as inside the container.
 	User string `json:"User,omitempty"`
 
-	// volumes
-	Volumes *ContainerConfigVolumes `json:"Volumes,omitempty"`
+	// An object mapping mount point paths inside the container to empty objects.
+	Volumes map[string]interface{} `json:"Volumes,omitempty"`
 
 	// The working directory for commands to run in.
 	WorkingDir string `json:"WorkingDir,omitempty"`
@@ -165,6 +166,11 @@ func (m *ContainerConfig) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateExposedPorts(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateHostname(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -262,6 +268,23 @@ func (m *ContainerConfig) validateExposedPorts(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *ContainerConfig) validateHostname(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Hostname) { // not required
+		return nil
+	}
+
+	if err := validate.MinLength("Hostname", "body", string(m.Hostname), 1); err != nil {
+		return err
+	}
+
+	if err := validate.FormatOf("Hostname", "body", "hostname", m.Hostname.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *ContainerConfig) validateImage(formats strfmt.Registry) error {
 
 	if err := validate.RequiredString("Image", "body", string(m.Image)); err != nil {
@@ -289,20 +312,41 @@ func (m *ContainerConfig) validateShell(formats strfmt.Registry) error {
 	return nil
 }
 
+// additional properties value enum
+var containerConfigVolumesValueEnum []interface{}
+
+func init() {
+	var res []interface{}
+	if err := json.Unmarshal([]byte(`[{}]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		containerConfigVolumesValueEnum = append(containerConfigVolumesValueEnum, v)
+	}
+}
+func (m *ContainerConfig) validateVolumesValueEnum(path, location string, value interface{}) error {
+	if err := validate.Enum(path, location, value, containerConfigVolumesValueEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *ContainerConfig) validateVolumes(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Volumes) { // not required
 		return nil
 	}
 
-	if m.Volumes != nil {
+	if swag.IsZero(m.Volumes) { // not required
+		return nil
+	}
 
-		if err := m.Volumes.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("Volumes")
-			}
-			return err
+	for k := range m.Volumes {
+
+		if swag.IsZero(m.Volumes[k]) { // not required
+			continue
 		}
+
 	}
 
 	return nil
@@ -319,79 +363,6 @@ func (m *ContainerConfig) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *ContainerConfig) UnmarshalBinary(b []byte) error {
 	var res ContainerConfig
-	if err := swag.ReadJSON(b, &res); err != nil {
-		return err
-	}
-	*m = res
-	return nil
-}
-
-// ContainerConfigVolumes An object mapping mount point paths inside the container to empty objects.
-// swagger:model ContainerConfigVolumes
-
-type ContainerConfigVolumes struct {
-
-	// additional properties
-	AdditionalProperties interface{} `json:"additionalProperties,omitempty"`
-}
-
-/* polymorph ContainerConfigVolumes additionalProperties false */
-
-// Validate validates this container config volumes
-func (m *ContainerConfigVolumes) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateAdditionalProperties(formats); err != nil {
-		// prop
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-var containerConfigVolumesTypeAdditionalPropertiesPropEnum []interface{}
-
-func init() {
-	var res []interface{}
-	if err := json.Unmarshal([]byte(`[{}]`), &res); err != nil {
-		panic(err)
-	}
-	for _, v := range res {
-		containerConfigVolumesTypeAdditionalPropertiesPropEnum = append(containerConfigVolumesTypeAdditionalPropertiesPropEnum, v)
-	}
-}
-
-// prop value enum
-func (m *ContainerConfigVolumes) validateAdditionalPropertiesEnum(path, location string, value interface{}) error {
-	if err := validate.Enum(path, location, value, containerConfigVolumesTypeAdditionalPropertiesPropEnum); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (m *ContainerConfigVolumes) validateAdditionalProperties(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.AdditionalProperties) { // not required
-		return nil
-	}
-
-	return nil
-}
-
-// MarshalBinary interface implementation
-func (m *ContainerConfigVolumes) MarshalBinary() ([]byte, error) {
-	if m == nil {
-		return nil, nil
-	}
-	return swag.WriteJSON(m)
-}
-
-// UnmarshalBinary interface implementation
-func (m *ContainerConfigVolumes) UnmarshalBinary(b []byte) error {
-	var res ContainerConfigVolumes
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/apis/types/exec_start_config.go
+++ b/apis/types/exec_start_config.go
@@ -17,10 +17,10 @@ import (
 
 type ExecStartConfig struct {
 
-	// detach
+	// ExecStart will first check if it's detached
 	Detach bool `json:"Detach,omitempty"`
 
-	// tty
+	// Check if there's a tty
 	Tty bool `json:"Tty,omitempty"`
 }
 

--- a/cli/container.go
+++ b/cli/container.go
@@ -17,7 +17,7 @@ func (c *container) config() *types.ContainerCreateConfig {
 	}
 
 	// TODO
-	config.Tty = &c.tty
+	config.Tty = c.tty
 
 	// set bind volume
 	if c.volume != nil {

--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -7,6 +7,7 @@ import (
 	apitypes "github.com/alibaba/pouch/apis/types"
 
 	// NOTE: "golang.org/x/net/context" is compatible with standard "context" in golang1.7+.
+	"github.com/go-openapi/strfmt"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
@@ -89,7 +90,7 @@ func (c *CriManager) makeSandboxPouchConfig(config *runtime.PodSandboxConfig, im
 	hc := &apitypes.HostConfig{}
 	createConfig := &apitypes.ContainerCreateConfig{
 		ContainerConfig: apitypes.ContainerConfig{
-			Hostname: config.Hostname,
+			Hostname: strfmt.Hostname(config.Hostname),
 			Image:    image,
 			Labels:   labels,
 		},

--- a/daemon/mgr/spec_network.go
+++ b/daemon/mgr/spec_network.go
@@ -7,7 +7,7 @@ import (
 )
 
 func setupNetwork(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
-	s.Hostname = c.Config.Hostname
+	s.Hostname = c.Config.Hostname.String()
 	//TODO setup network parameters
 	return nil
 }

--- a/daemon/mgr/spec_process.go
+++ b/daemon/mgr/spec_process.go
@@ -45,13 +45,11 @@ func setupProcessCwd(ctx context.Context, c *ContainerMeta, s *specs.Spec) error
 }
 
 func setupProcessTTY(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
-	if c.Config.Tty != nil {
-		s.Process.Terminal = *c.Config.Tty
-		if s.Process.Env != nil {
-			s.Process.Env = append(s.Process.Env, "TERM=xterm")
-		} else {
-			s.Process.Env = []string{"TERM=xterm"}
-		}
+	s.Process.Terminal = c.Config.Tty
+	if s.Process.Env != nil {
+		s.Process.Env = append(s.Process.Env, "TERM=xterm")
+	} else {
+		s.Process.Env = []string{"TERM=xterm"}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

Original swagger.yml in Moby's repo has incompatibility with its API, mainly on API structs like ContainerConfig.

This pr makes API structs swagger.yml generated compatible with Moby's API:

* `AttachStdout`, `AttachStderr `, `AttachStdin`, `StdinOnce `, `OpenStdin`, `ArgsEscaped`, `StopSignal ` and `tty` should not be a pointer

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


