### PR TITLE
feature: add config to ImageInfo and user to CriImage

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1589,6 +1589,8 @@ definitions:
       Size:
         description: "size of image's taking disk space."
         type: "integer"
+      Config:
+        $ref: "#/definitions/ContainerConfig"
 
   SearchResultItem:
     type: "object"

--- a/apis/types/image_info.go
+++ b/apis/types/image_info.go
@@ -17,6 +17,9 @@ import (
 
 type ImageInfo struct {
 
+	// config
+	Config *ContainerConfig `json:"Config,omitempty"`
+
 	// Time of image creation
 	CreatedAt string `json:"CreatedAt,omitempty"`
 
@@ -36,6 +39,8 @@ type ImageInfo struct {
 	Tag string `json:"Tag,omitempty"`
 }
 
+/* polymorph ImageInfo Config false */
+
 /* polymorph ImageInfo CreatedAt false */
 
 /* polymorph ImageInfo Digest false */
@@ -52,9 +57,33 @@ type ImageInfo struct {
 func (m *ImageInfo) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateConfig(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *ImageInfo) validateConfig(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Config) { // not required
+		return nil
+	}
+
+	if m.Config != nil {
+
+		if err := m.Config.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("Config")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/ctrd/image.go
+++ b/ctrd/image.go
@@ -94,7 +94,20 @@ func (c *Client) ListImages(ctx context.Context, filter ...string) ([]types.Imag
 
 		// TODO(Wei Fu): the go-digest will deprecate the Hex() method.
 		// We need to use Encoded() if update the go-digest version.
+		imageConfig, err := c.GetImageConfig(ctx, ref.String())
+		cfg := &types.ContainerConfig{
+			// TODO: add more fields
+			User:       imageConfig.User,
+			Env:        imageConfig.Env,
+			Entrypoint: imageConfig.Entrypoint,
+			Cmd:        imageConfig.Cmd,
+			WorkingDir: imageConfig.WorkingDir,
+			Labels:     imageConfig.Labels,
+			StopSignal: imageConfig.StopSignal,
+		}
+
 		images = append(images, types.ImageInfo{
+			Config:    cfg,
 			CreatedAt: image.CreatedAt.Format(utils.TimeLayout),
 			Name:      image.Name,
 			ID:        truncateID(digest.Hex()),

--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -550,7 +550,12 @@ func (c *CriManager) ListImages(ctx context.Context, r *runtime.ListImagesReques
 // ImageStatus returns the status of the image, returns nil if the image isn't present.
 func (c *CriManager) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
 	imageRef := r.GetImage().GetImage()
-	imageInfo, err := c.ImageMgr.GetImage(ctx, imageRef)
+	ref, err := reference.Parse(imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	imageInfo, err := c.ImageMgr.GetImage(ctx, ref.String())
 	if err != nil {
 		return nil, err
 	}
@@ -577,7 +582,7 @@ func (c *CriManager) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 		return nil, err
 	}
 
-	imageInfo, err := c.ImageMgr.GetImage(ctx, imageRef)
+	imageInfo, err := c.ImageMgr.GetImage(ctx, ref.String())
 	if err != nil {
 		return nil, err
 	}
@@ -588,7 +593,12 @@ func (c *CriManager) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 // RemoveImage removes the image.
 func (c *CriManager) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
 	imageRef := r.GetImage().GetImage()
-	imageInfo, err := c.ImageMgr.GetImage(ctx, imageRef)
+	ref, err := reference.Parse(imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	imageInfo, err := c.ImageMgr.GetImage(ctx, ref.String())
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/pkg/errtypes"
 	"github.com/alibaba/pouch/pkg/jsonstream"
+	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/registry"
 
 	"github.com/pkg/errors"
@@ -92,12 +93,34 @@ func (mgr *ImageManager) PullImage(pctx context.Context, image, tag string, out 
 		return err
 	}
 
+	ctx, cancel = context.WithCancel(pctx)
+	imageConfig, err := mgr.client.GetImageConfig(ctx, image+":"+tag)
+	cancel()
+
+	if err != nil {
+		return err
+	}
+
+	cfg := &types.ContainerConfig{
+		// TODO: add more fields
+		User:       imageConfig.User,
+		Env:        imageConfig.Env,
+		Entrypoint: imageConfig.Entrypoint,
+		Cmd:        imageConfig.Cmd,
+		WorkingDir: imageConfig.WorkingDir,
+		Labels:     imageConfig.Labels,
+		StopSignal: imageConfig.StopSignal,
+	}
+
 	// FIXME need to refactor it and the image's list interface.
 	mgr.cache.put(&types.ImageInfo{
-		Name:   img.Name(),
-		ID:     strings.TrimPrefix(string(img.Target().Digest), "sha256:")[:12],
-		Digest: string(img.Target().Digest),
-		Size:   img.Target().Size,
+		Config:    cfg,
+		CreatedAt: time.Now().UTC().Format(utils.TimeLayout),
+		Name:      img.Name(),
+		ID:        strings.TrimPrefix(string(img.Target().Digest), "sha256:")[:12],
+		Digest:    string(img.Target().Digest),
+		Size:      img.Target().Size,
+		Tag:       tag,
 	})
 
 	return nil

--- a/test/api_image_inspect_test.go
+++ b/test/api_image_inspect_test.go
@@ -31,11 +31,13 @@ func (suite *APIImageInspectSuite) TestImageInspectOk(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// TODO: More specific check is needed
+	c.Assert(got.Config, check.NotNil)
 	c.Assert(got.Name, check.Equals, busyboxImage)
 	c.Assert(got.ID, check.NotNil)
 	c.Assert(got.CreatedAt, check.NotNil)
 	c.Assert(got.Digest, check.Matches, "sha256.*")
 	c.Assert(got.Size, check.NotNil)
+	c.Assert(got.Tag, check.Equals, "latest")
 }
 
 // TestImageInspectNotFound tests inspecting non-existing images.


### PR DESCRIPTION
Signed-off-by: zeppp <zeppp1995@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Add config to ImageInfo and user  info to CriImage.

**2.Does this pull request fix one issue?** 
fixes #570  

**3.Describe how you did it**

**4.Describe how to verify it**
```
-> #pouch images
IMAGE ID       IMAGE NAME                                       SIZE
ac2fc418f334   registry.hub.docker.com/library/busybox:latest   710.48 KB

-> #pouch image inspect  registry.hub.docker.com/library/busybox:latest
{
  "Config": {
    "Cmd": [
      "sh"
    ],
    "Entrypoint": null,
    "Env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ],
    "Image": "",
    "OnBuild": null,
    "Shell": null
  },
  "CreatedAt": "2018-01-17T06:59:16.191892985Z",
  "Digest": "sha256:ac2fc418f3348815e68e266a5aa1b60bc522581c96964912560a0baacc4f5c06",
  "ID": "ac2fc418f334",
  "Name": "registry.hub.docker.com/library/busybox:latest",
  "Size": 2699,
  "Tag": "latest"
}
```

**5.Special notes for reviews**


