### PR TITLE
feature: implement RemoveImage and ImageStatus methods for cri manager

### DIFF
--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -290,7 +290,18 @@ func (c *CriManager) ListImages(ctx context.Context, r *runtime.ListImagesReques
 
 // ImageStatus returns the status of the image, returns nil if the image isn't present.
 func (c *CriManager) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
-	return nil, fmt.Errorf("ImageStatus Not Implemented Yet")
+	imageRef := r.GetImage().GetImage()
+	imageInfo, err := c.ImageMgr.GetImage(ctx, imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	image, err := imageToCriImage(imageInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return &runtime.ImageStatusResponse{Image: image}, nil
 }
 
 // PullImage pulls an image with authentication config.
@@ -317,7 +328,18 @@ func (c *CriManager) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 
 // RemoveImage removes the image.
 func (c *CriManager) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
-	return nil, fmt.Errorf("RemoveImage Not Implemented Yet")
+	imageRef := r.GetImage().GetImage()
+	imageInfo, err := c.ImageMgr.GetImage(ctx, imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.ImageMgr.RemoveImage(ctx, imageInfo, &ImageRemoveOption{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &runtime.RemoveImageResponse{}, nil
 }
 
 // ImageFsInfo returns information of the filesystem that is used to store images.


### PR DESCRIPTION
Signed-off-by: zeppp <zeppp1995@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
implement RemoveImage and ImageStatus methods for cri manager
**2.Does this pull request fix one issue?** 
fixes part of #420

**3.Describe how you did it**

**4.Describe how to verify it**
Use [cri-tools](https://github.com/kubernetes-incubator/cri-tools) to check.
```
→ # crictl images
IMAGE                       TAG                 IMAGE ID            SIZE
docker.io/library/busybox   latest              bbc3a03235220       720kB

→ # crictl rmi docker.io/library/busybox 
FATA[0000] image status request failed: rpc error: code = Unknown desc = image: docker.io/library/busybox: not found 

→ # crictl rmi docker.io/library/busybox:latest
Deleted: docker.io/library/busybox:latest

→ # crictl images
IMAGE               TAG                 IMAGE ID            SIZE

→ # crictl inspecti docker.io/library/busybox:latest
{
  "status": {
    "id": "sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0",
    "repoTags": [
      "docker.io/library/busybox:latest"
    ],
    "repoDigests": [
      "docker.io/library/busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0"
    ],
    "size": "2699",
    "username": ""
  }
}


```
**5.Special notes for reviews**



  