### PR TITLE
feature: pouch ps support --quiet flag

### DIFF
--- a/cli/ps.go
+++ b/cli/ps.go
@@ -20,6 +20,7 @@ type containerList []*types.Container
 // PsCommand is used to implement 'ps' command.
 type PsCommand struct {
 	baseCommand
+	flagQuiet bool
 }
 
 // Init initializes PsCommand command.
@@ -40,7 +41,9 @@ func (p *PsCommand) Init(c *Cli) {
 
 // addFlags adds flags for specific command.
 func (p *PsCommand) addFlags() {
-	// TODO: add flags here
+	flagSet := p.cmd.Flags()
+	flagSet.SetInterspersed(false)
+	flagSet.BoolVarP(&p.flagQuiet, "quiet", "q", false, "Only display numeric IDs")
 }
 
 // runPs is the entry of PsCommand command.
@@ -51,6 +54,13 @@ func (p *PsCommand) runPs(args []string) error {
 	containers, err := apiClient.ContainerList()
 	if err != nil {
 		return fmt.Errorf("failed to get container list: %v", err)
+	}
+
+	if p.flagQuiet {
+		for _, c := range containers {
+			fmt.Println(c.ID[:6])
+		}
+		return nil
 	}
 
 	sort.Sort(containers)


### PR DESCRIPTION
Signed-off-by: HusterWan <zirenwan@gmail.com>

**1.Describe what this PR did**
pouch ps support --quiet flag
```
[root@docker-registry github.com]# pouch ps --help | grep quiet
  -q, --quiet   Only display numeric IDs
```

**2.Does this pull request fix one issue?** 

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**
It's useful just print container ID, when i want to delete a batch of containers once.
```
[root@docker-registry github.com]# pouch rm $(pouch ps -q)
442bd2
a6667b
907be3
114b3b
09ee8c
52a165
83ade9
b37a44
83bb48
bda9ea
``` 

