### PR TITLE
test: remove cleanup on teardowntest

### DIFF
--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -29,7 +29,6 @@ func (suite *PouchCreateSuite) SetUpSuite(c *check.C) {
 
 // TearDownTest does cleanup work in the end of each test.
 func (suite *PouchCreateSuite) TearDownTest(c *check.C) {
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
 }
 
 // TestCreateName is to verify the correctness of creating contaier with specified name.

--- a/test/cli_exec_test.go
+++ b/test/cli_exec_test.go
@@ -27,7 +27,6 @@ func (suite *PouchExecSuite) SetUpSuite(c *check.C) {
 
 // TearDownTest does cleanup work in the end of each test.
 func (suite *PouchExecSuite) TearDownTest(c *check.C) {
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
 }
 
 // TestExecCommand is to verify the correctness of execing container with specified command.

--- a/test/cli_ps_test.go
+++ b/test/cli_ps_test.go
@@ -27,7 +27,6 @@ func (suite *PouchPsSuite) SetUpSuite(c *check.C) {
 
 // TearDownTest does cleanup work in the end of each test.
 func (suite *PouchPsSuite) TearDownTest(c *check.C) {
-	environment.PruneAllContainers(apiClient)
 }
 
 // TestPsWorks tests "pouch ps" work.

--- a/test/cli_pull_test.go
+++ b/test/cli_pull_test.go
@@ -25,7 +25,6 @@ func (suite *PouchPullSuite) SetUpSuite(c *check.C) {
 
 // TearDownTest does cleanup work in the end of each test.
 func (suite *PouchPullSuite) TearDownTest(c *check.C) {
-	environment.PruneAllImages(apiClient)
 }
 
 // TestPullWorks tests "pouch pull" work.

--- a/test/cli_rmi_test.go
+++ b/test/cli_rmi_test.go
@@ -19,6 +19,7 @@ func init() {
 // SetUpSuite does common setup in the beginning of each test suite.
 func (suite *PouchRmiSuite) SetUpSuite(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
 }
 
 // TestRmiWorks tests "pouch rmi" work.

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -30,7 +30,6 @@ func (suite *PouchRunSuite) SetUpSuite(c *check.C) {
 
 // TearDownTest does cleanup work in the end of each test.
 func (suite *PouchRunSuite) TearDownTest(c *check.C) {
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
 }
 
 // TestRun is to verify the correctness of run container with specified name.

--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -30,7 +30,6 @@ func (suite *PouchStartSuite) SetUpSuite(c *check.C) {
 
 // TearDownTest does cleanup work in the end of each test.
 func (suite *PouchStartSuite) TearDownTest(c *check.C) {
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
 }
 
 // TestStartCommand tests "pouch start" work.

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -27,7 +27,6 @@ func (suite *PouchStopSuite) SetUpSuite(c *check.C) {
 
 // TearDownTest does cleanup work in the end of each test.
 func (suite *PouchStopSuite) TearDownTest(c *check.C) {
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
 }
 
 // TestStopWorks tests "pouch stop" work.

--- a/test/cli_unpause_test.go
+++ b/test/cli_unpause_test.go
@@ -24,7 +24,6 @@ func (suite *PouchUnpauseSuite) SetUpSuite(c *check.C) {
 
 // TearDownTest does cleanup work in the end of each test.
 func (suite *PouchUnpauseSuite) TearDownTest(c *check.C) {
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
 }
 
 // TestStopWorks tests "pouch unpause" work.


### PR DESCRIPTION
Signed-off-by: letty <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Remove `PruneAllContainers` function in TearDownTest, as it has already been called in SetupTest.
We should not rely on this function to do all cleanup work.
And this function may be the reason why test cases panic.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #569 
**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


