### PR TITLE
test: ignore error in cleanup function

### DIFF
--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -22,7 +22,7 @@ func init() {
 func (suite *PouchCreateSuite) SetUpSuite(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
 
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+	environment.PruneAllContainers(apiClient)
 
 	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
 }

--- a/test/cli_exec_test.go
+++ b/test/cli_exec_test.go
@@ -20,7 +20,7 @@ func init() {
 func (suite *PouchExecSuite) SetUpSuite(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
 
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+	environment.PruneAllContainers(apiClient)
 
 	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
 }

--- a/test/cli_ps_test.go
+++ b/test/cli_ps_test.go
@@ -21,7 +21,7 @@ func init() {
 func (suite *PouchPsSuite) SetUpSuite(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
 
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+	environment.PruneAllContainers(apiClient)
 	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
 }
 

--- a/test/cli_pull_test.go
+++ b/test/cli_pull_test.go
@@ -20,7 +20,7 @@ func init() {
 func (suite *PouchPullSuite) SetUpSuite(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
 
-	c.Assert(environment.PruneAllImages(apiClient), check.IsNil)
+	environment.PruneAllContainers(apiClient)
 }
 
 // TearDownTest does cleanup work in the end of each test.

--- a/test/cli_rmi_test.go
+++ b/test/cli_rmi_test.go
@@ -19,7 +19,7 @@ func init() {
 // SetUpSuite does common setup in the beginning of each test suite.
 func (suite *PouchRmiSuite) SetUpSuite(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+	environment.PruneAllContainers(apiClient)
 }
 
 // TestRmiWorks tests "pouch rmi" work.

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -23,7 +23,7 @@ func init() {
 func (suite *PouchRunSuite) SetUpSuite(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
 
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+	environment.PruneAllContainers(apiClient)
 
 	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
 }

--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -23,7 +23,7 @@ func init() {
 func (suite *PouchStartSuite) SetUpSuite(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
 
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+	environment.PruneAllContainers(apiClient)
 
 	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
 }

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -20,7 +20,7 @@ func init() {
 func (suite *PouchStopSuite) SetUpSuite(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
 
-	c.Assert(environment.PruneAllContainers(apiClient), check.IsNil)
+	environment.PruneAllContainers(apiClient)
 
 	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
 }


### PR DESCRIPTION
Signed-off-by: letty <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
When call cleanup function in SetupTest, we could ignore the error.
As this is not the `test point`, if you really wanna test cleanup work, you could code it explicitly in Test cases.
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


