### PR TITLE
fix: report error when creating a new network with an existent name

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -763,6 +763,10 @@ paths:
           description: "bad parameter"
           schema:
             $ref: "#/definitions/Error"
+        409:
+          description: "name already in use"
+          schema:
+            $ref: "#/definitions/Error"
         500:
           $ref: "#/responses/500ErrorResponse"
       parameters:

--- a/daemon/mgr/network.go
+++ b/daemon/mgr/network.go
@@ -86,6 +86,10 @@ func (nm *NetworkManager) Create(ctx context.Context, create apitypes.NetworkCre
 		return nil, errors.Wrap(err, "failed to build network's options")
 	}
 
+	if net, err := nm.controller.NetworkByName(name); err == nil && net != nil {
+		return nil, errors.Wrap(errtypes.ErrAlreadyExisted, fmt.Sprintf("network %s already exists", name))
+	}
+
 	net, err := nm.controller.NewNetwork(driver, name, id, nwOptions...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create network")

--- a/test/api_network_create.go
+++ b/test/api_network_create.go
@@ -37,6 +37,29 @@ func (suite *APINetworkCreateSuite) TestNetworkCreateOk(c *check.C) {
 	//DelNetworkOk(c, nname)
 }
 
+// TestNetworkCreateExistentName tests if creating network with an existent name returns error.
+func (suite *APINetworkCreateSuite) TestNetworkCreateExistentName(c *check.C) {
+	nname := "TestNetworkCreateExistentName"
+	obj := map[string]interface{}{
+		"Name":   nname,
+		"Driver": "bridge",
+	}
+
+	body := request.WithJSONBody(obj)
+	resp, err := request.Post("/networks/create", body)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 201)
+
+	resp, err = request.Post("/networks/create", body)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 409)
+
+	// delete network TestNetworkCreateExistentName
+	resp, err = request.Delete("/networks/" + "TestNetworkCreateExistentName")
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 204)
+}
+
 // TestNetworkCreateNilName tests creating network without name returns error.
 func (suite *APINetworkCreateSuite) TestNetworkCreateNilName(c *check.C) {
 	obj := map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**
Report error message when creating a new network with an existent name.
**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #662 
**3.Describe how you did it**
Before creating a new network, check if the network name exists.
**4.Describe how to verify it**
$ pouch network create net1
net1: b8d22aaa9db862f9f393eca9f4bdb45b12539b6352d417456bf4fd7774f3e2de
$ pouch network create net1
Error: {"message":"network net1 already exists"}

**5.Special notes for reviews**


