### PR TITLE
feature: privilege mode for both cri manager and container manager

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -31,6 +31,7 @@ type container struct {
 	memorySwappiness     int64
 	devices              []string
 	enableLxcfs          bool
+	privileged           bool
 	restartPolicy        string
 	ipcMode              string
 	pidMode              string
@@ -133,6 +134,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 				BlkioDeviceWriteIOps: c.blkioDeviceWriteIOps.value(),
 			},
 			EnableLxcfs:   c.enableLxcfs,
+			Privileged:    c.privileged,
 			RestartPolicy: restartPolicy,
 			IpcMode:       c.ipcMode,
 			PidMode:       c.pidMode,

--- a/cli/create.go
+++ b/cli/create.go
@@ -57,6 +57,7 @@ func (cc *CreateCommand) addFlags() {
 	flagSet.StringVar(&cc.memorySwap, "memory-swap", "", "Container swap limit")
 	flagSet.StringSliceVarP(&cc.devices, "device", "", nil, "Add a host device to the container")
 	flagSet.BoolVar(&cc.enableLxcfs, "enableLxcfs", false, "Enable lxcfs")
+	flagSet.BoolVar(&cc.privileged, "privileged", false, "Give extended privileges to the container")
 	flagSet.StringVar(&cc.restartPolicy, "restart", "", "Restart policy to apply when container exits")
 	flagSet.StringVar(&cc.ipcMode, "ipc", "", "IPC namespace to use")
 	flagSet.StringVar(&cc.pidMode, "pid", "", "PID namespace to use")

--- a/cli/run.go
+++ b/cli/run.go
@@ -66,6 +66,7 @@ func (rc *RunCommand) addFlags() {
 	flagSet.StringVar(&rc.memorySwap, "memory-swap", "", "Container swap limit")
 	flagSet.StringSliceVarP(&rc.devices, "device", "", nil, "Add a host device to the container")
 	flagSet.BoolVar(&rc.enableLxcfs, "enableLxcfs", false, "Enable lxcfs")
+	flagSet.BoolVar(&rc.privileged, "privileged", false, "Give extended privileges to the container")
 	flagSet.StringVar(&rc.restartPolicy, "restart", "", "Restart policy to apply when container exits")
 	flagSet.StringVar(&rc.ipcMode, "ipc", "", "IPC namespace to use")
 	flagSet.StringVar(&rc.pidMode, "pid", "", "PID namespace to use")

--- a/daemon/mgr/cri_utils.go
+++ b/daemon/mgr/cri_utils.go
@@ -301,6 +301,7 @@ func modifyHostConfig(sc *runtime.LinuxContainerSecurityContext, hostConfig *api
 	// TODO: apply other security options.
 
 	// Apply capability options.
+	hostConfig.Privileged = sc.Privileged
 	if sc.GetCapabilities() != nil {
 		hostConfig.CapAdd = sc.GetCapabilities().GetAddCapabilities()
 		hostConfig.CapDrop = sc.GetCapabilities().GetDropCapabilities()

--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -48,8 +48,15 @@ func setupAppArmor(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) 
 	switch appArmorProfile {
 	case ProfileNameUnconfined:
 		return nil
-	case ProfileRuntimeDefault, "":
+	case ProfileRuntimeDefault:
 		// TODO: handle runtime default case.
+		return nil
+	case "":
+		if meta.HostConfig.Privileged {
+			return nil
+		}
+		// TODO: if user does not specify the AppArmor and the container is not in privilege mode,
+		// we need to specify it as default case, handle it later.
 		return nil
 	default:
 		spec.s.Process.ApparmorProfile = appArmorProfile

--- a/hack/cri-test/test-cri.sh
+++ b/hack/cri-test/test-cri.sh
@@ -23,7 +23,7 @@ POUCH_SOCK="/var/run/pouchcri.sock"
 
 # CRI_FOCUS focuses the test to run.
 # With the CRI manager completes its function, we may need to expand this field.
-CRI_FOCUS=${CRI_FOCUS:-"PodSandbox|AppArmor|basic operations on container|Runtime info"}
+CRI_FOCUS=${CRI_FOCUS:-"PodSandbox|AppArmor|Privileged is true|basic operations on container|Runtime info"}
 
 # CRI_SKIP skips the test to skip.
 CRI_SKIP=${CRI_SKIP:-""}

--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -193,6 +193,22 @@ func (suite *PouchCreateSuite) TestCreateWithCapability(c *check.C) {
 	}
 }
 
+// TestCreateWithPrivilege tries to test create a container with privilege.
+func (suite *PouchCreateSuite) TestCreateWithPrivilege(c *check.C) {
+	name := "create-privilege"
+
+	res := command.PouchRun("create", "--name", name, "--privileged", busyboxImage, "brctl", "addbr", "foobar")
+	res.Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", name).Stdout()
+
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result.HostConfig.Privileged, check.Equals, true)
+}
+
 // TestCreateEnableLxcfs tries to test create a container with lxcfs.
 func (suite *PouchCreateSuite) TestCreateEnableLxcfs(c *check.C) {
 	name := "create-lxcfs"

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -271,6 +271,15 @@ func (suite *PouchRunSuite) TestRunWithCapability(c *check.C) {
 	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
+// TestRunWithPrivilege is to verify run container with privilege.
+func (suite *PouchRunSuite) TestRunWithPrivilege(c *check.C) {
+	name := "run-privilege"
+
+	res := command.PouchRun("run", "--name", name, "--privileged", busyboxImage, "brctl", "addbr", "foobar")
+	res.Assert(c, icmd.Success)
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
+}
+
 // TestRunWithBlkioWeight is to verify --specific Blkio Weight when running a container.
 func (suite *PouchRunSuite) TestRunWithBlkioWeight(c *check.C) {
 	name := "test-run-with-blkio-weight"

--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -173,3 +173,12 @@ func (suite *PouchStartSuite) TestStartWithCapability(c *check.C) {
 	res.Assert(c, icmd.Success)
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 }
+
+// TestStartWithPrivilege starts a container with privilege.
+func (suite *PouchStartSuite) TestStartWithPrivilege(c *check.C) {
+	name := "start-privilege"
+
+	res := command.PouchRun("create", "--name", name, "--privileged", busyboxImage, "brctl", "addbr", "foobar")
+	res.Assert(c, icmd.Success)
+	command.PouchRun("start", name).Assert(c, icmd.Success)
+}


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

If the container is in privilege mode, it will have the full access to the host.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes part of #635 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it

```
root@pouch-ubuntu:/gopath/src/github.com/alibaba/pouch# pouch run busybox:1.26 brctl addbr foobar
brctl: bridge foobar: Operation not permitted
root@pouch-ubuntu:/gopath/src/github.com/alibaba/pouch# pouch run --privileged busybox:1.26 brctl addbr foobar
root@pouch-ubuntu:/gopath/src/github.com/alibaba/pouch# 
```


### Ⅴ. Special notes for reviews

As the development move on, we should consider if the container is in privilege mode in more places.

