### PR TITLE
feature: implement ContainerStatus and PodSandboxStatus of cri manager

### DIFF
--- a/daemon/mgr/cri_test.go
+++ b/daemon/mgr/cri_test.go
@@ -25,6 +25,22 @@ func TestParseUint32(t *testing.T) {
 	}
 }
 
+func TestToCriTimestamp(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected int64
+	}{
+		{input: "", expected: int64(0)},
+		{input: "2018-01-12T07:38:32.245589846Z", expected: int64(1515742712245589846)},
+	}
+
+	for _, test := range testCases {
+		actual, err := toCriTimestamp(test.input)
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, actual)
+	}
+}
+
 func TestLabelsAndAnnotationsRoundTrip(t *testing.T) {
 	expectedLabels := map[string]string{"label.123.abc": "foo", "label.456.efg": "bar"}
 	expectedAnnotations := map[string]string{"annotation.abc.123": "uvw", "annotation.def.456": "xyz"}

--- a/daemon/mgr/cri_utils.go
+++ b/daemon/mgr/cri_utils.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	apitypes "github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/pkg/reference"
+	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/go-openapi/strfmt"
 
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
@@ -18,6 +20,19 @@ func parseUint32(s string) (uint32, error) {
 		return 0, err
 	}
 	return uint32(n), nil
+}
+
+func toCriTimestamp(t string) (int64, error) {
+	if t == "" {
+		return 0, nil
+	}
+
+	result, err := time.Parse(utils.TimeLayout, t)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.UnixNano(), nil
 }
 
 // generateEnvList converts KeyValue list to a list of strings, in the form of


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes part of #420 

**3.Describe how you did it**

**4.Describe how to verify it**

Maybe the [cri-tools](https://github.com/kubernetes-incubator/cri-tools) is what you need.

We may use the following method to verify that we can get status of sandboxes and containers:
```
// Now we must ensure the sandbox image has already exists.
[root@pouch-test cri-tools]# pouch pull k8s.gcr.io/pause-amd64:3.0
[root@pouch-test cri-tools]# cat sandbox-config.json
{
    "metadata": {
        "name": "nginx-sandbox",
        "namespace": "default",
        "attempt": 1,
        "uid": "hdishd83djaidwnduwk28bcsb"
    },
    "linux": {
    }
}
[root@pouch-test cri-tools]# crictl runs sandbox-config.json
6ca39d7986fce58e7fd7fabe17e4acf7e5220ed82deca119fe40218ef6803cc4
[root@pouch-test cri-tools]# crictl inspects 6ca39d7986fce58e7fd7fabe17e4acf7e5220ed82deca119fe40218ef6803cc4
{
  "status": {
    "id": "6ca39d7986fce58e7fd7fabe17e4acf7e5220ed82deca119fe40218ef6803cc4",
    "metadata": {
      "attempt": 1,
      "name": "nginx-sandbox",
      "namespace": "default",
      "uid": "hdishd83djaidwnduwk28bcsb"
    },
    "state": "SANDBOX_NOTREADY",
    "createdAt": "2018-01-12T07:52:38.529798965Z",
    "network": null,
    "linux": null,
    "labels": null,
    "annotations": null
  }
}
[root@pouch-test cri-tools]# cat container-config.json 
{
  "metadata": {
      "name": "busybox"
  },
  "image":{
      "image": "docker.io/library/busybox:latest"
  },
  "command": [
      "top"
  ],
  "linux": {
  }
}
[root@pouch-test cri-tools]# crictl create 6ca39d7986fce58e7fd7fabe17e4acf7e5220ed82deca119fe40218ef6803cc4 container-config.json sandbox-config.json
2b1ae5026fc784bd33f17680b39fa7aea2c68b22cb6bdbf2b74ac7172736ef34
[root@pouch-test cri-tools]# crictl inspect 2b1ae5026fc784bd33f17680b39fa7aea2c68b22cb6bdbf2b74ac7172736ef34
{
  "status": {
    "id": "2b1ae5026fc784bd33f17680b39fa7aea2c68b22cb6bdbf2b74ac7172736ef34",
    "metadata": {
      "attempt": 0,
      "name": "busybox"
    },
    "state": "CONTAINER_CREATED",
    "createdAt": "2018-01-12T07:53:07.935952223Z",
    "startedAt": "1970-01-01T00:00:00Z",
    "finishedAt": "1970-01-01T00:00:00Z",
    "exitCode": 0,
    "image": {
      "image": "docker.io/library/busybox:latest"
    },
    "imageRef": "docker.io/library/busybox:latest",
    "reason": "",
    "message": "",
    "labels": null,
    "annotations": null,
    "mounts": null,
    "logPath": ""
  }
}
```

**5.Special notes for reviews**


