### PR TITLE
feature: add fields to ImageInfo

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1574,6 +1574,7 @@ definitions:
       ID:
         description: "ID of an image."
         type: "string"
+        x-nullable: false
       Name:
         description: "name of an image."
         type: "string"
@@ -1584,13 +1585,40 @@ definitions:
         description: "digest of image."
         type: "string"
       CreatedAt:
-        description: "Time of image creation"
+        description: "time of image creation."
         type: "string"
+        x-nullable: false
       Size:
         description: "size of image's taking disk space."
         type: "integer"
+        x-nullable: false
       Config:
         $ref: "#/definitions/ContainerConfig"
+      Architecture:
+        description: "the CPU architecture."
+        type: "string"
+        x-nullable: false
+      Os:
+        description: "the name of the operating system."
+        type: "string"
+        x-nullable: false
+      RootFS:
+        description: "the rootfs key references the layer content addresses used by the image."
+        type: "object"
+        required: [Type]
+        properties:
+          Type:
+            description: "type of the rootfs"
+            type: "string"
+            x-nullable: false
+          Layers:
+            description: "an array of layer content hashes"
+            type: "array"
+            items:
+              type: "string"
+          BaseLayer:
+            description: "the base layer content hash."
+            type: "string"
 
   SearchResultItem:
     type: "object"

