### PR TITLE
feature: add volume list command

### DIFF
--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -46,6 +46,7 @@ func initRoute(s *Server) http.Handler {
 	r.Path("/images/{name:.*}/json").Methods(http.MethodGet).Handler(s.filter(s.getImage))
 
 	// volume
+	r.Path("/volumes").Methods(http.MethodGet).Handler(s.filter(s.listVolume))
 	r.Path("/volumes/create").Methods(http.MethodPost).Handler(s.filter(s.createVolume))
 	r.Path("/volumes/{name:.*}").Methods(http.MethodGet).Handler(s.filter(s.getVolume))
 	r.Path("/volumes/{name:.*}").Methods(http.MethodDelete).Handler(s.filter(s.removeVolume))

--- a/apis/server/volume_bridge.go
+++ b/apis/server/volume_bridge.go
@@ -77,3 +77,16 @@ func (s *Server) removeVolume(ctx context.Context, rw http.ResponseWriter, req *
 	rw.WriteHeader(http.StatusNoContent)
 	return nil
 }
+
+func (s *Server) listVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+	volumes, err := s.VolumeMgr.List(ctx, map[string]string{})
+	if err != nil {
+		return err
+	}
+
+	respVolumes := types.VolumeListResp{Volumes: []*types.VolumeInfo{}, Warnings: nil}
+	for _, name := range volumes {
+		respVolumes.Volumes = append(respVolumes.Volumes, &types.VolumeInfo{Name: name})
+	}
+	return EncodeResponse(rw, http.StatusOK, respVolumes)
+}

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -34,6 +34,7 @@ func (v *VolumeCommand) Init(c *Cli) {
 	c.AddCommand(v, &VolumeCreateCommand{})
 	c.AddCommand(v, &VolumeRemoveCommand{})
 	c.AddCommand(v, &VolumeInspectCommand{})
+	c.AddCommand(v, &VolumeListCommand{})
 }
 
 // RunE is the entry of VolumeCommand command.
