### PR TITLE
test: add cri test for pouch

### DIFF
--- a/hack/cri-test/test-cri.sh
+++ b/hack/cri-test/test-cri.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+
+source $(dirname "${BASH_SOURCE[0]}")/test-utils.sh
+
+POUCH_SOCK="/var/run/pouchcri.sock"
+
+# CRI_FOCUS focuses the test to run.
+CRI_FOCUS=${CRI_FOCUS:-""}
+
+# CRI_SKIP skips the test to skip.
+CRI_SKIP=${CRI_SKIP:-""}
+# REPORT_DIR is the the directory to store test logs.
+REPORT_DIR=${REPORT_DIR:-"/tmp/test-cri"}
+
+# Check GOPATH
+if [[ -z "${GOPATH}" ]]; then
+  echo "GOPATH is not set"
+  exit 1
+fi
+
+# For multiple GOPATHs, keep the first one only
+GOPATH=${GOPATH%%:*}
+
+CRITEST=${GOPATH}/bin/critest
+CRITOOL_PKG=github.com/kubernetes-incubator/cri-tools
+
+# Install critest
+if [ ! -x "$(command -v ${CRITEST})" ]; then
+  go get -d ${CRITOOL_PKG}/...
+  cd ${GOPATH}/src/${CRITOOL_PKG}
+  git fetch --all
+  git checkout ${CRITOOL_VERSION}
+  make
+fi
+which ${CRITEST}
+
+mkdir -p ${REPORT_DIR}
+test_setup ${REPORT_DIR}
+
+# Run cri validation test
+sudo env PATH=${PATH} GOPATH=${GOPATH} ${CRITEST} --runtime-endpoint=${POUCH_SOCK} --focus="${CRI_FOCUS}" --ginkgo-flags="--skip=\"${CRI_SKIP}\"" validation
+test_exit_code=$?
+
+test_teardown
+
+exit ${test_exit_code}
+

--- a/hack/cri-test/test-utils.sh
+++ b/hack/cri-test/test-utils.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. ${ROOT}/versions
+# POUCH_FLAGS are the extra flags to use when start pouchd.
+POUCH_FLAGS=${POUCH_FLAGS:-""}
+# RESTART_WAIT_PERIOD is the period to wait before restarting pouchd/containerd.
+RESTART_WAIT_PERIOD=${RESTART_WAIT_PERIOD:-10}
+
+POUCH_SOCK=/var/run/pouchcri.sock
+
+pouch_pid=
+containerd_pid=
+
+# test_setup starts containerd and pouchd.
+test_setup() {
+  local report_dir=$1 
+
+  # Start containerd
+  if [ ! -x "$(command -v containerd)" ]; then
+    echo "containerd is not installed, please run hack/make.sh"
+    exit 1
+  fi
+  containerd_pid_command=`pgrep containerd`
+  containerd_pid=${containerd_pid_command}
+  if [ ! -n "${containerd_pid}" ]; then
+    keepalive "/usr/local/bin/containerd" ${RESTART_WAIT_PERIOD} &> ${report_dir}/containerd.log &
+    containerd_pid=$!
+  fi
+  # Wait for containerd to be running by using the containerd client ctr to check the version
+  # of the containerd server. Wait an increasing amount of time after each of five attempts
+  readiness_check "ctr version"
+
+  # Start pouchd
+  pouch_pid_command=`pgrep pouchd`
+  pouch_pid=${pouch_pid_command}
+  if [ ! -n "${pouch_pid}" ]; then
+    keepalive "pouchd ${POUCH_FLAGS}" \
+	  ${RESTART_WAIT_PERIOD} &> ${report_dir}/pouch.log &
+    pouch_pid=$!
+  fi
+  readiness_check "pouch version"
+}
+
+# test_teardown kills containerd and cri-containerd.
+test_teardown() {
+  if [ -n "${containerd_pid}" ]; then
+    kill ${containerd_pid}
+  fi
+  if [ -n "${pouch_pid}" ]; then
+    kill ${pouch_pid}
+  fi
+  sudo pkill containerd
+}
+
+# keepalive runs a command and keeps it alive.
+# keepalive process is eventually killed in test_teardown.
+keepalive() {
+  local command=$1
+  echo ${command}
+  local wait_period=$2
+  while true; do
+    ${command}
+    sleep ${wait_period}
+  done
+}
+
+# readiness_check checks readiness of a daemon with specified command.
+readiness_check() {
+  local command=$1
+  local MAX_ATTEMPTS=5
+  local attempt_num=1
+  until ${command} &> /dev/null || (( attempt_num == MAX_ATTEMPTS ))
+  do
+      echo "$attempt_num attempt \"$command\"! Trying again in $attempt_num seconds..."
+      sleep $(( attempt_num++ ))
+  done
+}
+

