### PR TITLE
test: add a workaround for issue#569

### DIFF
--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -43,6 +43,7 @@ func (suite *PouchRunSuite) TestRun(c *check.C) {
 	if out := res.Combined(); !strings.Contains(out, name) {
 		c.Fatalf("unexpected output %s: should contains container %s\n", out, name)
 	}
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunPrintHi is to verify run container with executing a command.
@@ -55,6 +56,7 @@ func (suite *PouchRunSuite) TestRunPrintHi(c *check.C) {
 	if out := res.Combined(); !strings.Contains(out, "hi") {
 		c.Fatalf("unexpected output %s expected hi\n", out)
 	}
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunDeviceMapping is to verify --device param when running a container.
@@ -72,6 +74,7 @@ func (suite *PouchRunSuite) TestRunDeviceMapping(c *check.C) {
 	if out := res.Combined(); !strings.Contains(out, testDev) {
 		c.Fatalf("unexpected output %s expected %s\n", out, testDev)
 	}
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunDevicePermissions is to verify --device permissions mode when running a container.
@@ -90,6 +93,7 @@ func (suite *PouchRunSuite) TestRunDevicePermissions(c *check.C) {
 	if out := res.Combined(); !strings.HasPrefix(out, permissions) {
 		c.Fatalf("Output should begin with %s, got %s\n", permissions, out)
 	}
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunDeviceInvalidMode is to verify --device wrong mode when running a container.
@@ -123,6 +127,7 @@ func (suite *PouchRunSuite) TestRunDeviceDirectory(c *check.C) {
 	if out := res.Combined(); !strings.Contains(out, expected) {
 		c.Fatalf("Output should contain %s, got %s\n", expected, out)
 	}
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunWithBadDevice is to verify --device with bad device dir when running a container.
@@ -165,6 +170,7 @@ func (suite *PouchRunSuite) TestRunEnableLxcfs(c *check.C) {
 	if out := res.Combined(); !strings.Contains(out, "524288 kB") {
 		c.Fatalf("upexpected output %s expected %s\n", out, "524288 kB")
 	}
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunRestartPolicyAlways is to verify restart policy always works.
@@ -180,6 +186,7 @@ func (suite *PouchRunSuite) TestRunRestartPolicyAlways(c *check.C) {
 	if out := res.Combined(); !strings.Contains(out, name) {
 		c.Fatalf("expect container %s to be up: %s\n", name, out)
 	}
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunRestartPolicyNone is to verify restart policy none works.
@@ -195,6 +202,7 @@ func (suite *PouchRunSuite) TestRunRestartPolicyNone(c *check.C) {
 	if out := res.Combined(); strings.Contains(out, name) {
 		c.Fatalf("expect container %s to be exited: %s\n", name, out)
 	}
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunWithIPCMode is to verify --specific IPC mode when running a container.
@@ -204,6 +212,7 @@ func (suite *PouchRunSuite) TestRunWithIPCMode(c *check.C) {
 
 	res := command.PouchRun("run", "--name", name, "--ipc", "host", busyboxImage)
 	res.Assert(c, icmd.Success)
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunWithPIDMode is to verify --specific PID mode when running a container.
@@ -213,6 +222,7 @@ func (suite *PouchRunSuite) TestRunWithPIDMode(c *check.C) {
 
 	res := command.PouchRun("run", "--name", name, "--pid", "host", busyboxImage)
 	res.Assert(c, icmd.Success)
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunWithUTSMode is to verify --specific UTS mode when running a container.
@@ -221,4 +231,5 @@ func (suite *PouchRunSuite) TestRunWithUTSMode(c *check.C) {
 
 	res := command.PouchRun("run", "--name", name, "--uts", "host", busyboxImage)
 	res.Assert(c, icmd.Success)
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }


### PR DESCRIPTION
Signed-off-by: letty <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
As described in issue #569, cli_run_test.go always panic on CentOS.
After debugging, it may be related to the `PruneAllContainers` function in environment/cleanup.go.
Currently, adding remove CLI in each test could workaround this failure.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


