### PR TITLE
fix: make exec could get multiple commands

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/alibaba/pouch/apis/types"
@@ -43,6 +42,7 @@ func (e *ExecCommand) Init(c *Cli) {
 // addFlags adds flags for specific command.
 func (e *ExecCommand) addFlags() {
 	flagSet := e.cmd.Flags()
+	flagSet.SetInterspersed(false)
 	flagSet.BoolVarP(&e.Detach, "detach", "d", false, "Run the process in the background")
 	flagSet.BoolVarP(&e.Terminal, "tty", "t", false, "Allocate a tty device")
 	flagSet.BoolVarP(&e.Interactive, "interactive", "i", false, "Open container's STDIN")
@@ -54,10 +54,10 @@ func (e *ExecCommand) runExec(args []string) error {
 
 	// create exec process.
 	id := args[0]
-	command := args[1]
+	command := args[1:]
 
 	createExecConfig := &types.ExecCreateConfig{
-		Cmd:          strings.Fields(command),
+		Cmd:          command,
 		Tty:          e.Terminal || e.Interactive,
 		Detach:       e.Detach,
 		AttachStderr: !e.Detach,

--- a/test/cli_exec_test.go
+++ b/test/cli_exec_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// PouchExecSuite is the test suite fo exec CLI.
+type PouchExecSuite struct{}
+
+func init() {
+	check.Suite(&PouchExecSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each test suite.
+func (suite *PouchExecSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+
+	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
+}
+
+// TearDownTest does cleanup work in the end of each test.
+func (suite *PouchExecSuite) TearDownTest(c *check.C) {
+	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+}
+
+// TestExecCommand is to verify the correctness of execing container with specified command.
+func (suite *PouchExecSuite) TestExecCommand(c *check.C) {
+	name := "exec-normal"
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "sleep", "100000")
+
+	res.Assert(c, icmd.Success)
+
+	res = command.PouchRun("exec", name, "ls")
+	// the result should be like the following:
+	// root@ubuntu:~/# pouch exec bf50a0 ls
+	// bin
+	// dev
+	// etc
+	// home
+	// ...
+	if out := res.Combined(); !strings.Contains(out, "etc") {
+		c.Fatalf("unexpected output %s expected %s\n", out, name)
+	}
+}
+
+// TestExecMultiCommands is to verify the correctness of execing container with specified commands.
+func (suite *PouchExecSuite) TestExecMultiCommands(c *check.C) {
+	name := "exec-normal2"
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "sleep", "100000")
+
+	res.Assert(c, icmd.Success)
+
+	res = command.PouchRun("exec", name, "ls", "/etc")
+	// the result should be like the following:
+	// root@ubuntu:~/# pouch exec bf50a0 ls /etc
+	// group
+	// localtime
+	// passwd
+	// shadow
+	if out := res.Combined(); !strings.Contains(out, "passwd") {
+		c.Fatalf("unexpected output %s expected %s\n", out, name)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

This PR fixed that command args are dealt incorrectly in command `pouch exec`.

What I did:

* fix command dealing for `pouch exec` and keep that dealt by `SetInterspersed`;
* add two test cases for exec command.

**2.Does this pull request fix one issue?** 
fixes https://github.com/alibaba/pouch/issues/537
fixes https://github.com/alibaba/pouch/issues/536
fixes https://github.com/alibaba/pouch/issues/535

**3.Describe how you did it**
Make command executed well in command line.

**4.Describe how to verify it**

```
root@ubuntu:~/go/src/github.com/alibaba/pouch# pouch exec bf50a0 ls
bin
dev
etc
home
proc
root
run
sys
tmp
usr
var
root@ubuntu:~/go/src/github.com/alibaba/pouch# pouch exec bf50a0 ls /home
root@ubuntu:~/go/src/github.com/alibaba/pouch# pouch exec bf50a0 ls /etc
group
localtime
passwd
shadow
```

**5.Special notes for reviews**



  
  