--- a/hack/cri-test/versions
+++ b/hack/cri-test/versions
@@ -1,0 +1,2 @@
+CRITOOL_VERSION=v1.0.0-alpha.0
+


### PR DESCRIPTION
Signed-off-by:  czm4514 <1141685075@qq.com>
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
this PR is to add cri test for pouch.
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**
i use the cri-tools project to add cri test for pouch. there are lots of test cases in the project.   
**4.Describe how to verify it**
when you run the test-cri.sh ,
``./test-cri.sh``
you could get the information like this(the variable focus is set to "Runtime"):
```
/root/gocodes/bin/critest
1 attempt "ctr version"! Trying again in 1 seconds...
2 attempt "ctr version"! Trying again in 2 seconds...
3 attempt "ctr version"! Trying again in 3 seconds...
4 attempt "ctr version"! Trying again in 4 seconds...
Running Suite: E2ECRI Suite
===========================
Random Seed: 1515481734 - Will randomize all specs
Will run 2 of 55 specs

SSSSSSSSSSSSSSSS
------------------------------
[k8s.io] Runtime info runtime should support returning runtime info
  runtime should return runtime conditions [Conformance]
  /root/gocodes/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/runtime_info.go:48
[BeforeEach] [k8s.io] Runtime info
  /root/gocodes/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:50
[BeforeEach] [k8s.io] Runtime info
  /root/gocodes/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/runtime_info.go:39
[It] runtime should return runtime conditions [Conformance]
  /root/gocodes/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/runtime_info.go:48
STEP: test runtime status
[AfterEach] [k8s.io] Runtime info
  /root/gocodes/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:51
•SSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[k8s.io] Runtime info runtime should support returning runtime info
  runtime should return version info [Conformance]
  /root/gocodes/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/runtime_info.go:43
[BeforeEach] [k8s.io] Runtime info
  /root/gocodes/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:50
[BeforeEach] [k8s.io] Runtime info
  /root/gocodes/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/runtime_info.go:39
[It] runtime should return version info [Conformance]
  /root/gocodes/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/runtime_info.go:43
Jan  9 15:08:54.098: INFO: Get version info succeed
[AfterEach] [k8s.io] Runtime info
  /root/gocodes/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:51
•SSSSSSSSSSSSSS
Ran 2 of 55 Specs in 0.004 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 53 Skipped PASS

Ginkgo ran 1 suite in 85.546375ms
Test Suite Passed
./test-utils.sh: line 54: 13560 Terminated              keepalive "containerd" ${RESTART_WAIT_PERIOD} &>${report_dir}/containerd.log
./test-utils.sh: line 54: 13694 Terminated              keepalive "pouchd ${POUCH_FLAGS}" ${RESTART_WAIT_PERIOD} &>${report_dir}/pouch.log
```
**5.Special notes for reviews**
when you want to run Specified test case ，you can through the param "--focus" to filter. you can get mor informations from https://github.com/kubernetes-incubator/cri-tools. you can use the cri-tools through the command:  critest -f "image status|public image" validation 


  