### PR TITLE
feature: return empty if the image doesn't exist in CRI mananger and add "basic operations on container" into CI

### DIFF
--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -585,7 +585,9 @@ func (c *CriManager) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequ
 
 	imageInfo, err := c.ImageMgr.GetImage(ctx, ref.String())
 	if err != nil {
-		return nil, err
+		// TODO: seperate ErrImageNotFound with others.
+		// Now we just return empty if the error occured.
+		return &runtime.ImageStatusResponse{}, nil
 	}
 
 	image, err := imageToCriImage(imageInfo)
@@ -628,7 +630,9 @@ func (c *CriManager) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequ
 
 	imageInfo, err := c.ImageMgr.GetImage(ctx, ref.String())
 	if err != nil {
-		return nil, err
+		// TODO: seperate ErrImageNotFound with others.
+		// Now we just return empty if the error occured.
+		return &runtime.RemoveImageResponse{}, nil
 	}
 
 	err = c.ImageMgr.RemoveImage(ctx, imageInfo, &ImageRemoveOption{})

--- a/hack/cri-test/test-cri.sh
+++ b/hack/cri-test/test-cri.sh
@@ -23,7 +23,7 @@ POUCH_SOCK="/var/run/pouchcri.sock"
 
 # CRI_FOCUS focuses the test to run.
 # With the CRI manager completes its function, we may need to expand this field.
-CRI_FOCUS=${CRI_FOCUS:-"basic operations on PodSandbox|runtime info"}
+CRI_FOCUS=${CRI_FOCUS:-"basic operations on PodSandbox|basic operations on container|runtime info"}
 
 # CRI_SKIP skips the test to skip.
 CRI_SKIP=${CRI_SKIP:-""}


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

For method ImageRemove and ImageStatus, if the image doesn't exist, we should return an empty response instead of an error. Hmmm...., bugfix may be more appropriate for this PR 😄 

With this PR and #617 being merged, it is ok for us to add "basic operations on container" CRI test into CI.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


