### PR TITLE
feature: add network inspect implementation on cli and client side

### DIFF
--- a/apis/server/network_bridge.go
+++ b/apis/server/network_bridge.go
@@ -70,6 +70,7 @@ func buildNetworkInspectResp(n *networktypes.Network) *types.NetworkInspectResp 
 		Internal:   info.Internal(),
 		Options:    info.DriverOptions(),
 		Labels:     info.Labels(),
+		IPAM:       &types.IPAM{},
 	}
 	buildIpamResources(network, info)
 	return network

--- a/cli/network.go
+++ b/cli/network.go
@@ -31,6 +31,7 @@ func (n *NetworkCommand) Init(c *Cli) {
 
 	c.AddCommand(n, &NetworkCreateCommand{})
 	c.AddCommand(n, &NetworkRemoveCommand{})
+	c.AddCommand(n, &NetworkInspectCommand{})
 }
 
 // networkCreateDescription is used to describe network create command in detail and auto generate command doc.
@@ -177,4 +178,63 @@ func (n *NetworkRemoveCommand) runNetworkRemove(args []string) error {
 func networkRemoveExample() string {
 	return `$ pouch network remove pouch-net
 Removed: pouch-net`
+}
+
+// networkInspectDescription is used to describe network inspect command in detail and auto generate command doc.
+var networkInspectDescription = "Inspect a network in pouchd. " +
+	"It must specify network's name."
+
+// NetworkInspectCommand is used to implement 'network inspect' command.
+type NetworkInspectCommand struct {
+	baseCommand
+
+	name string
+}
+
+// Init initializes NetworkInspectCommand command.
+func (n *NetworkInspectCommand) Init(c *Cli) {
+	n.cli = c
+
+	n.cmd = &cobra.Command{
+		Use:   "inspect [OPTIONS] NAME",
+		Short: "Inspect a pouch network",
+		Long:  networkInspectDescription,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return n.runNetworkInspect(args)
+		},
+		Example: networkInspectExample(),
+	}
+
+	n.addFlags()
+}
+
+// addFlags adds flags for specific command.
+func (n *NetworkInspectCommand) addFlags() {
+	//TODO add flags
+}
+
+// runNetworkInspect is the entry of NetworkInspectCommand command.
+func (n *NetworkInspectCommand) runNetworkInspect(args []string) error {
+	name := args[0]
+
+	apiClient := n.cli.Client()
+	resp, err := apiClient.NetworkInspect(name)
+	if err != nil {
+		return err
+	}
+
+	n.cli.Print(resp)
+	return nil
+}
+
+// networkInspectExample shows examples in network inspect command, and is used in auto-generated cli docs.
+func networkInspectExample() string {
+	return `$ pouch network inspect net1
+Name:         net1
+Scope:        
+Driver:       bridge
+EnableIPV6:   false
+ID:           c33c2646dc8ce9162faa65d17e80582475bbe53dc70ba0dc4def4b71e44551d6
+Internal:     false`
 }

--- a/client/network.go
+++ b/client/network.go
@@ -27,3 +27,18 @@ func (client *APIClient) NetworkRemove(networkID string) error {
 	ensureCloseReader(resp)
 	return err
 }
+
+//NetworkInspect inspects a network.
+func (client *APIClient) NetworkInspect(networkID string) (*types.NetworkInspectResp, error) {
+	resp, err := client.get("/networks/"+networkID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	network := &types.NetworkInspectResp{}
+
+	err = decodeBody(network, resp.Body)
+	ensureCloseReader(resp)
+
+	return network, err
+}


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

add network inspect implementation on cli and client side

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes part of #218
 
**3.Describe how you did it**

a)implement network inspect on cli and client side
b)initialize IPAM field on api side

**4.Describe how to verify it**
```
$ pouch network create -n net1
net1: c33c2646dc8ce9162faa65d17e80582475bbe53dc70ba0dc4def4b71e44551d6
$ pouch network inspect net1
Name:         net1
Scope:        
Driver:       bridge
EnableIPV6:   false
ID:           c33c2646dc8ce9162faa65d17e80582475bbe53dc70ba0dc4def4b71e44551d6
Internal:     false
$ pouch network remove net1
Removed: net1
$ pouch network inspect net1
Error: {"message":"network net1 not found: not found"}
```

**5.Special notes for reviews**


