### PR TITLE
feature: pouch run in terminal default connects to container's stdout

### DIFF
--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -34,11 +34,23 @@ func (suite *PouchRunSuite) TearDownTest(c *check.C) {
 func (suite *PouchRunSuite) TestRun(c *check.C) {
 	name := "test-run"
 
-	_ = command.PouchRun("run", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "--name", name, busyboxImage).Assert(c, icmd.Success)
 
 	res := command.PouchRun("ps").Assert(c, icmd.Success)
 	if out := res.Combined(); !strings.Contains(out, name) {
 		c.Fatalf("unexpected output %s: should contains container %s\n", out, name)
+	}
+}
+
+// TestRunPrintHi is to verify run container with executing a command.
+func (suite *PouchRunSuite) TestRunPrintHi(c *check.C) {
+	name := "test-run-print-hi"
+
+	res := command.PouchRun("run", "--name", name, busyboxImage, "echo", "hi")
+	res.Assert(c, icmd.Success)
+
+	if out := res.Combined(); !strings.Contains(out, "hi") {
+		c.Fatalf("upexpected output %s expected hi\n", out)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: HusterWan <zirenwan@gmail.com>

**1.Describe what this PR did**
As the title says

**2.Does this pull request fix one issue?** 

fixes https://github.com/alibaba/pouch/issues/491

**3.Describe how you did it**

**4.Describe how to verify it**
```
[root@docker-registry github.com]# pouch run -e aaa=bbb registry.hub.docker.com/library/busybox:latest env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
aaa=bbb
TERM=xterm
HOME=/root
```

```
[root@docker-registry github.com]# pouch run -d -e aaa=bbb registry.hub.docker.com/library/busybox:latest env
90719b5f9a455b3314a49e72e3ecb9962f215e0f90153aa8911882acf2ba2c84
```

**5.Special notes for reviews**



  
  