@@ -259,4 +260,65 @@ CreatedAt:
 Driver:
 Mountpoint:
 Name:         a02217023fc477876a5483100b87d84d8845d5ac7c0c706717f2ff6edc0cf425`
+}
+
+// volumeListDescription is used to describe volume list command in detail and auto generate command doc.
+var volumeListDescription = "List volumes in pouchd. " +
+	"It lists the volume's name"
+
+// VolumeListCommand is used to implement 'volume rm' command.
+type VolumeListCommand struct {
+	baseCommand
+}
+
+// Init initializes VolumeListCommand command.
+func (v *VolumeListCommand) Init(c *Cli) {
+	v.cli = c
+	v.cmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List volumes",
+		Long:    volumeListDescription,
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return v.runVolumeList(args)
+		},
+		Example: volumeListExample(),
+	}
+	v.addFlags()
+}
+
+// addFlags adds flags for specific command.
+func (v *VolumeListCommand) addFlags() {}
+
+// runVolumeList is the entry of VolumeListCommand command.
+func (v *VolumeListCommand) runVolumeList(args []string) error {
+	logrus.Debugf("list the volumes")
+
+	apiClient := v.cli.Client()
+
+	volumeList, err := apiClient.VolumeList()
+	if err != nil {
+		return err
+	}
+
+	display := v.cli.NewTableDisplay()
+	display.AddRow([]string{"Name:"})
+
+	for _, v := range volumeList.Volumes {
+		display.AddRow([]string{v.Name})
+	}
+
+	display.Flush()
+
+	return nil
+}
+
+// volumeListExample shows examples in volume list command, and is used in auto-generated cli docs.
+func volumeListExample() string {
+	return `$ pouch volume list
+Name:
+pouch-volume-1
+pouch-volume-2
+pouch-volume-3`
 }

--- a/client/volume.go
+++ b/client/volume.go
@@ -1,6 +1,8 @@
 package client
 
-import "github.com/alibaba/pouch/apis/types"
+import (
+	"github.com/alibaba/pouch/apis/types"
+)
 
 // VolumeCreate creates a volume.
 func (client *APIClient) VolumeCreate(config *types.VolumeCreateConfig) (*types.VolumeInfo, error) {
@@ -38,4 +40,16 @@ func (client *APIClient) VolumeInspect(name string) (*types.VolumeInfo, error) {
 	ensureCloseReader(resp)
 
 	return volume, err
+}
+
+// VolumeList returns the list of volumes.
+func (client *APIClient) VolumeList() (*types.VolumeListResp, error) {
+	resp, err := client.get("/volumes", nil)
+
+	volumeListResp := &types.VolumeListResp{}
+
+	err = decodeBody(volumeListResp, resp.Body)
+	ensureCloseReader(resp)
+
+	return volumeListResp, err
 }

--- a/test/api_volume_list_test.go
+++ b/test/api_volume_list_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/test/request"
+
+	"github.com/go-check/check"
+)
+
+// APIVolumeListSuite is the test suite for volume inspect API.
+type APIVolumeListSuite struct{}
+
+func init() {
+	check.Suite(&APIVolumeListSuite{})
+}
+
+// SetUpTest does common setup in the beginning of each test.
+func (suite *APIVolumeListSuite) SetUpTest(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+}
+
+// TestVolumeListOk tests if list volumes is OK.
+func (suite *APIVolumeListSuite) TestVolumeListOk(c *check.C) {
+	// Create a volume with the name "TestVolume1".
+	err := CreateVolume(c, "TestVolume1", "local")
+	c.Assert(err, check.IsNil)
+
+	// Create a volume with the name "TestVolume1".
+	err = CreateVolume(c, "TestVolume2", "local")
+	c.Assert(err, check.IsNil)
+
+	// Test volume list feature.
+	path := "/volumes"
+	resp, err := request.Get(path)
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.StatusCode, check.Equals, 200)
+
+	// Check list result.
+	volumeListResp := &types.VolumeListResp{}
+	err = request.DecodeBody(volumeListResp, resp.Body)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(volumeListResp.Volumes), check.Equals, 2)
+
+	// Delete the TestVolume1.
+	err = RemoveVolume(c, "TestVolume1")
+	c.Assert(err, check.IsNil)
+
+	// Delete the TestVolume2.
+	err = RemoveVolume(c, "TestVolume2")
+	c.Assert(err, check.IsNil)
+}

--- a/test/utils.go
+++ b/test/utils.go
@@ -211,3 +211,33 @@ func StartContainerExec(c *check.C, execid string, tty bool, detach bool) (*http
 		request.WithHeader("Upgrade", "tcp"),
 		request.WithJSONBody(obj))
 }
+
+// CreateVolume creates a volume in pouchd.
+func CreateVolume(c *check.C, name, driver string) error {
+	obj := map[string]interface{}{
+		"Driver": driver,
+		"Name":   name,
+	}
+	path := "/volumes/create"
+	body := request.WithJSONBody(obj)
+
+	resp, err := request.Post(path, body)
+	defer resp.Body.Close()
+
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.StatusCode, check.Equals, 201)
+
+	return err
+}
+
+// RemoveVolume removes a volume in pouchd.
+func RemoveVolume(c *check.C, name string) error {
+	path := "/volumes/" + name
+	resp, err := request.Delete(path)
+	defer resp.Body.Close()
+
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.StatusCode, check.Equals, 204)
+
+	return err
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Add volume list command, it returns all the volumes in pouch.
Now it just returns the name of volume.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

**3.Describe how you did it**

**4.Describe how to verify it**
create three volume in pouchd
```
# pouch volume create -d local -n pouch-volume-1 -o size=100g
CreatedAt:
Driver:       local
Mountpoint:
Name:         pouch-volume-1
Scope:
# pouch volume create -d local -n pouch-volume-2 -o size=100g
Driver:       local
Mountpoint:
Name:         pouch-volume-2
Scope:
CreatedAt:
# pouch volume create -d local -n pouch-volume-3 -o size=100g
Scope:
CreatedAt:
Driver:       local
Mountpoint:
Name:         pouch-volume-3
```
then use list to get the volumes that are created just now.
```
# pouch volume list
Name:
pouch-volume-1
pouch-volume-2
pouch-volume-3
```
**5.Special notes for reviews**



Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
