### PR TITLE
test: use CheckRespStatus(c, resp, code) to add comment when failure

### DIFF
--- a/test/api_image_create_test.go
+++ b/test/api_image_create_test.go
@@ -30,14 +30,14 @@ func (suite *APIImageCreateSuite) TestImageCreateOk(c *check.C) {
 	query := request.WithQuery(q)
 	resp, err := request.Post("/images/create", query)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	// TODO: add a waituntil func to check the exsitence of image
 	time.Sleep(5000 * time.Millisecond)
 
 	resp, err = request.Delete("/images/" + helloworldImage + ":latest")
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	CheckRespStatus(c, resp, 204)
 }
 
 // TestImageCreateNil tests fromImage is nil.
@@ -49,7 +49,7 @@ func (suite *APIImageCreateSuite) TestImageCreateNil(c *check.C) {
 
 	resp, err := request.Post("/images/create", query)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 400)
+	CheckRespStatus(c, resp, 400)
 }
 
 // TestImageCreateWithoutTag tests creating an image without tag, will use "latest" by default.
@@ -59,13 +59,13 @@ func (suite *APIImageCreateSuite) TestImageCreateWithoutTag(c *check.C) {
 	query := request.WithQuery(q)
 	resp, err := request.Post("/images/create", query)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	time.Sleep(5000 * time.Millisecond)
 
 	resp, err = request.Delete("/images/" + helloworldImage + ":latest")
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	CheckRespStatus(c, resp, 204)
 }
 
 // TestImageCreateWithoutRegistry tests creating an image only by name, will use "latest" by default.
@@ -75,11 +75,11 @@ func (suite *APIImageCreateSuite) TestImageCreateWithoutRegistry(c *check.C) {
 	query := request.WithQuery(q)
 	resp, err := request.Post("/images/create", query)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	time.Sleep(5000 * time.Millisecond)
 
 	resp, err = request.Delete("/images/" + helloworldImageOnlyRepoName + ":latest")
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	CheckRespStatus(c, resp, 204)
 }

--- a/test/api_image_delete_test.go
+++ b/test/api_image_delete_test.go
@@ -26,7 +26,7 @@ func (suite *APIImageDeleteSuite) TestDeleteNonExisting(c *check.C) {
 	img := "TestDeleteNonExisting"
 	resp, err := request.Delete("/images/" + img)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	CheckRespStatus(c, resp, 404)
 }
 
 // TestDeleteUsingImage tests deleting an image in use by running container will fail.
@@ -41,7 +41,7 @@ func (suite *APIImageDeleteSuite) TestDeleteUsingImage(c *check.C) {
 
 	resp, err := request.Delete("/images/" + busyboxImage)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 500)
+	CheckRespStatus(c, resp, 500)
 
 	DelContainerForceOk(c, cname)
 }

