### PR TITLE
feature: add volume inspect on cli and client side

### DIFF
--- a/apis/server/volume_bridge.go
+++ b/apis/server/volume_bridge.go
@@ -55,10 +55,20 @@ func (s *Server) getVolume(ctx context.Context, rw http.ResponseWriter, req *htt
 	if err != nil {
 		return err
 	}
-	return EncodeResponse(rw, http.StatusOK, volume)
+	respVolume := types.VolumeInfo{
+		Name:       volume.Name,
+		Driver:     volume.Driver(),
+		Mountpoint: volume.Path(),
+		CreatedAt:  volume.CreationTimestamp.Format("2006-1-2 15:04:05"),
+		Labels:     volume.Labels,
+		Status: map[string]interface{}{
+			"size": volume.Size(),
+		},
+	}
+	return EncodeResponse(rw, http.StatusOK, respVolume)
 }
 
-func (s *Server) removeVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
+func (s *Server) removeVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	name := mux.Vars(req)["name"]
 
 	if err := s.VolumeMgr.Remove(ctx, name); err != nil {

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -33,6 +33,7 @@ func (v *VolumeCommand) Init(c *Cli) {
 
 	c.AddCommand(v, &VolumeCreateCommand{})
 	c.AddCommand(v, &VolumeRemoveCommand{})
+	c.AddCommand(v, &VolumeInspectCommand{})
 }
 
 // RunE is the entry of VolumeCommand command.
@@ -153,20 +154,21 @@ Driver:       local`
 
 // volumeRmDescription is used to describe volume rm command in detail and auto generate command doc.
 var volumeRmDescription = "Remove a volume in pouchd. " +
-	"It need specify volume's name, when the volume is exist and is unuse, it will be remove."
+	"It must specify volume's name, and the volume will be removed when it is existent and unused."
 
 // VolumeRemoveCommand is used to implement 'volume rm' command.
 type VolumeRemoveCommand struct {
 	baseCommand
+	name string
 }
 
 // Init initializes VolumeRemoveCommand command.
 func (v *VolumeRemoveCommand) Init(c *Cli) {
 	v.cli = c
 	v.cmd = &cobra.Command{
-		Use:     "remove VOLUME",
+		Use:     "remove [OPTIONS] NAME",
 		Aliases: []string{"rm"},
-		Short:   "Remove volume",
+		Short:   "Remove a volume",
 		Long:    volumeRmDescription,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -200,4 +202,61 @@ func (v *VolumeRemoveCommand) runVolumeRm(args []string) error {
 func volumeRmExample() string {
 	return `$ pouch volume rm pouch-volume
 Removed: pouch-volume`
+}
+
+// volumeInspectDescription is used to describe volume inspect command in detail and auto generate command doc.
+var volumeInspectDescription = "Inspect a volume in pouchd. " +
+	"It must specify volume's name."
+
+// VolumeInspectCommand is used to implement 'volume inspect' command.
+type VolumeInspectCommand struct {
+	baseCommand
+
+	name string
+}
+
+// Init initializes VolumeInspectCommand command.
+func (v *VolumeInspectCommand) Init(c *Cli) {
+	v.cli = c
+	v.cmd = &cobra.Command{
+		Use:   "inspect [OPTIONS] NAME",
+		Short: "Inspect a pouch volume",
+		Long:  volumeInspectDescription,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return v.runVolumeInspect(args)
+		},
+		Example: volumeInspectExample(),
+	}
+	v.addFlags()
+}
+
+// addFlags adds flags for specific command.
+func (v *VolumeInspectCommand) addFlags() {}
+
+// runVolumeInspect is the entry of VolumeInspectCommand command.
+func (v *VolumeInspectCommand) runVolumeInspect(args []string) error {
+	name := args[0]
+
+	logrus.Debugf("inspect a volume: %s", name)
+
+	apiClient := v.cli.Client()
+
+	resp, err := apiClient.VolumeInspect(name)
+	if err != nil {
+		return err
+	}
+
+	v.cli.Print(resp)
+	return nil
+}
+
+// volumeInspectExample shows examples in volume inspect command, and is used in auto-generated cli docs.
+func volumeInspectExample() string {
+	return `$ pouch volume inspect a02217023fc477876a5483100b87d84d8845d5ac7c0c706717f2ff6edc0cf425
+Scope:
+CreatedAt:
+Driver:
+Mountpoint:
+Name:         a02217023fc477876a5483100b87d84d8845d5ac7c0c706717f2ff6edc0cf425`
 }

--- a/client/volume.go
+++ b/client/volume.go
@@ -2,7 +2,7 @@ package client
 
 import "github.com/alibaba/pouch/apis/types"
 
-// VolumeCreate creates a volume
+// VolumeCreate creates a volume.
 func (client *APIClient) VolumeCreate(config *types.VolumeCreateConfig) (*types.VolumeInfo, error) {
 	resp, err := client.post("/volumes/create", nil, config)
 	if err != nil {
@@ -17,10 +17,25 @@ func (client *APIClient) VolumeCreate(config *types.VolumeCreateConfig) (*types.
 	return volume, err
 }
 
-// VolumeRemove removes a volume
+// VolumeRemove removes a volume.
 func (client *APIClient) VolumeRemove(name string) error {
 	resp, err := client.delete("/volumes/"+name, nil)
 	ensureCloseReader(resp)
 
 	return err
+}
+
+// VolumeInspect inspects a volume.
+func (client *APIClient) VolumeInspect(name string) (*types.VolumeInfo, error) {
+	resp, err := client.get("/volumes/"+name, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	volume := &types.VolumeInfo{}
+
+	err = decodeBody(volume, resp.Body)
+	ensureCloseReader(resp)
+
+	return volume, err
 }

--- a/test/api_volume_delete_test.go
+++ b/test/api_volume_delete_test.go
@@ -24,6 +24,5 @@ func (suite *APIVolumeDeleteSuite) TestDeleteNonExisting(c *check.C) {
 	vol := "TestDeleteNonExisting"
 	resp, err := request.Delete("/volumes/" + vol)
 	c.Assert(err, check.IsNil)
-	// TODO: Now server return 500, should return 404
-	c.Assert(resp.StatusCode, check.Equals, 500)
+	c.Assert(resp.StatusCode, check.Equals, 404)
 }

--- a/test/api_volume_inspect_test.go
+++ b/test/api_volume_inspect_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/test/request"
+
+	"github.com/go-check/check"
+)
+
+// APIVolumeInspectSuite is the test suite for volume inspect API.
+type APIVolumeInspectSuite struct{}
+
+func init() {
+	check.Suite(&APIVolumeInspectSuite{})
+}
+
+// SetUpTest does common setup in the beginning of each test.
+func (suite *APIVolumeInspectSuite) SetUpTest(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+}
+
+// TestVolumeInspectOk tests if inspecting a volume is OK.
+func (suite *APIVolumeInspectSuite) TestVolumeInspectOk(c *check.C) {
+	// Create a volume with the name "TestVolume".
+	vol := "TestVolume"
+	obj := map[string]interface{}{
+		"Driver": "local",
+		"Name":   vol,
+	}
+	path := "/volumes/create"
+	body := request.WithJSONBody(obj)
+	resp, err := request.Post(path, body)
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.StatusCode, check.Equals, 201)
+
+	// Test volume inspect feature.
+	path = "/volumes/" + vol
+	resp, err = request.Get(path)
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.StatusCode, check.Equals, 200)
+
+	// Delete the volume.
+	path = "/volumes/" + vol
+	resp, err = request.Delete(path)
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.StatusCode, check.Equals, 204)
+}
+
+// TestVolumeInspectNotFound tests if inspecting a nonexistent volume returns error.
+func (suite *APIVolumeInspectSuite) TestVolumeInspectNotFound(c *check.C) {
+	vol := "NotExistentVolume"
+
+	path := "/volumes/" + vol
+	resp, err := request.Get(path)
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.StatusCode, check.Equals, 404)
+
+}

--- a/test/cli_volume_test.go
+++ b/test/cli_volume_test.go
@@ -25,8 +25,6 @@ func (suite *PouchVolumeSuite) SetUpSuite(c *check.C) {
 }
 
 // TestVolumeWorks tests "pouch volume" work.
-//
-// TODO: use volume inspect to check value.
 func (suite *PouchVolumeSuite) TestVolumeWorks(c *check.C) {
 	pc, _, _, _ := runtime.Caller(0)
 	tmpname := strings.Split(runtime.FuncForPC(pc).Name(), ".")
@@ -36,5 +34,6 @@ func (suite *PouchVolumeSuite) TestVolumeWorks(c *check.C) {
 	}
 
 	command.PouchRun("volume", "create", "--name", funcname).Assert(c, icmd.Success)
+	command.PouchRun("volume", "inspect", funcname).Assert(c, icmd.Success)
 	command.PouchRun("volume", "remove", funcname).Assert(c, icmd.Success)
 }


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
add volume inspect on cli and client side
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes part of #139
**3.Describe how you did it**

**4.Describe how to verify it**

Firstly, you should create a volume.
Then you verify whether or not 'volume inspect' command works.
Finally, you remove that volume and try the 'volume inspect' command again to see if the error returned indicates that the volume does not exist.
```
$ pouch volume create -d local -n pouch-volume -o size=100g
Driver:       local
Mountpoint:   
Name:         pouch-volume
Scope:        
CreatedAt:    

$ pouch volume inspect pouch-volume
Mountpoint:   /mnt/local/pouch-volume
Name:         pouch-volume
Scope:        
CreatedAt:    2018-1-17 14:09:30
Driver:       local

$ pouch volume rm pouch-volume
Removed: pouch-volume

$ pouch volume inspect pouch-volume
Error: {"message":"volume not found"}

```

**5.Special notes for reviews**


