### PR TITLE
feature: add lxcfs flag to cli

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -28,6 +28,7 @@ type container struct {
 	memorySwap       string
 	memorySwappiness int64
 	devices          []string
+	enableLxcfs      bool
 }
 
 func (c *container) config() (*types.ContainerCreateConfig, error) {
@@ -105,6 +106,8 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 		deviceMappings = append(deviceMappings, deviceMapping)
 	}
 	config.HostConfig.Devices = deviceMappings
+
+	config.EnableLxcfs = c.enableLxcfs
 
 	return config, nil
 }

--- a/cli/create.go
+++ b/cli/create.go
@@ -56,6 +56,7 @@ func (cc *CreateCommand) addFlags() {
 	flagSet.StringVarP(&cc.memory, "memory", "m", "", "Container memory limit")
 	flagSet.StringVar(&cc.memorySwap, "memory-swap", "", "Container swap limit")
 	flagSet.StringSliceVarP(&cc.devices, "device", "", nil, "Add a host device to the container")
+	flagSet.BoolVar(&cc.enableLxcfs, "enableLxcfs", false, "Enable lxcfs")
 }
 
 // runCreate is the entry of create command.

--- a/cli/run.go
+++ b/cli/run.go
@@ -65,6 +65,7 @@ func (rc *RunCommand) addFlags() {
 	flagSet.StringVarP(&rc.memory, "memory", "m", "", "Container memory limit")
 	flagSet.StringVar(&rc.memorySwap, "memory-swap", "", "Container swap limit")
 	flagSet.StringSliceVarP(&rc.devices, "device", "", nil, "Add a host device to the container")
+	flagSet.BoolVar(&rc.enableLxcfs, "enableLxcfs", false, "Enable lxcfs")
 }
 
 // runRun is the entry of run command.

--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -118,3 +118,23 @@ func (suite *PouchCreateSuite) TestCreateWithLabels(c *check.C) {
 		c.Errorf("failed to set label: %s", label)
 	}
 }
+
+// TestCreateEnableLxcfs tries to test create a container with lxcfs.
+func (suite *PouchCreateSuite) TestCreateEnableLxcfs(c *check.C) {
+	name := "create-lxcfs"
+
+	res := command.PouchRun("create", "--name", name, "--enableLxcfs=true", busyboxImage)
+	res.Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", name).Stdout()
+
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result.Config.EnableLxcfs, check.NotNil)
+
+	if result.Config.EnableLxcfs != true {
+		c.Errorf("failed to set EnableLxcfs")
+	}
+}

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -151,3 +151,15 @@ func (suite *PouchRunSuite) TestRunInWrongWay(c *check.C) {
 		c.Assert(res.Error, check.NotNil, check.Commentf(tc.name))
 	}
 }
+
+// TestRunEnableLxcfs is to verify run container with lxcfs.
+func (suite *PouchRunSuite) TestRunEnableLxcfs(c *check.C) {
+	name := "test-run-lxcfs"
+
+	res := command.PouchRun("run", "--name", name, "--enableLxcfs=true", busyboxImage, "cat", "/proc/uptime")
+	res.Assert(c, icmd.Success)
+
+	if out := res.Combined(); !strings.Contains(out, " 0.0") {
+		c.Fatalf("upexpected output %s expected %s\n", out, " 0.0")
+	}
+}


### PR DESCRIPTION


<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Add lxcfs flag to cli

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**
1. start pouchd with lxcfs
```
pouchd --enable-lxcfs=true --lxcfs=/usr/bin/lxcfs --lxcfs-home="/var/lib/lxc/lxcfs/"
```
2. pouch create with lxcfs
```
./pouch create --enableLxcfs=true  docker.io/library/busybox:latest cat /proc/uptime
./pouch inspect [container ID]
```
the value of EnableLxcfs should be true.

3. pouch run with lxcfs 
```
pouch run --enableLxcfs=true  docker.io/library/busybox:latest cat /proc/uptime
```
the output should be equal to "0.0 0.0"

**5.Special notes for reviews**



  