### PR TITLE
feature: appArmor for both cri manager and container manager

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -37,6 +37,7 @@ type container struct {
 	utsMode              string
 	sysctls              []string
 	network              []string
+	securityOpt          []string
 	blkioWeight          uint16
 	blkioWeightDevice    WeightDevice
 	blkioDeviceReadBps   ThrottleBpsDevice
@@ -114,6 +115,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 			PidMode:       c.pidMode,
 			UTSMode:       c.utsMode,
 			Sysctls:       sysctls,
+			SecurityOpt:   c.securityOpt,
 		},
 	}
 

--- a/cli/create.go
+++ b/cli/create.go
@@ -63,6 +63,7 @@ func (cc *CreateCommand) addFlags() {
 	flagSet.StringVar(&cc.utsMode, "uts", "", "UTS namespace to use")
 	flagSet.StringSliceVar(&cc.sysctls, "sysctl", nil, "Sysctl options")
 	flagSet.StringSliceVar(&cc.network, "net", nil, "Set networks to container")
+	flagSet.StringSliceVar(&cc.securityOpt, "security-opt", nil, "Security Options")
 	flagSet.Uint16Var(&cc.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable")
 	flagSet.Var(&cc.blkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
 	flagSet.Var(&cc.blkioDeviceReadBps, "device-read-bps", "Limit read rate (bytes per second) from a device")

--- a/cli/run.go
+++ b/cli/run.go
@@ -72,6 +72,7 @@ func (rc *RunCommand) addFlags() {
 	flagSet.StringVar(&rc.utsMode, "uts", "", "UTS namespace to use")
 	flagSet.StringSliceVar(&rc.sysctls, "sysctl", nil, "Sysctl options")
 	flagSet.StringSliceVar(&rc.network, "net", nil, "Set networks to container")
+	flagSet.StringSliceVar(&rc.securityOpt, "security-opt", nil, "Security Options")
 	flagSet.Uint16Var(&rc.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable")
 	flagSet.Var(&rc.blkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
 	flagSet.Var(&rc.blkioDeviceReadBps, "device-read-bps", "Limit read rate (bytes per second) from a device")

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -330,6 +330,10 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 		meta.Config.NetworkDisabled = true
 	}
 
+	if err := parseSecurityOpt(meta, config.HostConfig.SecurityOpt); err != nil {
+		return nil, err
+	}
+
 	// merge image's config into container's meta
 	if err := meta.merge(func() (v1.ImageConfig, error) {
 		ociimage, err := mgr.Client.GetOciImage(ctx, config.Image)
@@ -437,7 +441,8 @@ func (mgr *ContainerManager) Start(ctx context.Context, id, detachKeys string) (
 		c.meta.State.FinishedAt = time.Now().UTC().Format(utils.TimeLayout)
 		c.meta.State.Error = err.Error()
 		c.meta.State.Pid = 0
-		//TODO get and set exit code
+		//TODO: make exit code more correct.
+		c.meta.State.ExitCode = 127
 
 		// release io
 		io.Close()

--- a/daemon/mgr/container_utils.go
+++ b/daemon/mgr/container_utils.go
@@ -2,6 +2,7 @@ package mgr
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/alibaba/pouch/daemon/meta"
 	"github.com/alibaba/pouch/pkg/errtypes"
@@ -97,4 +98,23 @@ func (mgr *ContainerManager) generateName(id string) string {
 		}
 	}
 	return name
+}
+
+func parseSecurityOpt(meta *ContainerMeta, securityOpts []string) error {
+	for _, opt := range securityOpts {
+		fields := strings.SplitN(opt, "=", 2)
+		if len(fields) != 2 {
+			return fmt.Errorf("invalid --security-opt %q: it should be in format of key=value", opt)
+		}
+
+		switch fields[0] {
+		// TODO: handle other security options.
+		case "apparmor":
+			meta.AppArmorProfile = fields[1]
+		default:
+			return fmt.Errorf("invalid --security-opt %q: unknown type", opt)
+		}
+	}
+
+	return nil
 }

--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -270,9 +270,8 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 	createConfig := &apitypes.ContainerCreateConfig{
 		ContainerConfig: apitypes.ContainerConfig{
-			// TODO: wait for them to be fully supported.
-			// Entrypoint:		config.Command,
-			// Cmd:			config.Args,
+			// TODO: maybe we should ditinguish cmd and entrypoint more clearly.
+			Cmd:        config.Command,
 			Env:        generateEnvList(config.GetEnvs()),
 			Image:      image,
 			WorkingDir: config.WorkingDir,

--- a/daemon/mgr/spec.go
+++ b/daemon/mgr/spec.go
@@ -52,6 +52,8 @@ var setupFunc = []SetupFunc{
 
 	// linux-platform-specifc spec
 	setupSysctl,
+	setupAppArmor,
+
 	// blkio spec
 	setupBlkio,
 }

--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -2,11 +2,56 @@ package mgr
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
+)
+
+const (
+	// ProfileNamePrefix is the prefix for loading profiles on a localhost. Eg. localhost/profileName.
+	ProfileNamePrefix = "localhost/"
+	// ProfileRuntimeDefault indicates that we should use or create a runtime default profile.
+	ProfileRuntimeDefault = "runtime/default"
+	// ProfileNameUnconfined is a string indicating one should run a pod/containerd without a security profile.
+	ProfileNameUnconfined = "unconfined"
 )
 
 // Setup linux-platform-sepecific specification.
 
 func setupSysctl(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) error {
 	spec.s.Linux.Sysctl = meta.HostConfig.Sysctls
+	return nil
+}
+
+// isAppArmorEnabled returns true if apparmor is enabled for the host.
+// This function is forked from
+// https://github.com/opencontainers/runc/blob/1a81e9ab1f138c091fe5c86d0883f87716088527/libcontainer/apparmor/apparmor.go
+// to avoid the libapparmor dependency.
+func isAppArmorEnabled() bool {
+	if _, err := os.Stat("/sys/kernel/security/apparmor"); err == nil && os.Getenv("container") == "" {
+		if _, err = os.Stat("/sbin/apparmor_parser"); err == nil {
+			buf, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
+			return err == nil && len(buf) > 1 && buf[0] == 'Y'
+		}
+	}
+	return false
+}
+
+func setupAppArmor(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) error {
+	if !isAppArmorEnabled() {
+		// Return if the apparmor is disabled.
+		return nil
+	}
+
+	appArmorProfile := meta.AppArmorProfile
+	switch appArmorProfile {
+	case ProfileNameUnconfined:
+		return nil
+	case ProfileRuntimeDefault, "":
+		// TODO: handle runtime default case.
+		return nil
+	default:
+		spec.s.Process.ApparmorProfile = appArmorProfile
+	}
+
 	return nil
 }

--- a/hack/cri-test/test-cri.sh
+++ b/hack/cri-test/test-cri.sh
@@ -23,7 +23,7 @@ POUCH_SOCK="/var/run/pouchcri.sock"
 
 # CRI_FOCUS focuses the test to run.
 # With the CRI manager completes its function, we may need to expand this field.
-CRI_FOCUS=${CRI_FOCUS:-"PodSandbox|basic operations on container|Runtime info"}
+CRI_FOCUS=${CRI_FOCUS:-"PodSandbox|AppArmor|basic operations on container|Runtime info"}
 
 # CRI_SKIP skips the test to skip.
 CRI_SKIP=${CRI_SKIP:-""}

--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -139,6 +139,33 @@ func (suite *PouchCreateSuite) TestCreateWithSysctls(c *check.C) {
 	}
 }
 
+// TestCreateWithAppArmor tries to test create a container with security option AppArmor.
+func (suite *PouchCreateSuite) TestCreateWithAppArmor(c *check.C) {
+	appArmor := "apparmor=unconfined"
+	name := "create-apparmor"
+
+	res := command.PouchRun("create", "--name", name, "--security-opt", appArmor, busyboxImage)
+	res.Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", name).Stdout()
+
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result.HostConfig.SecurityOpt, check.NotNil)
+
+	exist := false
+	for _, opt := range result.HostConfig.SecurityOpt {
+		if opt == appArmor {
+			exist = true
+		}
+	}
+	if !exist {
+		c.Errorf("failed to set AppArmor in security-opt")
+	}
+}
+
 // TestCreateEnableLxcfs tries to test create a container with lxcfs.
 func (suite *PouchCreateSuite) TestCreateEnableLxcfs(c *check.C) {
 	name := "create-lxcfs"

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -245,6 +245,20 @@ func (suite *PouchRunSuite) TestRunWithSysctls(c *check.C) {
 	if !strings.Contains(output, "1") {
 		c.Fatalf("failed to run a container with sysctls: %s", output)
 	}
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
+}
+
+// TestRunWithAppArmor is to verify run container with security option AppArmor.
+func (suite *PouchRunSuite) TestRunWithAppArmor(c *check.C) {
+	appArmor := "apparmor=unconfined"
+	name := "run-apparmor"
+
+	res := command.PouchRun("run", "--name", name, "--security-opt", appArmor, busyboxImage)
+	res.Assert(c, icmd.Success)
+
+	// TODO: do the test more strictly with effective AppArmor profile.
+
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestRunWithBlkioWeight is to verify --specific Blkio Weight when running a container.

--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -150,3 +150,16 @@ func (suite *PouchStartSuite) TestStartWithSysctls(c *check.C) {
 
 	command.PouchRun("stop", name).Assert(c, icmd.Success)
 }
+
+// TestStartWithAppArmor starts a container with security option AppArmor.
+func (suite *PouchStartSuite) TestStartWithAppArmor(c *check.C) {
+	appArmor := "apparmor=unconfined"
+	name := "start-apparmor"
+
+	command.PouchRun("create", "--name", name, "--security-opt", appArmor, busyboxImage)
+	command.PouchRun("start", name).Assert(c, icmd.Success)
+
+	// TODO: do the test more strictly with effective AppArmor profile.
+
+	command.PouchRun("stop", name).Assert(c, icmd.Success)
+}


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

With this PR, we could enable one of the security option AppArmor.

Now we could apply AppArmor with options like:
1. "apparmor=unconfined": which means don't apply any AppArmor profile
2. "apparmor=XXX": which means apply AppArmor profile "XXX"
3. "apparmor=pouch-default": see below.

Actually in docker, we should apply default AppArmor profile "docker-default" to every container which not explicitly specify it or explicitly specify it with "docker-default". We should implement it in pouch as well.

**2.Does this pull request fix one issue?** 
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes part of #635 

**3.Describe how you did it**

**4.Describe how to verify it**

**5.Special notes for reviews**


