### PR TITLE
fix: correct one reference format in swagger.yml

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1387,7 +1387,7 @@ definitions:
         type: "array"
         description: "Set of mount point in a container."
         items:
-          $ref: "#definitions/MountPoint"
+          $ref: "#/definitions/MountPoint"
       NetworkSettings:
         additionalProperties:
           $ref: "#/definitions/EndpointSettings"
@@ -1728,7 +1728,7 @@ definitions:
         type: "array"
         description: "Set of mount point in a container."
         items:
-          $ref: "#definitions/MountPoint"
+          $ref: "#/definitions/MountPoint"
       NetworkSettings:
         description: "NetworkSettings exposes the network settings in the API."
         $ref: "#/definitions/NetworkSettings"
@@ -1801,6 +1801,7 @@ definitions:
   MountPoint:
     type: "object"
     description: "A mount point inside a container"
+    x-nullable: false
     properties:
       Type:
         type: "string"

--- a/apis/types/container.go
+++ b/apis/types/container.go
@@ -127,10 +127,6 @@ func (m *Container) validateMounts(formats strfmt.Registry) error {
 		return nil
 	}
 
-	for i := 0; i < len(m.Mounts); i++ {
-
-	}
-
 	return nil
 }
 

--- a/apis/types/container_json.go
+++ b/apis/types/container_json.go
@@ -233,10 +233,6 @@ func (m *ContainerJSON) validateMounts(formats strfmt.Registry) error {
 		return nil
 	}
 
-	for i := 0; i < len(m.Mounts); i++ {
-
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**
fix: correct one reference format in swagger.yml

Otherwise, the CI would report a warning message:

```
2018/01/03 10:38:50 - WARNING: definition "#/definitions/MountPoint" is not used anywhere
```

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


