### PR TITLE
test: remove -it option when start test contaienr

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -39,21 +39,21 @@ function target()
 {
 	case $1 in
 	check)
-		docker run --rm -ti -v $(pwd):$SOURCEDIR $IMAGE bash -c "make check"
+		docker run --rm -v $(pwd):$SOURCEDIR $IMAGE bash -c "make check"
 		;;
 	build)
-		docker run --rm -ti -v $(pwd):$SOURCEDIR $IMAGE bash -c "make build"
+		docker run --rm -v $(pwd):$SOURCEDIR $IMAGE bash -c "make build"
 		install_pouch
 		;;
 	unit-test)
-		docker run --rm -ti -v $(pwd):$SOURCEDIR $IMAGE bash -c "make unit-test"
+		docker run --rm -v $(pwd):$SOURCEDIR $IMAGE bash -c "make unit-test"
 		;;
 	cri-test)
 		cd $SOURCEDIR
 		env PATH=$GOROOT/bin:$PATH $SOURCEDIR/hack/cri-test/test-cri.sh
 		;;
 	integration-test)
-		docker run --rm -ti -v $(pwd):$SOURCEDIR $IMAGE bash -c "cd test && go test -c -o integration-test"
+		docker run --rm -v $(pwd):$SOURCEDIR $IMAGE bash -c "cd test && go test -c -o integration-test"
 
 		if [[ $SOURCEDIR != $DIR ]];then
 			[ -d $SOURCEDIR ] && rm -rf $SOURCEDIR


### PR DESCRIPTION
Signed-off-by: letty <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
`docker -ti` may fail due to no TTY could be allocated. And for CI, there is no need to allocate a tty when create a test container.
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