--- a/apis/types/image_info.go
+++ b/apis/types/image_info.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // ImageInfo An object containing all details of an image at API side
@@ -17,10 +18,13 @@ import (
 
 type ImageInfo struct {
 
+	// the CPU architecture.
+	Architecture string `json:"Architecture,omitempty"`
+
 	// config
 	Config *ContainerConfig `json:"Config,omitempty"`
 
-	// Time of image creation
+	// time of image creation.
 	CreatedAt string `json:"CreatedAt,omitempty"`
 
 	// digest of image.
@@ -32,12 +36,20 @@ type ImageInfo struct {
 	// name of an image.
 	Name string `json:"Name,omitempty"`
 
+	// the name of the operating system.
+	Os string `json:"Os,omitempty"`
+
+	// root f s
+	RootFS *ImageInfoRootFS `json:"RootFS,omitempty"`
+
 	// size of image's taking disk space.
 	Size int64 `json:"Size,omitempty"`
 
 	// tag of an image.
 	Tag string `json:"Tag,omitempty"`
 }
+
+/* polymorph ImageInfo Architecture false */
 
 /* polymorph ImageInfo Config false */
 
@@ -49,6 +61,10 @@ type ImageInfo struct {
 
 /* polymorph ImageInfo Name false */
 
+/* polymorph ImageInfo Os false */
+
+/* polymorph ImageInfo RootFS false */
+
 /* polymorph ImageInfo Size false */
 
 /* polymorph ImageInfo Tag false */
@@ -58,6 +74,11 @@ func (m *ImageInfo) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateConfig(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateRootFS(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -87,6 +108,25 @@ func (m *ImageInfo) validateConfig(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *ImageInfo) validateRootFS(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.RootFS) { // not required
+		return nil
+	}
+
+	if m.RootFS != nil {
+
+		if err := m.RootFS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("RootFS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // MarshalBinary interface implementation
 func (m *ImageInfo) MarshalBinary() ([]byte, error) {
 	if m == nil {
@@ -98,6 +138,84 @@ func (m *ImageInfo) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *ImageInfo) UnmarshalBinary(b []byte) error {
 	var res ImageInfo
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// ImageInfoRootFS the rootfs key references the layer content addresses used by the image.
+// swagger:model ImageInfoRootFS
+
+type ImageInfoRootFS struct {
+
+	// the base layer content hash.
+	BaseLayer string `json:"BaseLayer,omitempty"`
+
+	// an array of layer content hashes
+	Layers []string `json:"Layers"`
+
+	// type of the rootfs
+	// Required: true
+	Type string `json:"Type"`
+}
+
+/* polymorph ImageInfoRootFS BaseLayer false */
+
+/* polymorph ImageInfoRootFS Layers false */
+
+/* polymorph ImageInfoRootFS Type false */
+
+// Validate validates this image info root f s
+func (m *ImageInfoRootFS) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateLayers(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateType(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *ImageInfoRootFS) validateLayers(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Layers) { // not required
+		return nil
+	}
+
+	return nil
+}
+
+func (m *ImageInfoRootFS) validateType(formats strfmt.Registry) error {
+
+	if err := validate.RequiredString("RootFS"+"."+"Type", "body", string(m.Type)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *ImageInfoRootFS) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *ImageInfoRootFS) UnmarshalBinary(b []byte) error {
+	var res ImageInfoRootFS
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/cli/image_list.go
+++ b/cli/image_list.go
@@ -64,7 +64,7 @@ func (i *ImagesCommand) runImages(args []string) error {
 
 	if i.flagQuiet {
 		for _, image := range imageList {
-			fmt.Println(image.ID)
+			fmt.Println(utils.TruncateID(image.ID))
 		}
 		return nil
 	}
@@ -80,14 +80,14 @@ func (i *ImagesCommand) runImages(args []string) error {
 	for _, image := range imageList {
 		if i.flagDigest {
 			display.AddRow([]string{
-				image.ID,
+				utils.TruncateID(image.ID),
 				image.Name,
 				image.Digest,
 				fmt.Sprintf("%s", imageSize(image.Size)),
 			})
 		} else {
 			display.AddRow([]string{
-				image.ID,
+				utils.TruncateID(image.ID),
 				image.Name,
 				fmt.Sprintf("%s", imageSize(image.Size)),
 			})

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -323,7 +323,11 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 
 	// merge image's config into container's meta
 	if err := meta.merge(func() (v1.ImageConfig, error) {
-		return mgr.Client.GetImageConfig(ctx, config.Image)
+		ociimage, err := mgr.Client.GetOciImage(ctx, config.Image)
+		if err != nil {
+			return ociimage.Config, err
+		}
+		return ociimage.Config, nil
 	}); err != nil {
 		return nil, err
 	}

--- a/daemon/mgr/cri_utils.go
+++ b/daemon/mgr/cri_utils.go
@@ -367,7 +367,7 @@ func imageToCriImage(image *apitypes.ImageInfo) (*runtime.Image, error) {
 	size := uint64(image.Size)
 	// TODO: improve type ImageInfo to include RepoTags and RepoDigests.
 	return &runtime.Image{
-		Id:          image.Digest,
+		Id:          image.ID,
 		RepoTags:    []string{fmt.Sprintf("%s:%s", ref.Name, ref.Tag)},
 		RepoDigests: []string{fmt.Sprintf("%s@%s", ref.Name, image.Digest)},
 		Size_:       size,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -108,4 +109,15 @@ func FormatTimeInterval(input int64) (formattedTime string, err error) {
 	}
 
 	return formattedTime, nil
+}
+
+// TruncateID is used to transfer image ID from digest to short ID.
+func TruncateID(id string) string {
+	var shortLen = 12
+
+	id = strings.TrimPrefix(id, "sha256:")
+	if len(id) > shortLen {
+		return id[:shortLen]
+	}
+	return id
 }

--- a/test/cli_images_test.go
+++ b/test/cli_images_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/client"
+	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
 	"github.com/go-check/check"
@@ -36,7 +37,7 @@ func (suite *PouchImagesSuite) TestImagesWorks(c *check.C) {
 		res := command.PouchRun("images").Assert(c, icmd.Success)
 		items := imagesListToKV(res.Combined())[busyboxImage]
 
-		c.Assert(items[0], check.Equals, image.ID)
+		c.Assert(items[0], check.Equals, utils.TruncateID(image.ID))
 	}
 
 	// with -q and --quiet
@@ -45,7 +46,7 @@ func (suite *PouchImagesSuite) TestImagesWorks(c *check.C) {
 		resQuiet := command.PouchRun("images", "--quiet").Assert(c, icmd.Success)
 
 		c.Assert(resQ.Combined(), check.Equals, resQuiet.Combined())
-		c.Assert(strings.TrimSpace(resQ.Combined()), check.Equals, image.ID)
+		c.Assert(strings.TrimSpace(resQ.Combined()), check.Equals, utils.TruncateID(image.ID))
 	}
 
 	// with --digest


### PR DESCRIPTION
Signed-off-by: zeppp <zeppp1995@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
add fields `Architecture` `Os ` `RootFS` to ImageInfo and change the generation of image ID.
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**
```
-># pouch images
IMAGE ID       IMAGE NAME                                       SIZE
9ffc1866b13a   registry.hub.docker.com/library/busybox:latest   710.74 KB

-># pouch image inspect registry.hub.docker.com/library/busybox
{
  "Architecture": "amd64",
  "Config": {
    "Cmd": [
      "sh"
    ],
    "Entrypoint": null,
    "Env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ],
    "Image": "",
    "OnBuild": null,
    "Shell": null
  },
  "CreatedAt": "2018-01-24T04:29:35.590938514Z",
  "ID": "sha256:9ffc1866b13a384dfbcf77d92fb85dba870949c646f88e38bdeaecce18291817",
  "Name": "registry.hub.docker.com/library/busybox:latest",
  "Tag": "latest",
  "Digest": "sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac75b7083da748db",
  "Os": "linux",
  "RootFS": {
    "Layers": [
      "sha256:4febd3792a1fb2153108b4fa50161c6ee5e3d16aa483a63215f936a113a88e9a"
    ],
    "Type": "layers"
  },
  "Size": 2699
}

```
**5.Special notes for reviews**


