### PR TITLE
fix: support using image ID

### DIFF
--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -21,6 +21,11 @@ type Ref struct {
 
 // String returns reference in string.
 func (r Ref) String() string {
+	// abandon tag if Name is numeric ID
+	if isImageID(r.Name) && r.Tag == defaultTag {
+		return r.Name
+	}
+
 	return fmt.Sprintf("%s:%s", r.Name, r.Tag)
 }
 

--- a/pkg/reference/regexp.go
+++ b/pkg/reference/regexp.go
@@ -65,3 +65,9 @@ func oneOrMore(exp ...*regexp.Regexp) *regexp.Regexp {
 func group(exp ...*regexp.Regexp) *regexp.Regexp {
 	return regexp.MustCompile("(?:" + concat(exp...).String() + ")")
 }
+
+// isImageID returns true if input is a numeric ID of image,otherwise it returns false.
+func isImageID(input string) bool {
+	match, _ := regexp.MatchString("^[0-9a-f]+$", input)
+	return match
+}

--- a/test/cli_rmi_test.go
+++ b/test/cli_rmi_test.go
@@ -62,3 +62,16 @@ func (suite *PouchRmiSuite) TestRmiInWrongWay(c *check.C) {
 		c.Assert(res.Error, check.NotNil, check.Commentf(tc.name))
 	}
 }
+
+// TestRmiWithImageID tests "pouch rmi {ID}" work.
+func (suite *PouchRmiSuite) TestRmiWithImageID(c *check.C) {
+	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
+
+	busyBoxImageID := busyboxImageDigest[:12]
+	command.PouchRun("rmi", busyBoxImageID).Assert(c, icmd.Success)
+
+	res := command.PouchRun("images").Assert(c, icmd.Success)
+	if out := res.Combined(); strings.Contains(out, busyboxImage) {
+		c.Fatalf("unexpected output %s: should rm image %s\n", out, busyboxImage)
+	}
+}

--- a/test/utils.go
+++ b/test/utils.go
@@ -14,8 +14,9 @@ import (
 
 // const defines common image name
 const (
-	busyboxImage    = "registry.hub.docker.com/library/busybox:latest"
-	helloworldImage = "registry.hub.docker.com/library/hello-world"
+	busyboxImage       = "registry.hub.docker.com/library/busybox:latest"
+	busyboxImageDigest = "1b124b4f31609dfdd23563b0f6f37430a85cd485cf8224e09f9cb376b7756347"
+	helloworldImage    = "registry.hub.docker.com/library/hello-world"
 )
 
 // VerifyCondition is used to check the condition value.


### PR DESCRIPTION
Signed-off-by: zeppp <zeppp1995@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Now the daemon side is supported to create container with image's id. But cli is not.
This is due to the ref will add a default flag "latest" when parse it before this PR. 
See  [Parse](https://github.com/zeppp/pouch/blob/a5f3584d804a507f657e6e96471446d8d56c62a7/pkg/reference/reference.go#L33)
Now,if use image ID,it will not add a default tag.
**2.Does this pull request fix one issue?** 
fixes part of #374

**3.Describe how you did it**
if ref is a numeric ID,not add a default flag.
```
// isImageID returns true if input is a numeric ID of image,otherwise it returns false.
func isImageID(input string) bool {
 	match, _ := regexp.MatchString("^[0-9a-f]+$", input)
	return match
}
```

**4.Describe how to verify it**
```
>> # pouch images
IMAGE ID       IMAGE NAME                         SIZE
436bbf48aa11   docker.io/library/busybox:latest   710.47 KB

>> # pouch image inspect 436bbf48aa11
{
  "Digest": "sha256:436bbf48aa1198ebca8eac0ad9a9c80c8929d9242e02608f76ce18334e0cfe6a",
  "ID": "436bbf48aa11",
  "Name": "docker.io/library/busybox:latest",
  "Size": 2699
}

>> # pouch rmi 436bbf48aa11
436bbf48aa11

>> # pouch images
IMAGE ID   IMAGE NAME   SIZE

```
**5.Special notes for reviews**


