### PR TITLE
feature: InspectExec method of Container manager to get the result of exec

### DIFF
--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/ctrd"
 	"github.com/alibaba/pouch/daemon/meta"
 	"github.com/alibaba/pouch/pkg/utils"
 
@@ -27,6 +28,15 @@ type containerExecConfig struct {
 
 	// Save the container's id into exec config.
 	ContainerID string
+
+	// Get exit message from exitCh, we could only get it once.
+	// Do we need to get the result of exec many times?
+	exitCh chan *ctrd.Message
+}
+
+// ContainerExecInspect holds low-level information about exec command.
+type ContainerExecInspect struct {
+	ExitCh chan *ctrd.Message
 }
 
 // AttachConfig wraps some infos of attaching.


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Now the caller can't get the status (such as exitCode, exitTime, etc) of exec process which caused 
great trouble for us to pass many CRI related test cases.

With this PR, the problem described above is gone.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it

Maybe the [cri-tools](https://github.com/kubernetes-incubator/cri-tools) is what you need.

We may use the following method to verify that we can create and start container in sandbox:
```
// Now we must ensure the sandbox image has already exists.
[root@pouch-test cri-tools]# pouch pull k8s.gcr.io/pause-amd64:3.0
[root@pouch-test cri-tools]# cat sandbox-config.json
{
    "metadata": {
        "name": "nginx-sandbox",
        "namespace": "default",
        "attempt": 1,
        "uid": "hdishd83djaidwnduwk28bcsb"
    },
    "linux": {
    }
}
[root@pouch-test cri-tools]# crictl runs sandbox-config.json
008cc69c9c9c8e9c4d78aa8d6c528e21ab26affdc64748f631fb5dcb59963216
[root@pouch-test cri-tools]# cat container-config.json 
{
  "metadata": {
      "name": "busybox"
  },
  "image":{
      "image": "docker.io/library/busybox:latest"
  },
  "command": [
      "top"
  ],
  "linux": {
  }
}
[root@pouch-test cri-tools]# crictl create 008cc69c9c9c8e9c4d78aa8d6c528e21ab26affdc64748f631fb5dcb59963216 container-config.json sandbox-config.json
3530bbb414ccce09ba52fbdf781df53b881661720f05d92edf8820280abf064d
[root@pouch-test cri-tools]# crictl start 3530bbb414ccce09ba52fbdf781df53b881661720f05d92edf8820280abf064d
[root@pouch-test cri-tools]# pouch ps
Name                                                            ID       Status    Image                              Runtime   Created
k8s_busybox_nginx-sandbox_default_hdishd83djaidwnduwk28bcsb_0   3530bb   running   docker.io/library/busybox:latest   runc      4 seconds ago
k8s_POD_nginx-sandbox_default_hdishd83djaidwnduwk28bcsb_1       008cc6   running   k8s.gcr.io/pause-amd64:3.0         runc      1 minute ago
[root@pouch-test cri-tools]# crictl exec -s 3530bbb414ccce09ba52fbdf781df53b881661720f05d92edf8820280abf064d brctl addbr abc
brctl: bridge abc: Operation not permitted
Exit code: 1
[root@pouch-test cri-tools]# 
```



### Ⅴ. Special notes for reviews


