### PR TITLE
feature: add alios container extra options

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1375,7 +1375,6 @@ definitions:
       CpuCount:
         description: |
           The number of usable CPUs (Windows only).
-
           On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last.
         type: "integer"
         format: "int64"
@@ -1393,6 +1392,29 @@ definitions:
         description: "Maximum IO in bytes per second for the container system drive (Windows only)"
         type: "integer"
         format: "uint64"
+      IntelRdtL3Cbm:
+        description: "IntelRdtL3Cbm specifies settings for Intel RDT/CAT group that the container is placed into to limit the resources (e.g., L3 cache) the container has available."
+        type: "string"
+
+      # applicable to AliKenerl 4.9
+      ScheLatSwitch:
+        description: "ScheLatSwitch enables scheduler latency count in cpuacct"
+        type: "integer"
+        format: "int64"
+      MemoryWmarkRatio:
+        description: | 
+          MemoryWmarkRatio is an integer value representing this container's memory low water mark percentage. 
+          The value of memory low water mark is memory.limit_in_bytes * MemoryWmarkRatio.
+        type: "integer"
+        format: "int64"
+      MemoryExtra:
+        description: "MemoryExtra is an integer value representing this container's memory high water mark percentage."
+        type: "integer"
+        format: "int64"
+      MemoryForceEmptyCtl:
+        description: "MemoryForceEmptyCtl represents whether to reclaim the page cache when deleting cgroup."
+        type: "integer"
+        format: "int64"
 
   ThrottleDevice:
     type: "object"

--- a/apis/types/resources.go
+++ b/apis/types/resources.go
@@ -49,7 +49,6 @@ type Resources struct {
 	CgroupParent string `json:"CgroupParent,omitempty"`
 
 	// The number of usable CPUs (Windows only).
-	//
 	// On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last.
 	//
 	CPUCount int64 `json:"CpuCount,omitempty"`
@@ -99,11 +98,20 @@ type Resources struct {
 	// Maximum IOps for the container system drive (Windows only)
 	IOMaximumIOps uint64 `json:"IOMaximumIOps,omitempty"`
 
+	// IntelRdtL3Cbm specifies settings for Intel RDT/CAT group that the container is placed into to limit the resources (e.g., L3 cache) the container has available.
+	IntelRdtL3Cbm string `json:"IntelRdtL3Cbm,omitempty"`
+
 	// Kernel memory limit in bytes.
 	KernelMemory int64 `json:"KernelMemory,omitempty"`
 
 	// Memory limit in bytes.
 	Memory int64 `json:"Memory,omitempty"`
+
+	// MemoryExtra is an integer value representing this container's memory high water mark percentage.
+	MemoryExtra int64 `json:"MemoryExtra,omitempty"`
+
+	// MemoryForceEmptyCtl represents whether to reclaim the page cache when deleting cgroup.
+	MemoryForceEmptyCtl int64 `json:"MemoryForceEmptyCtl,omitempty"`
 
 	// Memory soft limit in bytes.
 	MemoryReservation int64 `json:"MemoryReservation,omitempty"`
@@ -116,6 +124,11 @@ type Resources struct {
 	// Minimum: 0
 	MemorySwappiness *int64 `json:"MemorySwappiness,omitempty"`
 
+	// MemoryWmarkRatio is an integer value representing this container's memory low water mark percentage.
+	// The value of memory low water mark is memory.limit_in_bytes * MemoryWmarkRatio.
+	//
+	MemoryWmarkRatio int64 `json:"MemoryWmarkRatio,omitempty"`
+
 	// CPU quota in units of 10<sup>-9</sup> CPUs.
 	NanoCpus int64 `json:"NanoCPUs,omitempty"`
 
@@ -125,6 +138,9 @@ type Resources struct {
 	// Tune a container's pids limit. Set -1 for unlimited. Only on Linux 4.4 does this paramter support.
 	//
 	PidsLimit int64 `json:"PidsLimit,omitempty"`
+
+	// ScheLatSwitch enables scheduler latency count in cpuacct
+	ScheLatSwitch int64 `json:"ScheLatSwitch,omitempty"`
 
 	// A list of resource limits to set in the container. For example: `{"Name": "nofile", "Soft": 1024, "Hard": 2048}`"
 	//
@@ -173,9 +189,15 @@ type Resources struct {
 
 /* polymorph Resources IOMaximumIOps false */
 
+/* polymorph Resources IntelRdtL3Cbm false */
+
 /* polymorph Resources KernelMemory false */
 
 /* polymorph Resources Memory false */
+
+/* polymorph Resources MemoryExtra false */
+
+/* polymorph Resources MemoryForceEmptyCtl false */
 
 /* polymorph Resources MemoryReservation false */
 
@@ -183,11 +205,15 @@ type Resources struct {
 
 /* polymorph Resources MemorySwappiness false */
 
+/* polymorph Resources MemoryWmarkRatio false */
+
 /* polymorph Resources NanoCPUs false */
 
 /* polymorph Resources OomKillDisable false */
 
 /* polymorph Resources PidsLimit false */
+
+/* polymorph Resources ScheLatSwitch false */
 
 /* polymorph Resources Ulimits false */
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

**1.Describe what this PR did**

In Pouch, we support more useful container options on isolation. This helps a lot when Pouch comes to production environment in enterprises.

Here we add 5 container options there, 1 is going to support in runC, while the other 4 is supported in the coming opensourced alios.

IntelRdtL3Cbm is coming in RunC.

ScheLatSwitch
MemoryWmarkRatio
MemoryExtra
MemoryForceEmptyCtl

are from alios, they are all about per memcg background reclaim.

For these option, we will go on to support them in alibaba/runc. And we will make effort in supporting these in upstream.

**2.Does this pull request fix one issue?** 
NONE

**3.Describe how you did it**
NONE

**4.Describe how to verify it**
NONE

**5.Special notes for reviews**
NONE


