### PR TITLE
feature: sysctl configuration for both cri manager and container manager

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -61,6 +61,7 @@ func (cc *CreateCommand) addFlags() {
 	flagSet.StringVar(&cc.ipcMode, "ipc", "", "IPC namespace to use")
 	flagSet.StringVar(&cc.pidMode, "pid", "", "PID namespace to use")
 	flagSet.StringVar(&cc.utsMode, "uts", "", "UTS namespace to use")
+	flagSet.StringSliceVar(&cc.sysctls, "sysctl", nil, "Sysctl options")
 }
 
 // runCreate is the entry of create command.

--- a/cli/run.go
+++ b/cli/run.go
@@ -70,6 +70,7 @@ func (rc *RunCommand) addFlags() {
 	flagSet.StringVar(&rc.ipcMode, "ipc", "", "IPC namespace to use")
 	flagSet.StringVar(&rc.pidMode, "pid", "", "PID namespace to use")
 	flagSet.StringVar(&rc.utsMode, "uts", "", "UTS namespace to use")
+	flagSet.StringSliceVar(&rc.sysctls, "sysctl", nil, "Sysctl options")
 }
 
 // runRun is the entry of run command.

--- a/daemon/mgr/spec.go
+++ b/daemon/mgr/spec.go
@@ -49,6 +49,9 @@ var setupFunc = []SetupFunc{
 
 	// host device spec
 	setupDevices,
+
+	// linux-platform-specifc spec
+	setupSysctl,
 }
 
 // Register is used to registe spec setup function.

--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -1,0 +1,12 @@
+package mgr
+
+import (
+	"context"
+)
+
+// Setup linux-platform-sepecific specification.
+
+func setupSysctl(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) error {
+	spec.s.Linux.Sysctl = meta.HostConfig.Sysctls
+	return nil
+}

--- a/hack/cri-test/test-cri.sh
+++ b/hack/cri-test/test-cri.sh
@@ -23,7 +23,7 @@ POUCH_SOCK="/var/run/pouchcri.sock"
 
 # CRI_FOCUS focuses the test to run.
 # With the CRI manager completes its function, we may need to expand this field.
-CRI_FOCUS=${CRI_FOCUS:-"basic operations on PodSandbox|basic operations on container|runtime info"}
+CRI_FOCUS=${CRI_FOCUS:-"PodSandbox|basic operations on container|Runtime info"}
 
 # CRI_SKIP skips the test to skip.
 CRI_SKIP=${CRI_SKIP:-""}

--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -118,6 +118,27 @@ func (suite *PouchCreateSuite) TestCreateWithLabels(c *check.C) {
 	}
 }
 
+// TestCreateWithSysctls tries to test create a container with sysctls.
+func (suite *PouchCreateSuite) TestCreateWithSysctls(c *check.C) {
+	sysctl := "net.ipv4.ip_forward=1"
+	name := "create-sysctl"
+
+	res := command.PouchRun("create", "--name", name, "--sysctl", sysctl, busyboxImage)
+	res.Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", name).Stdout()
+
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result.HostConfig.Sysctls, check.NotNil)
+
+	if result.HostConfig.Sysctls["net.ipv4.ip_forward"] != "1" {
+		c.Errorf("failed to set sysctl: %s", sysctl)
+	}
+}
+
 // TestCreateEnableLxcfs tries to test create a container with lxcfs.
 func (suite *PouchCreateSuite) TestCreateEnableLxcfs(c *check.C) {
 	name := "create-lxcfs"

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -232,3 +232,19 @@ func (suite *PouchRunSuite) TestRunWithUTSMode(c *check.C) {
 	res.Assert(c, icmd.Success)
 	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
+
+// TestRunWithSysctls is to verify run container with sysctls.
+func (suite *PouchRunSuite) TestRunWithSysctls(c *check.C) {
+	sysctl := "net.ipv4.ip_forward=1"
+	name := "run-sysctl"
+
+	res := command.PouchRun("run", "--name", name, "--sysctl", sysctl, busyboxImage)
+	res.Assert(c, icmd.Success)
+
+	output := command.PouchRun("exec", name, "cat", "/proc/sys/net/ipv4/ip_forward").Stdout()
+	if !strings.Contains(output, "1") {
+		c.Fatalf("failed to run a container with sysctls: %s", output)
+	}
+
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
+}

--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -134,3 +134,19 @@ func (suite *PouchStartSuite) TestStartWithHostname(c *check.C) {
 
 	command.PouchRun("stop", name).Assert(c, icmd.Success)
 }
+
+// TestStartWithSysctls starts a container with sysctls.
+func (suite *PouchStartSuite) TestStartWithSysctls(c *check.C) {
+	sysctl := "net.ipv4.ip_forward=1"
+	name := "start-sysctl"
+
+	command.PouchRun("create", "--name", name, "--sysctl", sysctl, busyboxImage)
+
+	command.PouchRun("start", name).Assert(c, icmd.Success)
+	output := command.PouchRun("exec", name, "cat", "/proc/sys/net/ipv4/ip_forward").Stdout()
+	if !strings.Contains(output, "1") {
+		c.Errorf("failed to start a container with sysctls: %s", output)
+	}
+
+	command.PouchRun("stop", name).Assert(c, icmd.Success)
+}


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes part of #635 

**3.Describe how you did it**

**4.Describe how to verify it**

```
[root@pouch-test monster]# pouch run --sysctl kernel.shm_rmid_forced=1 docker.io/library/busybox:latest
[root@pouch-test monster]# pouch exec 7ee857 cat /proc/sys/kernel/shm_rmid_forced
1
```

**5.Special notes for reviews**


