### PR TITLE
fix: add complete ContainerState in Container Inspect

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -253,7 +253,7 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 		Name:    meta.Name,
 		Image:   meta.Config.Image,
 		Created: meta.State.StartedAt,
-		State:   &types.ContainerState{Pid: meta.State.Pid},
+		State:   meta.State,
 		Config:  meta.Config,
 	}
 	return EncodeResponse(rw, http.StatusOK, container)


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

In the latest master, we found that `GET /containers/{id}/json` has incomplete container state in response body, since we have not returned all data via API.

This PR fixes the bug, tries to return the whole container state in daemon side.

**2.Does this pull request fix one issue?** 

NONE

**3.Describe how you did it**

NONE

**4.Describe how to verify it**

NONE

**5.Special notes for reviews**

NONE


