### PR TITLE
bugfix: exec should return 200 if client doesn't upgrade proto

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -83,6 +83,7 @@ func (s *Server) startContainerExec(ctx context.Context, rw http.ResponseWriter,
 	}
 
 	name := mux.Vars(req)["name"]
+	_, upgrade := req.Header["Upgrade"]
 
 	var attach *mgr.AttachConfig
 
@@ -97,7 +98,7 @@ func (s *Server) startContainerExec(ctx context.Context, rw http.ResponseWriter,
 			Stdin:   config.Tty,
 			Stdout:  true,
 			Stderr:  true,
-			Upgrade: true,
+			Upgrade: upgrade,
 		}
 	}
 

--- a/test/utils.go
+++ b/test/utils.go
@@ -199,25 +199,15 @@ func CreateExecEchoOk(c *check.C, cname string) string {
 	return got.ID
 }
 
-// StartContainerExecOk starts executing a process in the container and asserts success.
-func StartContainerExecOk(c *check.C, execid string, tty bool, detach bool) {
-	resp, conn, _, err := StartContainerExec(c, execid, tty, detach)
-	c.Assert(err, check.IsNil)
-
-	// TODO: fix to use 200
-	CheckRespStatus(c, resp, 101)
-	defer conn.Close()
-}
-
 // StartContainerExec starts executing a process in the container.
 func StartContainerExec(c *check.C, execid string, tty bool, detach bool) (*http.Response, net.Conn, *bufio.Reader, error) {
-
 	obj := map[string]interface{}{
 		"Detach": detach,
 		"Tty":    tty,
 	}
-	body := request.WithJSONBody(obj)
 
-	resp, conn, reader, err := request.Hijack("/exec/"+execid+"/start", body, request.WithHeader("Content-Type", "text/plain"))
-	return resp, conn, reader, err
+	return request.Hijack("/exec/"+execid+"/start",
+		request.WithHeader("Connection", "Upgrade"),
+		request.WithHeader("Upgrade", "tcp"),
+		request.WithJSONBody(obj))
 }


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

If user calls `/exec/execid/start` without upgrade header, the pouchd should return 200 status.
But now, the pouchd always return 101 switch protocol. This PR is to fix this bug.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #494 

**3.Describe how you did it**

For the AttachConfig, the `Upgrade` field should check header from request.

**4.Describe how to verify it**

I have added the test for this.

**5.Special notes for reviews**

In this PR, I upgrades the `request.Hijack` function and add more comments here: 

For hijack request, the server can return 200 status or 101 switch proto. 

If http-client doesn't switch proto, the `Do` function will return error caused by `ErrPersistEOF`.

As the RFC 2616, section 4.4 mentioned,  if there is no Content-Length or chunked Transfer-Encoding on a *Response and the status is not 1xx, 204 or 304, then the body is unbounded. And the response is always terminated by the first empty line after the header fields.

In our case, the 200 response is like:

```
HTTP/1.1 200 OK
Content-Type: application/vnd.docker.raw-stream
<= first empty line
[raw-data]
```

The golang http client does follow the RFC 2616. More detail is here:
- https://github.com/golang/go/blob/release-branch.go1.9/src/net/http/response.go#L190
- https://github.com/golang/go/blob/release-branch.go1.9/src/net/http/transfer.go#L486:L518

For this case, both status and header has been read into response. And the [raw-data] will be read from hijack.reader. So we can ignore the `ErrPersistEOF` here.

cc @allencloud  and @Letty5411 
  
  
  