### PR TITLE
fix: make command usage more readable in doc

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -88,6 +88,7 @@ func (c *Cli) AddCommand(parent, child Command) {
 	// make command error not return command usage and error
 	childCmd.SilenceUsage = true
 	childCmd.SilenceErrors = true
+	childCmd.DisableFlagsInUseLine = true
 
 	childCmd.PreRun = func(cmd *cobra.Command, args []string) {
 		c.NewAPIClient()

--- a/cli/create.go
+++ b/cli/create.go
@@ -24,7 +24,7 @@ type CreateCommand struct {
 func (cc *CreateCommand) Init(c *Cli) {
 	cc.cli = c
 	cc.cmd = &cobra.Command{
-		Use:   "create [image]",
+		Use:   "create [OPTIONS] IMAGE [ARG...]",
 		Short: "Create a new container with specified image",
 		Long:  createDescription,
 		Args:  cobra.MinimumNArgs(1),

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -27,7 +27,7 @@ type ExecCommand struct {
 func (e *ExecCommand) Init(c *Cli) {
 	e.cli = c
 	e.cmd = &cobra.Command{
-		Use:   "exec [container]",
+		Use:   "exec [OPTIONS] CONTAINER COMMAND [ARG...]",
 		Short: "Exec a process in a running container",
 		Long:  execDescription,
 		Args:  cobra.MinimumNArgs(2),

--- a/cli/generate_doc.go
+++ b/cli/generate_doc.go
@@ -21,7 +21,7 @@ type GenDocCommand struct {
 func (g *GenDocCommand) Init(c *Cli) {
 	g.cli = c
 	g.cmd = &cobra.Command{
-		Use:   "gen-doc [container]",
+		Use:   "gen-doc",
 		Short: "Generate docs",
 		Long:  genDocDescription,
 		Args:  cobra.NoArgs,

--- a/cli/image_inspect.go
+++ b/cli/image_inspect.go
@@ -21,7 +21,7 @@ type ImageInspectCommand struct {
 func (i *ImageInspectCommand) Init(c *Cli) {
 	i.cli = c
 	i.cmd = &cobra.Command{
-		Use:   "inspect image",
+		Use:   "inspect [OPTIONS] IMAGE",
 		Short: "Display detailed information on one image",
 		Long:  imageInspectDescription,
 		Args:  cobra.ExactArgs(1),

--- a/cli/image_list.go
+++ b/cli/image_list.go
@@ -32,7 +32,7 @@ type ImagesCommand struct {
 func (i *ImagesCommand) Init(c *Cli) {
 	i.cli = c
 	i.cmd = &cobra.Command{
-		Use:   "images",
+		Use:   "images [OPTIONS]",
 		Short: "List all images",
 		Long:  imagesDescription,
 		Args:  cobra.NoArgs,

--- a/cli/inspect.go
+++ b/cli/inspect.go
@@ -19,7 +19,7 @@ type InspectCommand struct {
 func (p *InspectCommand) Init(c *Cli) {
 	p.cli = c
 	p.cmd = &cobra.Command{
-		Use:   "inspect [container]",
+		Use:   "inspect CONTAINER",
 		Short: "Get the detailed information of container",
 		Long:  inspectDescription,
 		Args:  cobra.ExactArgs(1),

--- a/cli/network.go
+++ b/cli/network.go
@@ -56,14 +56,14 @@ func (n *NetworkCreateCommand) Init(c *Cli) {
 	n.cli = c
 
 	n.cmd = &cobra.Command{
-		Use:   "create [name]",
+		Use:   "create [OPTIONS] [NAME]",
 		Short: "Create a pouch network",
 		Long:  networkCreateDescription,
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return n.runNetworkCreate(args)
 		},
 		Example: networkCreateExample(),
-		Args:    cobra.MaximumNArgs(1),
 	}
 
 	n.addFlags()

--- a/cli/pause.go
+++ b/cli/pause.go
@@ -21,7 +21,7 @@ type PauseCommand struct {
 func (p *PauseCommand) Init(c *Cli) {
 	p.cli = c
 	p.cmd = &cobra.Command{
-		Use:   "pause [container]",
+		Use:   "pause CONTAINER",
 		Short: "Pause a running container",
 		Long:  pauseDescription,
 		Args:  cobra.ExactArgs(1),

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -30,7 +30,7 @@ type PsCommand struct {
 func (p *PsCommand) Init(c *Cli) {
 	p.cli = c
 	p.cmd = &cobra.Command{
-		Use:   "ps",
+		Use:   "ps [OPTIONS]",
 		Short: "List containers",
 		Long:  psDescription,
 		Args:  cobra.NoArgs,

--- a/cli/pull.go
+++ b/cli/pull.go
@@ -32,7 +32,7 @@ func (p *PullCommand) Init(c *Cli) {
 	p.cli = c
 
 	p.cmd = &cobra.Command{
-		Use:   "pull [image]",
+		Use:   "pull IMAGE",
 		Short: "Pull an image from registry",
 		Long:  pullDescription,
 		Args:  cobra.MinimumNArgs(1),

--- a/cli/rename.go
+++ b/cli/rename.go
@@ -19,7 +19,7 @@ func (rc *RenameCommand) Init(c *Cli) {
 	rc.cli = c
 
 	rc.cmd = &cobra.Command{
-		Use:   "rename [container] [newName]",
+		Use:   "rename CONTAINER NEWNAME",
 		Short: "Rename a container with newName",
 		Long:  renameDescription,
 		Args:  cobra.ExactArgs(2),
@@ -36,9 +36,7 @@ func (rc *RenameCommand) runRename(args []string) error {
 	container := args[0]
 	newName := args[1]
 
-	err := apiClient.ContainerRename(container, newName)
-
-	return err
+	return apiClient.ContainerRename(container, newName)
 }
 
 // renameExample shows examples in rename command, and is used in auto-generated cli docs.

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -24,7 +24,7 @@ type RmCommand struct {
 func (r *RmCommand) Init(c *Cli) {
 	r.cli = c
 	r.cmd = &cobra.Command{
-		Use:   "rm container",
+		Use:   "rm [OPTIONS] CONTAINER [CONTAINER...]",
 		Short: "Remove one or more containers",
 		Long:  rmDescription,
 		Args:  cobra.MinimumNArgs(1),

--- a/cli/rmi.go
+++ b/cli/rmi.go
@@ -21,7 +21,7 @@ type RmiCommand struct {
 func (rmi *RmiCommand) Init(c *Cli) {
 	rmi.cli = c
 	rmi.cmd = &cobra.Command{
-		Use:   "rmi image ",
+		Use:   "rmi [OPTIONS] IMAGE [IMAGE...]",
 		Short: "Remove one or more images by reference",
 		Long:  rmiDescription,
 		Args:  cobra.MinimumNArgs(1),

--- a/cli/run.go
+++ b/cli/run.go
@@ -29,7 +29,7 @@ type RunCommand struct {
 func (rc *RunCommand) Init(c *Cli) {
 	rc.cli = c
 	rc.cmd = &cobra.Command{
-		Use:   "run a container",
+		Use:   "run [OPTIONS] IMAGE [ARG...]",
 		Short: "Create a new container and start it",
 		Long:  runDescription,
 		Args:  cobra.MinimumNArgs(1),

--- a/cli/start.go
+++ b/cli/start.go
@@ -27,10 +27,10 @@ type StartCommand struct {
 func (s *StartCommand) Init(c *Cli) {
 	s.cli = c
 	s.cmd = &cobra.Command{
-		Use:   "start [container]",
+		Use:   "start [OPTIONS] CONTAINER",
 		Short: "Start a created or stopped container",
 		Long:  startDescription,
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return s.runStart(args)
 		},

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -22,10 +22,10 @@ type StopCommand struct {
 func (s *StopCommand) Init(c *Cli) {
 	s.cli = c
 	s.cmd = &cobra.Command{
-		Use:   "stop [container]",
+		Use:   "stop [OPTIONS] CONTAINER",
 		Short: "Stop a running container",
 		Long:  stopDescription,
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return s.runStop(args)
 		},

--- a/cli/unpause.go
+++ b/cli/unpause.go
@@ -20,7 +20,7 @@ type UnpauseCommand struct {
 func (p *UnpauseCommand) Init(c *Cli) {
 	p.cli = c
 	p.cmd = &cobra.Command{
-		Use:   "unpause [container]",
+		Use:   "unpause CONTAINER",
 		Short: "Unpause a paused container",
 		Long:  unpauseDescription,
 		Args:  cobra.ExactArgs(1),

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -60,7 +60,7 @@ func (v *VolumeCreateCommand) Init(c *Cli) {
 	v.cli = c
 
 	v.cmd = &cobra.Command{
-		Use:   "create [args]",
+		Use:   "create [OPTIONS]",
 		Short: "Create a volume",
 		Long:  volumeCreateDescription,
 		Args:  cobra.NoArgs,
@@ -164,7 +164,7 @@ type VolumeRemoveCommand struct {
 func (v *VolumeRemoveCommand) Init(c *Cli) {
 	v.cli = c
 	v.cmd = &cobra.Command{
-		Use:     "remove <name>",
+		Use:     "remove VOLUME",
 		Aliases: []string{"rm"},
 		Short:   "Remove volume",
 		Long:    volumeRmDescription,

--- a/docs/commandline/pouch.md
+++ b/docs/commandline/pouch.md
@@ -27,7 +27,7 @@ pouch is a client side tool pouch to interact with daemon side process pouchd. F
 * [pouch inspect](pouch_inspect.md)	 - Get the detailed information of container
 * [pouch network](pouch_network.md)	 - Manage pouch networks
 * [pouch pause](pouch_pause.md)	 - Pause a running container
-* [pouch ps](pouch_ps.md)	 - List all containers
+* [pouch ps](pouch_ps.md)	 - List containers
 * [pouch pull](pouch_pull.md)	 - Pull an image from registry
 * [pouch rename](pouch_rename.md)	 - Rename a container with newName
 * [pouch rm](pouch_rm.md)	 - Remove one or more containers

--- a/docs/commandline/pouch_create.md
+++ b/docs/commandline/pouch_create.md
@@ -7,7 +7,7 @@ Create a new container with specified image
 Create a static container object in Pouchd. When creating, all configuration user input will be stored in memory store of Pouchd. This is useful when you wish to create a container configuration ahead of time so that Pouchd will preserve the resource in advance. The container you created is ready to start when you need it.
 
 ```
-pouch create [image] [flags]
+pouch create [OPTIONS] IMAGE [ARG...]
 ```
 
 ### Examples
@@ -20,11 +20,24 @@ container ID: e1d541722d68dc5d133cca9e7bd8fd9338603e1763096c8e853522b60d11f7b9, 
 ### Options
 
 ```
-  -h, --help             help for create
-      --name string      Specify name of container
-      --runtime string   Specify oci runtime
-  -t, --tty              Allocate a tty device
-  -v, --volume strings   Bind mount volumes to container
+      --cpu-share int          CPU shares
+      --cpuset-cpus string     CPUs in cpuset
+      --cpuset-mems string     MEMs in cpuset
+      --device strings         Add a host device to the container
+      --enableLxcfs            Enable lxcfs
+      --entrypoint string      Overwrite the default entrypoint
+  -e, --env strings            Set environment variables for container
+  -h, --help                   help for create
+      --hostname string        Set container's hostname
+  -l, --label strings          Set label for a container
+  -m, --memory string          Container memory limit
+      --memory-swap string     Container swap limit
+      --memory-wappiness int   Container memory swappiness [0, 100] (default -1)
+      --name string            Specify name of container
+      --runtime string         Specify oci runtime
+  -t, --tty                    Allocate a tty device
+  -v, --volume strings         Bind mount volumes to container
+  -w, --workdir string         Set the working directory in a container
 ```
 
 ### Options inherited from parent commands

--- a/docs/commandline/pouch_exec.md
+++ b/docs/commandline/pouch_exec.md
@@ -7,7 +7,7 @@ Exec a process in a running container
 Exec a process in a running container
 
 ```
-pouch exec [container] [flags]
+pouch exec [OPTIONS] CONTAINER COMMAND [ARG...]
 ```
 
 ### Options

--- a/docs/commandline/pouch_gen-doc.md
+++ b/docs/commandline/pouch_gen-doc.md
@@ -7,7 +7,7 @@ Generate docs
 Generate docs
 
 ```
-pouch gen-doc [container] [flags]
+pouch gen-doc
 ```
 
 ### Options

--- a/docs/commandline/pouch_image_inspect.md
+++ b/docs/commandline/pouch_image_inspect.md
@@ -7,7 +7,7 @@ Display detailed information on one image
 Return detailed information on Pouch image
 
 ```
-pouch image inspect image [flags]
+pouch image inspect [OPTIONS] IMAGE
 ```
 
 ### Examples

--- a/docs/commandline/pouch_images.md
+++ b/docs/commandline/pouch_images.md
@@ -7,13 +7,13 @@ List all images
 List all images in Pouchd.This is useful when you wish to have a look at images and Pouchd will show all local images with their NAME and SIZE.All local images will be shown in a table format you can use.
 
 ```
-pouch images [flags]
+pouch images [OPTIONS]
 ```
 
 ### Examples
 
 ```
-$ pouch images ls
+$ pouch images
 IMAGE ID             IMAGE NAME                                               SIZE
 bbc3a0323522         docker.io/library/busybox:latest                         703.14 KB
 b81f317384d7         docker.io/library/nginx:latest                           42.39 MB

--- a/docs/commandline/pouch_inspect.md
+++ b/docs/commandline/pouch_inspect.md
@@ -7,7 +7,7 @@ Get the detailed information of container
 Return detailed information on Pouch container
 
 ```
-pouch inspect [container] [flags]
+pouch inspect CONTAINER
 ```
 
 ### Examples

--- a/docs/commandline/pouch_network_create.md
+++ b/docs/commandline/pouch_network_create.md
@@ -7,7 +7,7 @@ Create a pouch network
 Create a network in pouchd. It must specify network's name and driver. You can use 'network driver' to get drivers that pouch support.
 
 ```
-pouch network create [name] [flags]
+pouch network create [OPTIONS] [NAME]
 ```
 
 ### Examples

--- a/docs/commandline/pouch_pause.md
+++ b/docs/commandline/pouch_pause.md
@@ -7,7 +7,7 @@ Pause a running container
 Pause a running container object in Pouchd. when pausing, the container will pause its running but hold all the relevant resource.This is useful when you wish to pause a container for a while and to restore the running status later.The container you paused will pause without being terminated.
 
 ```
-pouch pause [container] [flags]
+pouch pause CONTAINER
 ```
 
 ### Examples

--- a/docs/commandline/pouch_ps.md
+++ b/docs/commandline/pouch_ps.md
@@ -1,30 +1,47 @@
 ## pouch ps
 
-List all containers
+List containers
 
 ### Synopsis
 
 
-List Containers with container name, ID, status, image reference, runtime and creation time.
+List Containers with container name, ID, status, creation time, image reference and runtime.
 
 ```
-pouch ps [flags]
+pouch ps [OPTIONS]
 ```
 
 ### Examples
 
 ```
 $ pouch ps
-Name     ID       Status    Image                              Runtime   Created
-1dad17   1dad17   stopped   docker.io/library/busybox:latest   runv      1 hour ago
-505571   505571   stopped   docker.io/library/busybox:latest   runc      1 hour ago
+Name   ID       Status          Created          Image                              Runtime
+2      e42c68   Up 15 minutes   16 minutes ago   docker.io/library/busybox:latest   runc
+1      a8c2ea   Up 16 minutes   17 minutes ago   docker.io/library/busybox:latest   runc
+
+$ pouch ps -a
+Name   ID       Status          Created          Image                              Runtime
+3      faf132   created         16 seconds ago   docker.io/library/busybox:latest   runc
+2      e42c68   Up 16 minutes   16 minutes ago   docker.io/library/busybox:latest   runc
+1      a8c2ea   Up 17 minutes   18 minutes ago   docker.io/library/busybox:latest   runc
+
+$ pouch ps -q
+e42c68
+a8c2ea
+
+$ pouch ps -a -q
+faf132
+e42c68
+a8c2ea
 
 ```
 
 ### Options
 
 ```
-  -h, --help   help for ps
+  -a, --all     Show all containers (default shows just running)
+  -h, --help    help for ps
+  -q, --quiet   Only show numeric IDs
 ```
 
 ### Options inherited from parent commands

--- a/docs/commandline/pouch_pull.md
+++ b/docs/commandline/pouch_pull.md
@@ -7,7 +7,7 @@ Pull an image from registry
 Pull an image or a repository from a registry. Most of your images will be created on top of a base image from the registry. So, you can pull and try prebuilt images contained by registry without needing to define and configure your own.
 
 ```
-pouch pull [image] [flags]
+pouch pull IMAGE
 ```
 
 ### Examples

--- a/docs/commandline/pouch_rename.md
+++ b/docs/commandline/pouch_rename.md
@@ -7,7 +7,7 @@ Rename a container with newName
 Rename a container object in Pouchd. You can change the name of one container identified by its name or ID. The container you renamed is ready to be used by its new name.
 
 ```
-pouch rename [container] [newName] [flags]
+pouch rename CONTAINER NEWNAME
 ```
 
 ### Examples

--- a/docs/commandline/pouch_rm.md
+++ b/docs/commandline/pouch_rm.md
@@ -13,7 +13,7 @@ be released.
 
 
 ```
-pouch rm container [flags]
+pouch rm [OPTIONS] CONTAINER [CONTAINER...]
 ```
 
 ### Examples

--- a/docs/commandline/pouch_rmi.md
+++ b/docs/commandline/pouch_rmi.md
@@ -7,7 +7,7 @@ Remove one or more images by reference
 Remove one or more images by reference.When the image is being used by a container, you must specify -f to delete it.But it is strongly discouraged, because the container will be in abnormal status.
 
 ```
-pouch rmi image  [flags]
+pouch rmi [OPTIONS] IMAGE [IMAGE...]
 ```
 
 ### Examples

--- a/docs/commandline/pouch_run.md
+++ b/docs/commandline/pouch_run.md
@@ -7,36 +7,52 @@ Create a new container and start it
 Create a container object in Pouchd, and start the container. This is useful when you just want to use one command to start a container. 
 
 ```
-pouch run a container [flags]
+pouch run [OPTIONS] IMAGE [ARG...]
 ```
 
 ### Examples
 
 ```
 $ pouch run --name test registry.hub.docker.com/library/busybox:latest echo "hi"
-23f8529fddf7c8bbea70e2c12353e47dbfa5eacda9d58ff8665269614456424b
-$ pouch ps
-Name   ID       Status    Image                                            Runtime   Created
-test   23f852   stopped   registry.hub.docker.com/library/busybox:latest   runc      4 seconds ago
-$ pouch run -i --name test registry.hub.docker.com/library/busybox:latest echo "hi"
 hi
 $ pouch ps
 Name   ID       Status    Image                                            Runtime   Created
-test   883ea9   stopped   registry.hub.docker.com/library/busybox:latest   runc      5 seconds ago
+test   23f852   stopped   registry.hub.docker.com/library/busybox:latest   runc      4 seconds ago
+$ pouch run -d --name test registry.hub.docker.com/library/busybox:latest
+90719b5f9a455b3314a49e72e3ecb9962f215e0f90153aa8911882acf2ba2c84
+$ pouch ps
+Name   ID       Status    Image                                            Runtime   Created
+test   90719b   stopped   registry.hub.docker.com/library/busybox:latest   runc      5 seconds ago
+$ pouch run --device /dev/zero:/dev/testDev:rwm --name test registry.hub.docker.com/library/busybox:latest ls -l /dev/testDev
+crw-rw-rw-    1 root     root        1,   3 Jan  8 09:40 /dev/testnull
 	
 ```
 
 ### Options
 
 ```
-  -a, --attach               Attach container's STDOUT and STDERR
-      --detach-keys string   Override the key sequence for detaching a container
-  -h, --help                 help for run
-  -i, --interactive          Attach container's STDIN
-      --name string          Specify name of container
-      --runtime string       Specify oci runtime
-  -t, --tty                  Allocate a tty device
-  -v, --volume strings       Bind mount volumes to container
+  -a, --attach                 Attach container's STDOUT and STDERR
+      --cpu-share int          CPU shares
+      --cpuset-cpus string     CPUs in cpuset
+      --cpuset-mems string     MEMs in cpuset
+  -d, --detach                 Run container in background and print container ID
+      --detach-keys string     Override the key sequence for detaching a container
+      --device strings         Add a host device to the container
+      --enableLxcfs            Enable lxcfs
+      --entrypoint string      Overwrite the default entrypoint
+  -e, --env strings            Set environment variables for container
+  -h, --help                   help for run
+      --hostname string        Set container's hostname
+  -i, --interactive            Attach container's STDIN
+  -l, --label strings          Set label for a container
+  -m, --memory string          Container memory limit
+      --memory-swap string     Container swap limit
+      --memory-wappiness int   Container memory swappiness [0, 100] (default -1)
+      --name string            Specify name of container
+      --runtime string         Specify oci runtime
+  -t, --tty                    Allocate a tty device
+  -v, --volume strings         Bind mount volumes to container
+  -w, --workdir string         Set the working directory in a container
 ```
 
 ### Options inherited from parent commands

--- a/docs/commandline/pouch_start.md
+++ b/docs/commandline/pouch_start.md
@@ -7,7 +7,7 @@ Start a created or stopped container
 Start a created container object in Pouchd. When starting, the relevant resource preserved during creating period comes into use.This is useful when you wish to start a container which has been created in advance.The container you started will be running if no error occurs.
 
 ```
-pouch start [container] [flags]
+pouch start [OPTIONS] CONTAINER
 ```
 
 ### Examples

--- a/docs/commandline/pouch_stop.md
+++ b/docs/commandline/pouch_stop.md
@@ -7,7 +7,7 @@ Stop a running container
 Stop a running container in Pouchd. Waiting the given number of seconds before forcefully killing the container.This is useful when you wish to stop a container. And Pouchd will stop this running container and release the resource. The container that you stopped will be terminated. 
 
 ```
-pouch stop [container] [flags]
+pouch stop [OPTIONS] CONTAINER
 ```
 
 ### Examples

--- a/docs/commandline/pouch_unpause.md
+++ b/docs/commandline/pouch_unpause.md
@@ -7,7 +7,7 @@ Unpause a paused container
 Unpause a paused container in Pouchd. when unpausing, the paused container will resumes the process execution within the container.The container you unpaused will be running again if no error occurs.
 
 ```
-pouch unpause [container] [flags]
+pouch unpause CONTAINER
 ```
 
 ### Examples

--- a/docs/commandline/pouch_version.md
+++ b/docs/commandline/pouch_version.md
@@ -7,7 +7,7 @@ Print versions about Pouch CLI and Pouchd
 Print versions about Pouch CLI and Pouchd
 
 ```
-pouch version [flags]
+pouch version
 ```
 
 ### Examples

--- a/docs/commandline/pouch_volume_create.md
+++ b/docs/commandline/pouch_volume_create.md
@@ -7,7 +7,7 @@ Create a volume
 Create a volume in pouchd. It must specify volume's name, size and driver. You can use 'volume driver' to get drivers that pouch support.
 
 ```
-pouch volume create [args] [flags]
+pouch volume create [OPTIONS]
 ```
 
 ### Examples

--- a/docs/commandline/pouch_volume_remove.md
+++ b/docs/commandline/pouch_volume_remove.md
@@ -7,7 +7,7 @@ Remove volume
 Remove a volume in pouchd. It need specify volume's name, when the volume is exist and is unuse, it will be remove.
 
 ```
-pouch volume remove <name> [flags]
+pouch volume remove VOLUME
 ```
 
 ### Examples

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -48,7 +48,7 @@ func (suite *PouchStopSuite) TestStopWorks(c *check.C) {
 
 	// test stop container with timeout(*seconds)
 	command.PouchRun("start", name).Assert(c, icmd.Success)
-	command.PouchRun("stop", name, "3").Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "3", name).Assert(c, icmd.Success)
 
 	res = command.PouchRun("ps", "-a")
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
 Issue https://github.com/alibaba/pouch/issues/541 mentioned that in pouch's cli command usage was not so readable. Originally, there are always a `[flags]` at the postfix of the usage sentence, like:
```
Usage:
  pouch create [image] [flags]
```

With this PR, we add a `childCmd.DisableFlagsInUseLine = true` to the command to disable flags in useline. With this, usage shows like:
```
Usage:
  pouch create [OPTIONS] IMAGE [ARG...]
```

**2.Does this pull request fix one issue?** 
fixes https://github.com/alibaba/pouch/issues/541

**3.Describe how you did it**

* add a `childCmd.DisableFlagsInUseLine = true`
* change the usage description of all commands

**4.Describe how to verify it**
```
Usage:
  pouch create [OPTIONS] IMAGE [ARG...]
```

**5.Special notes for reviews**

NONE


