### PR TITLE
feature: ipc, pid, uts namespace mode of container

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -31,6 +31,9 @@ type container struct {
 	devices          []string
 	enableLxcfs      bool
 	restartPolicy    string
+	ipcMode          string
+	pidMode          string
+	utsMode          string
 }
 
 func (c *container) config() (*types.ContainerCreateConfig, error) {
@@ -87,6 +90,9 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 			},
 			EnableLxcfs:   c.enableLxcfs,
 			RestartPolicy: restartPolicy,
+			IpcMode:       c.ipcMode,
+			PidMode:       c.pidMode,
+			UTSMode:       c.utsMode,
 		},
 	}
 

--- a/cli/create.go
+++ b/cli/create.go
@@ -58,6 +58,9 @@ func (cc *CreateCommand) addFlags() {
 	flagSet.StringSliceVarP(&cc.devices, "device", "", nil, "Add a host device to the container")
 	flagSet.BoolVar(&cc.enableLxcfs, "enableLxcfs", false, "Enable lxcfs")
 	flagSet.StringVar(&cc.restartPolicy, "restart", "", "Restart policy to apply when container exits")
+	flagSet.StringVar(&cc.ipcMode, "ipc", "", "IPC namespace to use")
+	flagSet.StringVar(&cc.pidMode, "pid", "", "PID namespace to use")
+	flagSet.StringVar(&cc.utsMode, "uts", "", "UTS namespace to use")
 }
 
 // runCreate is the entry of create command.

--- a/cli/run.go
+++ b/cli/run.go
@@ -67,6 +67,9 @@ func (rc *RunCommand) addFlags() {
 	flagSet.StringSliceVarP(&rc.devices, "device", "", nil, "Add a host device to the container")
 	flagSet.BoolVar(&rc.enableLxcfs, "enableLxcfs", false, "Enable lxcfs")
 	flagSet.StringVar(&rc.restartPolicy, "restart", "", "Restart policy to apply when container exits")
+	flagSet.StringVar(&rc.ipcMode, "ipc", "", "IPC namespace to use")
+	flagSet.StringVar(&rc.pidMode, "pid", "", "PID namespace to use")
+	flagSet.StringVar(&rc.utsMode, "uts", "", "UTS namespace to use")
 }
 
 // runRun is the entry of run command.

--- a/daemon/mgr/spec_namespace.go
+++ b/daemon/mgr/spec_namespace.go
@@ -2,9 +2,85 @@ package mgr
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
+
+// isEmpty indicates whether namespace mode is empty.
+func isEmpty(mode string) bool {
+	return mode == ""
+}
+
+// isNone indicates whether container's namespace mode is set to "none".
+func isNone(mode string) bool {
+	return mode == "none"
+}
+
+// isHost indicates whether the container shares the host's corresponding namespace.
+func isHost(mode string) bool {
+	return mode == "host"
+}
+
+// isShareable indicates whether the containers namespace can be shared with another container.
+func isShareable(mode string) bool {
+	return mode == "shareable"
+}
+
+// isContainer indicates whether the container uses another container's corresponding namespace.
+func isContainer(mode string) bool {
+	parts := strings.SplitN(mode, ":", 2)
+	return len(parts) > 1 && parts[0] == "container"
+}
+
+// isPrivate indicates whether the container uses its own namespace.
+func isPrivate(ns specs.LinuxNamespaceType, mode string) bool {
+	switch ns {
+	case specs.IPCNamespace:
+		return mode == "private"
+	case specs.NetworkNamespace, specs.PIDNamespace:
+		return !(isHost(mode) || isContainer(mode))
+	case specs.UserNamespace, specs.UTSNamespace:
+		return !(isHost(mode))
+	}
+	return false
+}
+
+// connectedContainer is the id or name of the container whose namespace this container share with.
+func connectedContainer(mode string) string {
+	parts := strings.SplitN(mode, ":", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return ""
+}
+
+func getIpcContainer(ctx context.Context, mgr ContainerMgr, id string) (*ContainerMeta, error) {
+	// Check whether the container exists.
+	c, err := mgr.Get(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("can't join IPC namespace of container %q: %v", id, err)
+	}
+
+	// TODO: check whether the container is running and not restarting.
+
+	// TODO: check whether the container's ipc namespace is shareable.
+
+	return c, nil
+}
+
+func getPidContainer(ctx context.Context, mgr ContainerMgr, id string) (*ContainerMeta, error) {
+	// Check the container exists.
+	c, err := mgr.Get(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("can't join PID namespace of %q: %v", id, err)
+	}
+
+	// TODO: check whether the container is running and not restarting.
+
+	return c, nil
+}
 
 // TODO
 func setupUserNamespace(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) error {
@@ -17,27 +93,57 @@ func setupNetworkNamespace(ctx context.Context, meta *ContainerMeta, spec *SpecW
 }
 
 func setupIpcNamespace(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) error {
-	s := spec.s
-	ns := specs.LinuxNamespace{Type: specs.IPCNamespace}
-	setNamespace(s, ns)
+	ipcMode := meta.HostConfig.IpcMode
+	switch {
+	case isContainer(ipcMode):
+		ns := specs.LinuxNamespace{Type: specs.IPCNamespace}
+		c, err := getIpcContainer(ctx, spec.ctrMgr, connectedContainer(ipcMode))
+		if err != nil {
+			return fmt.Errorf("setup container ipc namespace mode failed: %v", err)
+		}
+		ns.Path = fmt.Sprintf("/proc/%d/ns/ipc", c.State.Pid)
+		setNamespace(spec.s, ns)
+	case isHost(ipcMode):
+		removeNamespace(spec.s, specs.IPCNamespace)
+	default:
+		ns := specs.LinuxNamespace{Type: specs.IPCNamespace}
+		setNamespace(spec.s, ns)
+	}
 	return nil
 }
 
 func setupPidNamespace(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) error {
-	s := spec.s
-	ns := specs.LinuxNamespace{Type: specs.PIDNamespace}
-	setNamespace(s, ns)
+	pidMode := meta.HostConfig.PidMode
+	switch {
+	case isContainer(pidMode):
+		ns := specs.LinuxNamespace{Type: specs.PIDNamespace}
+		c, err := getPidContainer(ctx, spec.ctrMgr, connectedContainer(pidMode))
+		if err != nil {
+			return fmt.Errorf("setup container pid namespace mode failed: %v", err)
+		}
+		ns.Path = fmt.Sprintf("/proc/%d/ns/pid", c.State.Pid)
+		setNamespace(spec.s, ns)
+	case isHost(pidMode):
+		removeNamespace(spec.s, specs.PIDNamespace)
+	default:
+		ns := specs.LinuxNamespace{Type: specs.PIDNamespace}
+		setNamespace(spec.s, ns)
+	}
 	return nil
 }
 
 func setupUtsNamespace(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) error {
-	s := spec.s
-	ns := specs.LinuxNamespace{Type: specs.UTSNamespace}
-	setNamespace(s, ns)
-
-	// set hostname
-	if hostname := meta.Config.Hostname.String(); hostname != "" {
-		s.Hostname = hostname
+	utsMode := meta.HostConfig.UTSMode
+	switch {
+	case isHost(utsMode):
+		removeNamespace(spec.s, specs.UTSNamespace)
+	default:
+		ns := specs.LinuxNamespace{Type: specs.UTSNamespace}
+		setNamespace(spec.s, ns)
+		// set hostname
+		if hostname := meta.Config.Hostname.String(); hostname != "" {
+			spec.s.Hostname = hostname
+		}
 	}
 	return nil
 }
@@ -50,4 +156,13 @@ func setNamespace(s *specs.Spec, ns specs.LinuxNamespace) {
 		}
 	}
 	s.Linux.Namespaces = append(s.Linux.Namespaces, ns)
+}
+
+func removeNamespace(s *specs.Spec, nsType specs.LinuxNamespaceType) {
+	for i, n := range s.Linux.Namespaces {
+		if n.Type == nsType {
+			s.Linux.Namespaces = append(s.Linux.Namespaces[:i], s.Linux.Namespaces[i+1:]...)
+			return
+		}
+	}
 }

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -196,3 +196,29 @@ func (suite *PouchRunSuite) TestRunRestartPolicyNone(c *check.C) {
 		c.Fatalf("expect container %s to be exited: %s\n", name, out)
 	}
 }
