### PR TITLE
feature: add volume info command

### DIFF
--- a/apis/server/volume_bridge.go
+++ b/apis/server/volume_bridge.go
@@ -49,16 +49,27 @@ func (s *Server) createVolume(ctx context.Context, rw http.ResponseWriter, req *
 	return EncodeResponse(rw, http.StatusCreated, volume)
 }
 
-func (s *Server) getVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
+func (s *Server) getVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	name := mux.Vars(req)["name"]
 	volume, err := s.VolumeMgr.Get(ctx, name)
 	if err != nil {
 		return err
 	}
-	return EncodeResponse(rw, http.StatusOK, volume)
+	respVolume := types.VolumeInfo{
+		Name:       volume.Name,
+		Driver:     volume.Driver(),
+		Mountpoint: volume.Path(),
+		CreatedAt:  volume.CreationTimestamp.Format("2006-1-2 15:04:05"),
+		Labels:     volume.Labels,
+		Status: map[string]interface{}{
+			"size": volume.Size(),
+		},
+	}
+
+	return EncodeResponse(rw, http.StatusOK, respVolume)
 }
 
-func (s *Server) removeVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
+func (s *Server) removeVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	name := mux.Vars(req)["name"]
 
 	if err := s.VolumeMgr.Remove(ctx, name); err != nil {

--- a/client/volume.go
+++ b/client/volume.go
@@ -24,3 +24,18 @@ func (client *APIClient) VolumeRemove(name string) error {
 
 	return err
 }
+
+// VolumeInfo returns a volume's information.
+func (client *APIClient) VolumeInfo(name string) (*types.VolumeInfo, error) {
+	resp, err := client.get("/volumes/"+name, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	volume := &types.VolumeInfo{}
+
+	err = decodeBody(volume, resp.Body)
+	ensureCloseReader(resp)
+
+	return volume, err
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Add volume info command, it is used to get the information of volume,
include name, driver, mountpoint and so on.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

**3.Describe how you did it**

**4.Describe how to verify it**
create a pouch volume like this:
```
# pouch volume create -d local -n pouch-volume -o size=100g
Mountpoint:
Name:         pouch-volume
Scope:
CreatedAt:
Driver:       local
```
get the information of the created volume
```
# pouch volume info pouch-volume
CreatedAt:    2018 Jan 15 10:50:36
Driver:       local
Mountpoint:   /mnt/local/pouch-volume
Name:         pouch-volume
Scope:

```

**5.Special notes for reviews**

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
