### PR TITLE
feature: memory buffer container io backend

### DIFF
--- a/daemon/containerio/mem_buffer.go
+++ b/daemon/containerio/mem_buffer.go
@@ -1,0 +1,38 @@
+package containerio
+
+import (
+	"bytes"
+	"io"
+)
+
+func init() {
+	Register(func() Backend {
+		return &memBuffer{}
+	})
+}
+
+type memBuffer struct {
+	buffer *bytes.Buffer
+}
+
+func (b *memBuffer) Name() string {
+	return "memBuffer"
+}
+
+func (b *memBuffer) Init(opt *Option) error {
+	b.buffer = opt.memBuffer
+	return nil
+}
+
+func (b *memBuffer) Out() io.Writer {
+	return b.buffer
+}
+
+func (b *memBuffer) In() io.Reader {
+	return b.buffer
+}
+
+func (b *memBuffer) Close() error {
+	// Don't need to close bytes.Buffer.
+	return nil
+}

--- a/daemon/containerio/options.go
+++ b/daemon/containerio/options.go
@@ -1,6 +1,7 @@
 package containerio
 
 import (
+	"bytes"
 	"net/http"
 )
 
@@ -12,6 +13,7 @@ type Option struct {
 	hijack        http.Hijacker
 	hijackUpgrade bool
 	stdinBackend  string
+	memBuffer     *bytes.Buffer
 }
 
 // NewOption creates the Option instance.
@@ -75,5 +77,16 @@ func WithHijack(hi http.Hijacker, upgrade bool) func(*Option) {
 func WithStdinHijack() func(*Option) {
 	return func(opt *Option) {
 		opt.stdinBackend = "hijack"
+	}
+}
+
+// WithMemBuffer specified the memory buffer backend.
+func WithMemBuffer(memBuffer *bytes.Buffer) func(*Option) {
+	return func(opt *Option) {
+		if opt.backends == nil {
+			opt.backends = make(map[string]struct{})
+		}
+		opt.backends["memBuffer"] = struct{}{}
+		opt.memBuffer = memBuffer
 	}
 }

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -618,9 +618,15 @@ func (mgr *ContainerManager) openIO(id string, attach *AttachConfig, exec bool) 
 	}
 
 	if attach != nil {
-		options = append(options, containerio.WithHijack(attach.Hijack, attach.Upgrade))
-		if attach.Stdin {
-			options = append(options, containerio.WithStdinHijack())
+		if attach.Hijack != nil {
+			// Attaching using http.
+			options = append(options, containerio.WithHijack(attach.Hijack, attach.Upgrade))
+			if attach.Stdin {
+				options = append(options, containerio.WithStdinHijack())
+			}
+		} else if attach.MemBuffer != nil {
+			// Attaching using memory buffer.
+			options = append(options, containerio.WithMemBuffer(attach.MemBuffer))
 		}
 	} else if !exec {
 		options = append(options, containerio.WithRawFile())

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -1,6 +1,7 @@
 package mgr
 
 import (
+	"bytes"
 	"net/http"
 	"sync"
 	"time"
@@ -30,11 +31,16 @@ type containerExecConfig struct {
 
 // AttachConfig wraps some infos of attaching.
 type AttachConfig struct {
+	Stdin  bool
+	Stdout bool
+	Stderr bool
+
+	// Attach using http.
 	Hijack  http.Hijacker
-	Stdin   bool
-	Stdout  bool
-	Stderr  bool
 	Upgrade bool
+
+	// Attach using memory buffer.
+	MemBuffer *bytes.Buffer
 }
 
 // ContainerRemoveOption wraps the container remove interface params.


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

Now we only support using http to handle container IO.

With this PR, we could use memory buffer (bytes.Buffer in golang) as another backend type to handle container IO.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