--- a/test/api_image_inspect_test.go
+++ b/test/api_image_inspect_test.go
@@ -24,7 +24,7 @@ func (suite *APIImageInspectSuite) SetUpTest(c *check.C) {
 func (suite *APIImageInspectSuite) TestImageInspectOk(c *check.C) {
 	resp, err := request.Get("/images/" + busyboxImage + "/json")
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	got := types.ImageInfo{}
 	err = request.DecodeBody(&got, resp.Body)
@@ -44,5 +44,5 @@ func (suite *APIImageInspectSuite) TestImageInspectOk(c *check.C) {
 func (suite *APIImageInspectSuite) TestImageInspectNotFound(c *check.C) {
 	resp, err := request.Get("/images/" + "TestImageInspectNotFound" + "/json")
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	CheckRespStatus(c, resp, 404)
 }

--- a/test/api_image_list_test.go
+++ b/test/api_image_list_test.go
@@ -25,7 +25,7 @@ func (suite *APIImageListSuite) SetUpTest(c *check.C) {
 func (suite *APIImageListSuite) TestImageListOk(c *check.C) {
 	resp, err := request.Get("/images/json")
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 }
 
 // TestImageListAll tests listing all images layers.
@@ -36,7 +36,7 @@ func (suite *APIImageListSuite) TestImageListAll(c *check.C) {
 
 	resp, err := request.Get("/images/json", query)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	// TODO: Add more check
 }
@@ -49,7 +49,7 @@ func (suite *APIImageListSuite) TestImageListDigest(c *check.C) {
 
 	resp, err := request.Get("/images/json", query)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 }
 
 // TestImageListFilter tests listing images with filter.

--- a/test/api_network_inspect_test.go
+++ b/test/api_network_inspect_test.go
@@ -31,19 +31,19 @@ func (suite *APINetworkInspectSuite) TestNetworkInspectOk(c *check.C) {
 	body := request.WithJSONBody(obj)
 	resp, err := request.Post(path, body)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	CheckRespStatus(c, resp, 201)
 
 	// Inspect the created network.
 	path = "/networks/" + net
 	resp, err = request.Get(path)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	// Delete the network.
 	path = "/networks/" + net
 	resp, err = request.Delete(path)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	CheckRespStatus(c, resp, 204)
 }
 
 // TestNetworkInspectNotExistent tests if inspecting non-existent network returns error.
@@ -53,5 +53,5 @@ func (suite *APINetworkInspectSuite) TestNetworkInspectNotExistent(c *check.C) {
 	path := "/networks/" + net
 	resp, err := request.Get(path)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	CheckRespStatus(c, resp, 404)
 }

--- a/test/api_network_list_test.go
+++ b/test/api_network_list_test.go
@@ -31,17 +31,17 @@ func (suite *APINetworkListSuite) TestNetworkListOk(c *check.C) {
 	body := request.WithJSONBody(obj)
 	resp, err := request.Post(path, body)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	CheckRespStatus(c, resp, 201)
 
 	// List the created network.
 	path = "/networks"
 	resp, err = request.Get(path)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	// Delete the network.
 	path = "/networks/" + net
 	resp, err = request.Delete(path)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	CheckRespStatus(c, resp, 204)
 }

--- a/test/api_system_test.go
+++ b/test/api_system_test.go
@@ -32,7 +32,7 @@ func (suite *APISystemSuite) TestInfo(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer resp.Body.Close()
 
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	got := types.SystemInfo{}
 	err = json.NewDecoder(resp.Body).Decode(&got)
@@ -49,7 +49,7 @@ func (suite *APISystemSuite) TestVersion(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer resp.Body.Close()
 
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	got := types.SystemVersion{}
 	err = json.NewDecoder(resp.Body).Decode(&got)

--- a/test/api_volume_create_test.go
+++ b/test/api_volume_create_test.go
@@ -32,10 +32,10 @@ func (suite *APIVolumeCreateSuite) TestVolumeCreateOk(c *check.C) {
 	body := request.WithJSONBody(obj)
 	resp, err := request.Post(path, body)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	CheckRespStatus(c, resp, 201)
 
 	path = "/volumes/" + vol
 	resp, err = request.Delete(path)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	CheckRespStatus(c, resp, 204)
 }

--- a/test/api_volume_delete_test.go
+++ b/test/api_volume_delete_test.go
@@ -24,5 +24,5 @@ func (suite *APIVolumeDeleteSuite) TestDeleteNonExisting(c *check.C) {
 	vol := "TestDeleteNonExisting"
 	resp, err := request.Delete("/volumes/" + vol)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	CheckRespStatus(c, resp, 404)
 }

--- a/test/api_volume_inspect_test.go
+++ b/test/api_volume_inspect_test.go
@@ -31,19 +31,19 @@ func (suite *APIVolumeInspectSuite) TestVolumeInspectOk(c *check.C) {
 	body := request.WithJSONBody(obj)
 	resp, err := request.Post(path, body)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 201)
+	CheckRespStatus(c, resp, 201)
 
 	// Test volume inspect feature.
 	path = "/volumes/" + vol
 	resp, err = request.Get(path)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	// Delete the volume.
 	path = "/volumes/" + vol
 	resp, err = request.Delete(path)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 204)
+	CheckRespStatus(c, resp, 204)
 }
 
 // TestVolumeInspectNotFound tests if inspecting a nonexistent volume returns error.
@@ -53,6 +53,6 @@ func (suite *APIVolumeInspectSuite) TestVolumeInspectNotFound(c *check.C) {
 	path := "/volumes/" + vol
 	resp, err := request.Get(path)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 404)
+	CheckRespStatus(c, resp, 404)
 
 }

--- a/test/api_volume_list_test.go
+++ b/test/api_volume_list_test.go
@@ -34,7 +34,7 @@ func (suite *APIVolumeListSuite) TestVolumeListOk(c *check.C) {
 	path := "/volumes"
 	resp, err := request.Get(path)
 	c.Assert(err, check.IsNil)
-	c.Assert(resp.StatusCode, check.Equals, 200)
+	CheckRespStatus(c, resp, 200)
 
 	// Check list result.
 	volumeListResp := &types.VolumeListResp{}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

**1.Describe what this PR did**

In issue https://github.com/alibaba/pouch/issues/673, we found that some integration test fails without showing any error message, I think it is very unreasonable for us to debug and bugfix.

So, I think we need to use `CheckRespStatus(c, resp, code )` to check status code and should error if this checking failed.

However, we still have one potential issue:
```
// CheckRespStatus checks the http.Response.Status is equal to status.
func CheckRespStatus(c *check.C, resp *http.Response, status int) {
	if resp.StatusCode != status {
		got := types.Error{}
		_ = request.DecodeBody(&got, resp.Body)
		c.Assert(resp.StatusCode, check.Equals, status, check.Commentf("Error:%s", got.Message))
	}
}

In the code above if we assert CheckRespStatus(c, resp, 500), we mean error is supposed. But if the actual status code is 200, then the message is not so readable. But it is OK, I think.
```

**2.Does this pull request fix one issue?** 
related to #673 to find more test failure cases.

**3.Describe how you did it**
None

**4.Describe how to verify it**
None

**5.Special notes for reviews**
/cc @Letty5411 


