### PR TITLE
refactor: make time format compatible with Moby

### DIFF
--- a/daemon/mgr/container_types_test.go
+++ b/daemon/mgr/container_types_test.go
@@ -64,7 +64,7 @@ func TestContainerMeta_FormatStatus(t *testing.T) {
 		},
 	} {
 		output, err := tc.input.FormatStatus()
-		assert.Equal(t, output, tc.expected)
-		assert.Equal(t, err, tc.err)
+		assert.Equal(t, output, tc.expected, tc.name)
+		assert.Equal(t, err, tc.err, tc.name)
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -10,14 +10,15 @@ import (
 // Common durations that is .
 // There are some definitions for units of Day and larger .
 const (
-	Second     = time.Second
-	Minute     = Second * 60
-	Hour       = Minute * 60
-	Day        = Hour * 24
-	Week       = Day * 7
-	Month      = Day * 30
-	Year       = Day * 365
-	TimeLayout = "2006-01-02 15:04:05"
+	Second = time.Second
+	Minute = Second * 60
+	Hour   = Minute * 60
+	Day    = Hour * 24
+	Week   = Day * 7
+	Month  = Day * 30
+	Year   = Day * 365
+
+	TimeLayout = time.RFC3339Nano
 )
 
 var errInvalid = errors.New("invalid time")


### PR DESCRIPTION
Signed-off-by: zeppp <zeppp1995@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
The time fields such as `Created` and `StartAt` in Moby are both formatted by **RFC3339Nano** which is different from Pouch.
So I change the time format in Pouch to keep consistence with Moby.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**
```
>> # pouch ps
Name   ID       Status          Created          Image                                            Runtime
2      961798   Up 12 minutes   13 minutes ago   registry.hub.docker.com/library/busybox:latest   runc
>> # pouch inspect 2
{
  "Args": null,
  "Config": {
    "Cmd": [
      "sh"
    ],
    "Entrypoint": null,
    "Env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ],
    "Image": "registry.hub.docker.com/library/busybox:latest",
    "OnBuild": null,
    "Shell": null
  },
➡️  "Created": "2018-01-11T06:04:07.189360689Z",
  "HostConfig": {
    "Runtime": "runc",
    "BlkioDeviceReadBps": null,
    "BlkioDeviceReadIOps": null,
    "BlkioDeviceWriteBps": null,
    "BlkioDeviceWriteIOps": null,
    "BlkioWeightDevice": null,
    "DeviceCgroupRules": null,
    "Devices": [],
    "MemorySwappiness": -1,
    "Ulimits": null
  },
  "Id": "961798b0b8fa9b161863ec08eaf020293766a8758805e63c8e3f443c74bb5ee6",
  "Image": "registry.hub.docker.com/library/busybox:latest",
  "Mounts": null,
  "Name": "2",
  "State": {
    "Pid": 5931,
➡️    "StartedAt": "2018-01-11T06:04:26.971241293Z",
    "Status": "running"
  }
}

```
**5.Special notes for reviews**
Please remove old containers before applying this PR.
@allencloud 

