### PR TITLE
feature: add Volume Inspect API in daemon side

### DIFF
--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -47,6 +47,7 @@ func initRoute(s *Server) http.Handler {
 
 	// volume
 	r.Path("/volumes/create").Methods(http.MethodPost).Handler(s.filter(s.createVolume))
+	r.Path("/volumes/{name:.*}").Methods(http.MethodGet).Handler(s.filter(s.getVolume))
 	r.Path("/volumes/{name:.*}").Methods(http.MethodDelete).Handler(s.filter(s.removeVolume))
 
 	// metrics

--- a/apis/server/volume_bridge.go
+++ b/apis/server/volume_bridge.go
@@ -49,6 +49,15 @@ func (s *Server) createVolume(ctx context.Context, rw http.ResponseWriter, req *
 	return EncodeResponse(rw, http.StatusCreated, volume)
 }
 
+func (s *Server) getVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
+	name := mux.Vars(req)["name"]
+	volume, err := s.VolumeMgr.Get(ctx, name)
+	if err != nil {
+		return err
+	}
+	return EncodeResponse(rw, http.StatusOK, volume)
+}
+
 func (s *Server) removeVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
 	name := mux.Vars(req)["name"]
 

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -710,6 +710,38 @@ paths:
             $ref: "#/definitions/VolumeCreateConfig"
       tags: ["Volume"]
 
+  /volumes/{id}:
+    get:
+      summary: "Inspect a volume"
+      operationId: "VolumeInspect"
+      produces: ["application/json"]
+      responses:
+        200:
+          description: "No error"
+          schema:
+            $ref: "#/definitions/VolumeInfo"
+        404:
+          $ref: "#/responses/404ErrorResponse"
+        500:
+          $ref: "#/responses/500ErrorResponse"
+      parameters:
+        - $ref: "#/parameters/id"
+      tags: ["Volume"]
+
+    delete: 
+      summary: "Delete a volume"
+      operationId: "VolumeDelete"
+      responses:
+        204:
+          description: "No error"
+        404:
+          $ref: "#/responses/404ErrorResponse"
+        500:
+          $ref: "#/responses/500ErrorResponse"
+      parameters:
+        - $ref: "#/parameters/id"
+      tags: ["Volume"]
+
   /networks/create:
     post:
       summary: "Create a network"

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -688,7 +688,7 @@ func (mgr *ContainerManager) parseVolumes(ctx context.Context, c *types.Containe
 			source = randomid.Generate()
 		}
 		if !path.IsAbs(source) {
-			_, err := mgr.VolumeMgr.Info(ctx, source)
+			_, err := mgr.VolumeMgr.Get(ctx, source)
 			if err != nil {
 				opts := map[string]string{
 					"backend": "local",

--- a/daemon/mgr/volume.go
+++ b/daemon/mgr/volume.go
@@ -22,8 +22,8 @@ type VolumeMgr interface {
 	// List returns all volumes on this host.
 	List(ctx context.Context, labels map[string]string) ([]string, error)
 
-	// Info returns the information of volume that specified name/id.
-	Info(ctx context.Context, name string) (*types.Volume, error)
+	// Get returns the information of volume that specified name/id.
+	Get(ctx context.Context, name string) (*types.Volume, error)
 
 	// Path returns the mount path of volume.
 	Path(ctx context.Context, name string) (string, error)
@@ -109,8 +109,8 @@ func (vm *VolumeManager) List(ctx context.Context, labels map[string]string) ([]
 	return vm.core.ListVolumeName(labels)
 }
 
-// Info returns the information of volume that specified name/id.
-func (vm *VolumeManager) Info(ctx context.Context, name string) (*types.Volume, error) {
+// Get returns the information of volume that specified name/id.
+func (vm *VolumeManager) Get(ctx context.Context, name string) (*types.Volume, error) {
 	id := types.VolumeID{
 		Name: name,
 	}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

This PR adds two API endpoints in swagger.yml:

* GET /volumes/{id}
* DELETE /volumes/{id}

And the second API implementation has been done in code base.

This PR also adds `GET /volumes/{id}` in the daemon side. 

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


