### PR TITLE
feature: implement Status of cri manager

### DIFF
--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -363,7 +363,23 @@ func (c *CriManager) UpdateRuntimeConfig(ctx context.Context, r *runtime.UpdateR
 
 // Status returns the status of the runtime.
 func (c *CriManager) Status(ctx context.Context, r *runtime.StatusRequest) (*runtime.StatusResponse, error) {
-	return nil, fmt.Errorf("Status Not Implemented Yet")
+	runtimeCondition := &runtime.RuntimeCondition{
+		Type:   runtime.RuntimeReady,
+		Status: true,
+	}
+	networkCondition := &runtime.RuntimeCondition{
+		Type:   runtime.NetworkReady,
+		Status: true,
+	}
+
+	// TODO: check network status of CRI when it is ready.
+
+	return &runtime.StatusResponse{
+		Status: &runtime.RuntimeStatus{Conditions: []*runtime.RuntimeCondition{
+			runtimeCondition,
+			networkCondition,
+		}},
+	}, nil
 }
 
 // imageToCriImage converts pouch image API to CRI image API.


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes part of #420 

**3.Describe how you did it**

**4.Describe how to verify it**

Maybe the [cri-tools](https://github.com/kubernetes-incubator/cri-tools) is what you need.

We may use the following method to verify that we can get status of cri manager:
```
[root@pouch-test monster]# crictl info
{
  "status": {
    "conditions": [
      {
        "type": "RuntimeReady",
        "status": true,
        "reason": "",
        "message": ""
      },
      {
        "type": "NetworkReady",
        "status": true,
        "reason": "",
        "message": ""
      }
    ]
  }
}
```

**5.Special notes for reviews**


