### PR TITLE
test: print pouch deamon log when it fails to launch the daemon

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -65,6 +65,8 @@ function target()
 				break
 			elif (( $((daemon_timeout_time--)) == 0 ));then
 				echo "Failed to start pouch daemon"
+				echo "pouch daemon log:"
+				cat $TMP/log 
 				return 1
 			else
 				sleep 1


### PR DESCRIPTION
Signed-off-by: letty.ll <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Print daemon log when pouchd failed to be launched.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


