### PR TITLE
feature: implement ListPodSandbox method of cri manager

### DIFF
--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -130,7 +130,30 @@ func (c *CriManager) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 
 // ListPodSandbox returns a list of Sandbox.
 func (c *CriManager) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (*runtime.ListPodSandboxResponse, error) {
-	return nil, fmt.Errorf("ListPodSandbox Not Implemented Yet")
+	opts := &ContainerListOption{All: true}
+	filter := func(c *ContainerMeta) bool {
+		return c.Config.Labels[containerTypeLabelKey] == containerTypeLabelSandbox
+	}
+
+	// Filter *only* (sandbox) containers.
+	sandboxList, err := c.ContainerMgr.List(ctx, filter, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sandbox: %v", err)
+	}
+
+	sandboxes := make([]*runtime.PodSandbox, 0, len(sandboxList))
+	for _, s := range sandboxList {
+		sandbox, err := toCriSandbox(s)
+		if err != nil {
+			// TODO: log an error message?
+			continue
+		}
+		sandboxes = append(sandboxes, sandbox)
+	}
+
+	result := filterCRISandboxes(sandboxes, r.GetFilter())
+
+	return &runtime.ListPodSandboxResponse{Items: result}, nil
 }
 
 // CreateContainer creates a new container in the given PodSandbox.

--- a/daemon/mgr/cri_test.go
+++ b/daemon/mgr/cri_test.go
@@ -66,6 +66,21 @@ func TestSandboxNameRoundTrip(t *testing.T) {
 	assert.Equal(t, config.Metadata, actualMetadata)
 }
 
+func TestToCriSandboxState(t *testing.T) {
+	testCases := []struct {
+		input    apitypes.Status
+		expected runtime.PodSandboxState
+	}{
+		{input: apitypes.StatusRunning, expected: runtime.PodSandboxState_SANDBOX_READY},
+		{input: apitypes.StatusExited, expected: runtime.PodSandboxState_SANDBOX_NOTREADY},
+	}
+
+	for _, test := range testCases {
+		actual := toCriSandboxState(test.input)
+		assert.Equal(t, test.expected, actual)
+	}
+}
+
 // Container related unit tests.
 
 func TestContainerNameRoundTrip(t *testing.T) {
@@ -85,7 +100,7 @@ func TestContainerNameRoundTrip(t *testing.T) {
 	assert.Equal(t, config.Metadata, actualMetadata)
 }
 
-func TestConvertPouchStatusToCriContainerState(t *testing.T) {
+func TestToCriContainerState(t *testing.T) {
 	testCases := []struct {
 		input    apitypes.Status
 		expected runtime.ContainerState


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

fixes part of #420 

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**


Maybe the [cri-tools](https://github.com/kubernetes-incubator/cri-tools) is what you need.

We may use the following method to verify that we can list sandboxes:
```
// Now we must ensure the sandbox image has already exists.
[root@pouch-test cri-tools]# pouch pull k8s.gcr.io/pause-amd64:3.0
[root@pouch-test cri-tools]# cat sandbox-config.json
{
    "metadata": {
        "name": "nginx-sandbox",
        "namespace": "default",
        "attempt": 1,
        "uid": "hdishd83djaidwnduwk28bcsb"
    },
    "linux": {
    }
}
[root@pouch-test cri-tools]# crictl runs sandbox-config.json
008cc69c9c9c8e9c4d78aa8d6c528e21ab26affdc64748f631fb5dcb59963216
[root@pouch-test cri-tools]# crictl sandboxes
SANDBOX ID          CREATED             STATE               NAME                NAMESPACE           ATTEMPT
008cc69c9c9c8       48 years ago        SANDBOX_READY       nginx-sandbox       default             1
```

**5.Special notes for reviews**