+
+// TestRunWithIPCMode is to verify --specific IPC mode when running a container.
+// TODO: test container ipc namespace mode.
+func (suite *PouchRunSuite) TestRunWithIPCMode(c *check.C) {
+	name := "test-run-with-ipc-mode"
+
+	res := command.PouchRun("run", "--name", name, "--ipc", "host", busyboxImage)
+	res.Assert(c, icmd.Success)
+}
+
+// TestRunWithPIDMode is to verify --specific PID mode when running a container.
+// TODO: test container pid namespace mode.
+func (suite *PouchRunSuite) TestRunWithPIDMode(c *check.C) {
+	name := "test-run-with-pid-mode"
+
+	res := command.PouchRun("run", "--name", name, "--pid", "host", busyboxImage)
+	res.Assert(c, icmd.Success)
+}
+
+// TestRunWithUTSMode is to verify --specific UTS mode when running a container.
+func (suite *PouchRunSuite) TestRunWithUTSMode(c *check.C) {
+	name := "test-run-with-uts-mode"
+
+	res := command.PouchRun("run", "--name", name, "--uts", "host", busyboxImage)
+	res.Assert(c, icmd.Success)
+}


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
With this PR, we could specify uts, ipc and pid namespace mode of `pouch create` and `pouch run`

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**
In terminal one: 
```
[root@pouch-test pouch]# pouch run -it docker.io/library/ubuntu:14.04 bash
root@pouch-test:/# ipcmk -Q
Message queue id: 0
root@pouch-test:/# ipcs -q

------ Message Queues --------
key        msqid      owner      perms      used-bytes   messages    
0x50b336a0 0          root       644        0            0           

root@pouch-test:/# top
```

In terminal two: run a container to share the pid & ipc namespace of container created above.
```
[root@pouch-test monster]# pouch run -it --pid="container:b7d6eb" --ipc="container:b7d6eb" docker.io/library/ubuntu:14.04 bash
root@pouch-test:/# ps
  PID TTY          TIME CMD
    1 pts/0    00:00:00 bash
   18 pts/0    00:00:00 top
   19 pts/0    00:00:00 bash
   33 pts/0    00:00:00 ps
root@pouch-test:/# ipcs -q

------ Message Queues --------
key        msqid      owner      perms      used-bytes   messages    
0x50b336a0 0          root       644        0            0           

root@pouch-test:/# ps
  PID TTY          TIME CMD
    1 pts/0    00:00:00 bash
   19 pts/0    00:00:00 bash
   35 pts/0    00:00:00 ps
```

**5.Special notes for reviews**


