### PR TITLE
fix: make Container struct compatible with Moby

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/daemon/mgr"
 	"github.com/alibaba/pouch/pkg/httputils"
+	"github.com/alibaba/pouch/pkg/utils"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/gorilla/mux"
@@ -225,13 +227,14 @@ func (s *Server) getContainers(ctx context.Context, rw http.ResponseWriter, req 
 
 	containerList := make([]types.Container, 0, len(metas))
 	for _, m := range metas {
+		t, _ := time.Parse(utils.TimeLayout, m.Created)
 		container := types.Container{
 			ID:         m.ID,
 			Names:      []string{m.Name},
 			Status:     string(m.State.Status),
 			Image:      m.Config.Image,
 			Command:    strings.Join(m.Config.Cmd, " "),
-			Created:    m.State.StartedAt,
+			Created:    t.UnixNano(),
 			Labels:     m.Config.Labels,
 			HostConfig: m.HostConfig,
 		}

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1427,8 +1427,9 @@ definitions:
       Command:
         type: "string"
       Created:
-        description: "Created time of container in daemon. !! Incompatibility !! Moby has a type of int64."
-        type: "string"
+        description: "Created time of container in daemon."
+        type: "integer"
+        format: "int64"
       SizeRw:
         type: "integer"
         format: "int64"
@@ -1458,9 +1459,12 @@ definitions:
         items:
           $ref: "#/definitions/MountPoint"
       NetworkSettings:
-        additionalProperties:
-          $ref: "#/definitions/EndpointSettings"
-          x-nullable: true
+        type: "object"
+        properties:
+          Networks:
+            additionalProperties:
+              $ref: "#/definitions/EndpointSettings"
+              x-nullable: true
 
 
   NetworkingConfig:

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -89,7 +89,7 @@ func (c containerList) Swap(i, j int) {
 
 // Less implements the sort interface.
 func (c containerList) Less(i, j int) bool {
-	ivalue, _ := time.Parse(utils.TimeLayout, c[i].Created)
-	jvalue, _ := time.Parse(utils.TimeLayout, c[j].Created)
+	ivalue := time.Unix(0, c[i].Created)
+	jvalue := time.Unix(0, c[j].Created)
 	return ivalue.After(jvalue)
 }

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -295,14 +295,14 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 
 	meta := &ContainerMeta{
 		State: &types.ContainerState{
-			StartedAt: time.Now().UTC().Format(utils.TimeLayout),
-			Status:    types.StatusCreated,
+			Status: types.StatusCreated,
 		},
 		ID:         id,
 		Image:      image.Name,
 		Name:       name,
 		Config:     &config.ContainerConfig,
 		HostConfig: config.HostConfig,
+		Created:    time.Now().UTC().Format(utils.TimeLayout),
 	}
 
 	// merge image's config into container's meta

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -51,8 +51,8 @@ func FormatSize(size int64) string {
 }
 
 // FormatCreatedTime is used to show the time from creation to now.
-func FormatCreatedTime(created string) (formattedTime string, err error) {
-	start, err := time.Parse(TimeLayout, created)
+func FormatCreatedTime(created int64) (formattedTime string, err error) {
+	start := time.Unix(0, created)
 	if err != nil {
 		return "", errInvalid
 	}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

We have discussed before, that in `GET /containers/json` API, there is incompatibility. `Created` field in response of `GET /containers/json`in Moby is a type of int64, so we need to transfer original string into int64. Otherwise, incompatibility existence may bring obstacles when people change moby to pouch.

**2.Does this pull request fix one issue?** 
None

**3.Describe how you did it**
None

**4.Describe how to verify it**
None

**5.Special notes for reviews**

/cc @zeppp Since API changed, I updated a func you added. And now unit test may fails.



  