### PR TITLE
feature: add repoTags and repoDigests

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -99,7 +99,7 @@ func (s *Server) removeImage(ctx context.Context, rw http.ResponseWriter, req *h
 	}
 
 	containers, err := s.ContainerMgr.List(ctx, func(meta *mgr.ContainerMeta) bool {
-		return meta.Image == image.Name
+		return meta.Image == image.ID
 	}, &mgr.ContainerListOption{All: true})
 	if err != nil {
 		return err
@@ -107,14 +107,14 @@ func (s *Server) removeImage(ctx context.Context, rw http.ResponseWriter, req *h
 
 	isForce := httputils.BoolValue(req, "force")
 	if !isForce && len(containers) > 0 {
-		return fmt.Errorf("Unable to remove the image %q (must force) - container %s is using this image", image.Name, containers[0].ID)
+		return fmt.Errorf("Unable to remove the image %q (must force) - container %s is using this image", image.ID, containers[0].ID)
 	}
 
 	option := &mgr.ImageRemoveOption{
 		Force: isForce,
 	}
 
-	if err := s.ImageMgr.RemoveImage(ctx, image, option); err != nil {
+	if err := s.ImageMgr.RemoveImage(ctx, image, name, option); err != nil {
 		return err
 	}
 

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2382,15 +2382,16 @@ definitions:
         description: "ID of an image."
         type: "string"
         x-nullable: false
-      Name:
-        description: "name of an image."
-        type: "string"
-      Tag:
-        description: "tag of an image."
-        type: "string"
-      Digest:
-        description: "digest of image."
-        type: "string"
+      RepoTags:
+        description: "repository with tag."
+        type: "array"
+        items:
+          type: "string"
+      RepoDigests:
+        description: "repository with digest."
+        type: "array"
+        items:
+          type: "string"
       CreatedAt:
         description: "time of image creation."
         type: "string"

--- a/apis/types/image_info.go
+++ b/apis/types/image_info.go
@@ -27,26 +27,23 @@ type ImageInfo struct {
 	// time of image creation.
 	CreatedAt string `json:"CreatedAt,omitempty"`
 
-	// digest of image.
-	Digest string `json:"Digest,omitempty"`
-
 	// ID of an image.
 	ID string `json:"ID,omitempty"`
 
-	// name of an image.
-	Name string `json:"Name,omitempty"`
-
 	// the name of the operating system.
 	Os string `json:"Os,omitempty"`
+
+	// repository with digest.
+	RepoDigests []string `json:"RepoDigests"`
+
+	// repository with tag.
+	RepoTags []string `json:"RepoTags"`
 
 	// root f s
 	RootFS *ImageInfoRootFS `json:"RootFS,omitempty"`
 
 	// size of image's taking disk space.
 	Size int64 `json:"Size,omitempty"`
-
-	// tag of an image.
-	Tag string `json:"Tag,omitempty"`
 }
 
 /* polymorph ImageInfo Architecture false */
@@ -55,25 +52,33 @@ type ImageInfo struct {
 
 /* polymorph ImageInfo CreatedAt false */
 
-/* polymorph ImageInfo Digest false */
-
 /* polymorph ImageInfo ID false */
 
-/* polymorph ImageInfo Name false */
-
 /* polymorph ImageInfo Os false */
+
+/* polymorph ImageInfo RepoDigests false */
+
+/* polymorph ImageInfo RepoTags false */
 
 /* polymorph ImageInfo RootFS false */
 
 /* polymorph ImageInfo Size false */
-
-/* polymorph ImageInfo Tag false */
 
 // Validate validates this image info
 func (m *ImageInfo) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateConfig(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateRepoDigests(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateRepoTags(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -103,6 +108,24 @@ func (m *ImageInfo) validateConfig(formats strfmt.Registry) error {
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *ImageInfo) validateRepoDigests(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.RepoDigests) { // not required
+		return nil
+	}
+
+	return nil
+}
+
+func (m *ImageInfo) validateRepoTags(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.RepoTags) { // not required
+		return nil
 	}
 
 	return nil

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/opencontainers/image-spec/specs-go/v1"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -344,7 +344,15 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 	if err != nil {
 		return nil, err
 	}
-	config.Image = image.Name
+
+	// FIXME: image.Name does not exist,so convert Repotags or RepoDigests to ref
+	ref := ""
+	if len(image.RepoTags) > 0 {
+		ref = image.RepoTags[0]
+	} else {
+		ref = image.RepoDigests[0]
+	}
+	config.Image = ref
 
 	// set container runtime
 	if config.HostConfig.Runtime == "" {
@@ -372,7 +380,7 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 			Status: types.StatusCreated,
 		},
 		ID:         id,
-		Image:      image.Name,
+		Image:      image.ID,
 		Name:       name,
 		Config:     &config.ContainerConfig,
 		Created:    time.Now().UTC().Format(utils.TimeLayout),
@@ -767,8 +775,15 @@ func (mgr *ContainerManager) Update(ctx context.Context, name string, config *ty
 			return err
 		}
 		// TODO Image param is duplicate in ContainerMeta
-		c.meta.Config.Image = image.Name
-		c.meta.Image = image.Name
+		// FIXME: image.Name does not exist,so convert Repotags or RepoDigests to ref
+		ref := ""
+		if len(image.RepoTags) > 0 {
+			ref = image.RepoTags[0]
+		} else {
+			ref = image.RepoDigests[0]
+		}
+		c.meta.Config.Image = ref
+		c.meta.Image = ref
 	}
 
 	if len(config.Env) != 0 {

--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	apitypes "github.com/alibaba/pouch/apis/types"
@@ -748,7 +749,7 @@ func (c *CriManager) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequ
 		return nil, err
 	}
 
-	imageInfo, err := c.ImageMgr.GetImage(ctx, ref.String())
+	imageInfo, err := c.ImageMgr.GetImage(ctx, strings.TrimPrefix(ref.String(), "sha256:"))
 	if err != nil {
 		// TODO: seperate ErrImageNotFound with others.
 		// Now we just return empty if the error occured.
@@ -795,14 +796,14 @@ func (c *CriManager) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequ
 		return nil, err
 	}
 
-	imageInfo, err := c.ImageMgr.GetImage(ctx, ref.String())
+	imageInfo, err := c.ImageMgr.GetImage(ctx, strings.TrimPrefix(ref.String(), "sha256:"))
 	if err != nil {
 		// TODO: seperate ErrImageNotFound with others.
 		// Now we just return empty if the error occured.
 		return &runtime.RemoveImageResponse{}, nil
 	}
 
-	err = c.ImageMgr.RemoveImage(ctx, imageInfo, &ImageRemoveOption{})
+	err = c.ImageMgr.RemoveImage(ctx, imageInfo, strings.TrimPrefix(ref.String(), "sha256:"), &ImageRemoveOption{})
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/mgr/cri_utils.go
+++ b/daemon/mgr/cri_utils.go
@@ -663,12 +663,6 @@ func containerNetns(container *ContainerMeta) string {
 
 // imageToCriImage converts pouch image API to CRI image API.
 func imageToCriImage(image *apitypes.ImageInfo) (*runtime.Image, error) {
-	namedRef, err := reference.ParseNamedReference(image.Name)
-	if err != nil {
-		return nil, err
-	}
-	taggedRef := reference.WithDefaultTagIfMissing(namedRef).(reference.Tagged)
-
 	uid := &runtime.Int64Value{}
 	imageUID, username := getUserFromImageUser(image.Config.User)
 	if imageUID != nil {
@@ -678,9 +672,9 @@ func imageToCriImage(image *apitypes.ImageInfo) (*runtime.Image, error) {
 	size := uint64(image.Size)
 	// TODO: improve type ImageInfo to include RepoTags and RepoDigests.
 	return &runtime.Image{
-		Id:          image.Digest,
-		RepoTags:    []string{taggedRef.String()},
-		RepoDigests: []string{fmt.Sprintf("%s@%s", taggedRef.Name(), image.Digest)},
+		Id:          image.ID,
+		RepoTags:    image.RepoTags,
+		RepoDigests: image.RepoDigests,
 		Size_:       size,
 		Uid:         uid,
 		Username:    username,

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -34,7 +34,7 @@ type ImageMgr interface {
 	GetImage(ctx context.Context, idOrRef string) (*types.ImageInfo, error)
 
 	// RemoveImage deletes an image by reference.
-	RemoveImage(ctx context.Context, image *types.ImageInfo, option *ImageRemoveOption) error
+	RemoveImage(ctx context.Context, image *types.ImageInfo, name string, option *ImageRemoveOption) error
 }
 
 // ImageManager is an implementation of interface ImageMgr.
@@ -128,14 +128,37 @@ func (mgr *ImageManager) GetImage(ctx context.Context, idOrRef string) (*types.I
 }
 
 // RemoveImage deletes an image by reference.
-func (mgr *ImageManager) RemoveImage(ctx context.Context, image *types.ImageInfo, option *ImageRemoveOption) error {
-	if err := mgr.client.RemoveImage(ctx, image.Name); err != nil {
+func (mgr *ImageManager) RemoveImage(ctx context.Context, image *types.ImageInfo, name string, option *ImageRemoveOption) error {
+	// name is image ID
+	if strings.HasPrefix(strings.TrimPrefix(image.ID, "sha256:"), name) {
+		refs := mgr.cache.getIDToRefs(image.ID)
+		for _, ref := range refs {
+			if err := mgr.client.RemoveImage(ctx, ref); err != nil {
+				return err
+			}
+		}
+		mgr.cache.remove(image)
+		return nil
+	}
+
+	// name is tagged or digest
+	name = mgr.addRegistry(name)
+	refNamed, err := reference.ParseNamedReference(name)
+	if err != nil {
 		return err
 	}
 
-	// image has been deleted, delete from image cache too.
-	mgr.cache.remove(image)
+	var ref string
+	if refDigest, ok := refNamed.(reference.Digested); ok {
+		ref = refDigest.String()
+	} else if refTagged, ok := reference.WithDefaultTagIfMissing(refNamed).(reference.Tagged); ok {
+		ref = refTagged.String()
+	}
 
+	if err := mgr.client.RemoveImage(ctx, ref); err != nil {
+		return err
+	}
+	mgr.cache.untagged(ref)
 	return nil
 }
 
@@ -155,14 +178,20 @@ func (mgr *ImageManager) loadImages() error {
 
 type imageCache struct {
 	sync.Mutex
-	refs map[string]*types.ImageInfo // store the mapping ref to image.
-	ids  *patricia.Trie              // store the mapping id to image.
+	ids         *patricia.Trie             // store the mapping id to image.
+	idToTags    map[string]map[string]bool // store repoTags by id, the repoTag is ref if bool is true.
+	idToDigests map[string]map[string]bool // store repoDigests by id, the repoDigest is ref if bool is true.
+	refToID     map[string]string          // store refs by id.
+	tagToDigest map[string]string          // store the mapping repoTag to repoDigest.
 }
 
 func newImageCache() *imageCache {
 	return &imageCache{
-		refs: make(map[string]*types.ImageInfo),
-		ids:  patricia.NewTrie(),
+		ids:         patricia.NewTrie(),
+		idToTags:    make(map[string]map[string]bool),
+		idToDigests: make(map[string]map[string]bool),
+		refToID:     make(map[string]string),
+		tagToDigest: make(map[string]string),
 	}
 }
 
@@ -171,10 +200,62 @@ func (c *imageCache) put(image *types.ImageInfo) {
 	defer c.Unlock()
 
 	id := strings.TrimPrefix(image.ID, "sha256:")
-	ref := image.Name
 
-	c.refs[ref] = image
-	c.ids.Insert(patricia.Prefix(id), image)
+	repoDigests := image.RepoDigests
+	repoTags := image.RepoTags
+
+	if len(repoTags) > 0 {
+		for _, repoTag := range repoTags {
+			if len(c.idToTags[id]) == 0 {
+				tag := make(map[string]bool)
+				tag[repoTag] = true
+				c.idToTags[id] = tag
+			} else {
+				c.idToTags[id][repoTag] = true
+			}
+
+			if len(c.idToDigests[id]) == 0 {
+				digest := make(map[string]bool)
+				digest[repoDigests[0]] = false
+				c.idToDigests[id] = digest
+			} else {
+				c.idToDigests[id][repoDigests[0]] = false
+			}
+
+			c.tagToDigest[repoTag] = repoDigests[0]
+			c.refToID[repoTag] = id
+		}
+	} else {
+		if len(c.idToDigests[id]) == 0 {
+			digest := make(map[string]bool)
+			digest[repoDigests[0]] = true
+			c.idToDigests[id] = digest
+		} else {
+			c.idToDigests[id][repoDigests[0]] = true
+		}
+
+		c.refToID[repoDigests[0]] = id
+	}
+
+	// get repoTags and repoDigest from idToTags and idToDigests
+	if item := c.ids.Get(patricia.Prefix(id)); item != nil {
+		repoTags := []string{}
+		repoDigests := []string{}
+		for tag := range c.idToTags[id] {
+			repoTags = append(repoTags, tag)
+		}
+		for digest := range c.idToDigests[id] {
+			repoDigests = append(repoDigests, digest)
+		}
+
+		if img, ok := item.(*types.ImageInfo); ok {
+			img.RepoTags = repoTags
+			img.RepoDigests = repoDigests
+			c.ids.Set(patricia.Prefix(id), img)
+		}
+	} else {
+		c.ids.Insert(patricia.Prefix(id), image)
+	}
 }
 
 func (c *imageCache) get(idOrRef string) (*types.ImageInfo, error) {
@@ -182,18 +263,24 @@ func (c *imageCache) get(idOrRef string) (*types.ImageInfo, error) {
 	defer c.Unlock()
 
 	// use reference to parse idOrRef and add default tag if missing
-	ref, err := reference.ParseNamedReference(idOrRef)
+	refNamed, err := reference.ParseNamedReference(idOrRef)
 	if err != nil {
 		return nil, err
 	}
-	ref = reference.WithDefaultTagIfMissing(ref)
 
-	image, ok := c.refs[ref.String()]
-	if ok {
-		return image, nil
+	var id string
+	if refDigest, ok := refNamed.(reference.Digested); ok {
+		id = c.refToID[refDigest.String()]
+	} else {
+		refTagged := reference.WithDefaultTagIfMissing(refNamed).(reference.Tagged)
+		if len(c.refToID[refTagged.String()]) == 0 {
+			id = idOrRef
+		} else {
+			id = c.refToID[refTagged.String()]
+		}
 	}
 
-	// use trie to fetch image if the idOrRef is the image ID
+	// use trie to fetch image
 	var images []*types.ImageInfo
 
 	fn := func(prefix patricia.Prefix, item patricia.Item) error {
@@ -203,15 +290,15 @@ func (c *imageCache) get(idOrRef string) (*types.ImageInfo, error) {
 		return nil
 	}
 
-	if err := c.ids.VisitSubtree(patricia.Prefix(idOrRef), fn); err != nil {
+	if err := c.ids.VisitSubtree(patricia.Prefix(id), fn); err != nil {
 		// the error does not occur.
 		return nil, err
 	}
 
 	if len(images) > 1 {
-		return nil, errors.Wrap(errtypes.ErrTooMany, "image: "+idOrRef)
+		return nil, errors.Wrap(errtypes.ErrTooMany, "image: "+id)
 	} else if len(images) == 0 {
-		return nil, errors.Wrap(errtypes.ErrNotfound, "image: "+idOrRef)
+		return nil, errors.Wrap(errtypes.ErrNotfound, "image: "+id)
 	}
 
 	return images[0], nil
@@ -222,8 +309,73 @@ func (c *imageCache) remove(image *types.ImageInfo) {
 	defer c.Unlock()
 
 	id := strings.TrimPrefix(image.ID, "sha256:")
-	ref := image.Name
 
-	delete(c.refs, ref)
+	for _, v := range image.RepoTags {
+		delete(c.refToID, v)
+		delete(c.tagToDigest, v)
+	}
+	for _, v := range image.RepoDigests {
+		delete(c.refToID, v)
+	}
+	delete(c.idToTags, id)
+	delete(c.idToDigests, id)
+
 	c.ids.Delete(patricia.Prefix(id))
+}
+
+// untagged is used to remove the deleted repoTag or repoDigest from image.
+func (c *imageCache) untagged(ref string) {
+	c.Lock()
+	defer c.Unlock()
+
+	id := c.refToID[ref]
+	delete(c.idToTags[id], ref)
+	delete(c.idToDigests[id], c.tagToDigest[ref])
+	delete(c.refToID, ref)
+	delete(c.refToID, c.tagToDigest[ref])
+	delete(c.tagToDigest, ref)
+
+	if len(c.idToTags[id]) == 0 && len(c.idToDigests[id]) == 0 {
+		c.ids.Delete(patricia.Prefix(id))
+		return
+	}
+
+	// get repoTags and repoDigest from idToTags and idToDigests
+	if item := c.ids.Get(patricia.Prefix(id)); item != nil {
+		repoTags := []string{}
+		repoDigests := []string{}
+		for tag := range c.idToTags[id] {
+			repoTags = append(repoTags, tag)
+		}
+		for digest := range c.idToDigests[id] {
+			repoDigests = append(repoDigests, digest)
+		}
+
+		if img, ok := item.(*types.ImageInfo); ok {
+			img.RepoTags = repoTags
+			img.RepoDigests = repoDigests
+			c.ids.Set(patricia.Prefix(id), img)
+		}
+	}
+}
+
+// getIDToRefs returns refs stored by ID index.
+func (c *imageCache) getIDToRefs(id string) []string {
+	c.Lock()
+	defer c.Unlock()
+
+	refs := []string{}
+	id = strings.TrimPrefix(id, "sha256:")
+	for tag, v := range c.idToTags[id] {
+		if v {
+			refs = append(refs, tag)
+		}
+	}
+	for digest, v := range c.idToDigests[id] {
+		if v {
+			refs = append(refs, digest)
+		}
+	}
+
+	return refs
 }

--- a/daemon/mgr/image_test.go
+++ b/daemon/mgr/image_test.go
@@ -9,29 +9,29 @@ import (
 func TestImageCache(t *testing.T) {
 	images := []types.ImageInfo{
 		{
-			Digest: "sha256:dc5f67a48da730d67bf4bfb8824ea8a51be26711de090d6d5a1ffff2723168a3",
-			Name:   "docker.io/library/nginx:alpine",
-			ID:     "dc5f67a48da7",
+			RepoDigests: []string{"docker.io/library/nginx@sha256:dc5f67a48da730d67bf4bfb8824ea8a51be26711de090d6d5a1ffff2723168a3"},
+			RepoTags:    []string{"docker.io/library/nginx:alpine"},
+			ID:          "sha256:dc5f67a48da730d67bf4bfb8824ea8a51be26711de090d6d5a1ffff2723168a3",
 		},
 		{
-			Digest: "sha256:2075ac87b043415d35bb6351b4a59df19b8ad154e578f7048335feeb02d0f759",
-			Name:   "reg.docker.alibaba-inc.com/base/hello-world:latest",
-			ID:     "2075ac87b043",
+			RepoDigests: []string{"reg.docker.alibaba-inc.com/base/hello-world@sha256:2075ac87b043415d35bb6351b4a59df19b8ad154e578f7048335feeb02d0f759"},
+			RepoTags:    []string{"reg.docker.alibaba-inc.com/base/hello-world:latest"},
+			ID:          "sha256:2075ac87b043415d35bb6351b4a59df19b8ad154e578f7048335feeb02d0f759",
 		},
 		{
-			Digest: "sha256:ded83fbb30d5fad804784215bc454c3844653cb0a907a512d44e25429507e415",
-			Name:   "reg.docker.alibaba-inc.com/busybox:latest",
-			ID:     "ded83fbb30d5",
+			RepoDigests: []string{"reg.docker.alibaba-inc.com/base/hello-world@sha256:ded83fbb30d5fad804784215bc454c3844653cb0a907a512d44e25429507e415s"},
+			RepoTags:    []string{"reg.docker.alibaba-inc.com/busybox:latest"},
+			ID:          "sha256:ded83fbb30d5fad804784215bc454c3844653cb0a907a512d44e25429507e415s",
 		},
 		{
-			Digest: "sha256:6591a3cb89fec995f299fa52c65e56aa33c779fd965060cf3b7759cd4b346aac",
-			Name:   "reg.docker.alibaba-inc.com/fedora:21",
-			ID:     "6591a3cb89fe",
+			RepoDigests: []string{"reg.docker.alibaba-inc.com/base/hello-world@sha256:6591a3cb89fec995f299fa52c65e56aa33c779fd965060cf3b7759cd4b346aac"},
+			RepoTags:    []string{"reg.docker.alibaba-inc.com/fedora:21"},
+			ID:          "sha256:6591a3cb89fec995f299fa52c65e56aa33c779fd965060cf3b7759cd4b346aac",
 		},
 		{
-			Digest: "sha256:03b17f82af79a338571410df9b26670c160175eda81d6e9fd62e3fda6b728928",
-			Name:   "reg.docker.alibaba-inc.com/mysql:5.6.23",
-			ID:     "03b17f82af79",
+			RepoDigests: []string{"reg.docker.alibaba-inc.com/base/hello-world@sha256:03b17f82af79a338571410df9b26670c160175eda81d6e9fd62e3fda6b728928"},
+			RepoTags:    []string{"reg.docker.alibaba-inc.com/mysql:5.6.23"},
+			ID:          "sha256:03b17f82af79a338571410df9b26670c160175eda81d6e9fd62e3fda6b728928",
 		},
 	}
 
@@ -43,32 +43,32 @@ func TestImageCache(t *testing.T) {
 
 	if i, err := cache.get("dc5f67a48da7"); err != nil {
 		t.Fatal(err)
-	} else if i.Name != "docker.io/library/nginx:alpine" {
-		t.Errorf("get error: %s", i.Name)
+	} else if i.RepoTags[0] != "docker.io/library/nginx:alpine" {
+		t.Errorf("get error: %s", i.RepoTags[0])
 	}
 
 	if i, err := cache.get("ded83fbb30d5"); err != nil {
 		t.Fatal(err)
-	} else if i.Name != "reg.docker.alibaba-inc.com/busybox:latest" {
-		t.Errorf("get error: %s", i.Name)
+	} else if i.RepoTags[0] != "reg.docker.alibaba-inc.com/busybox:latest" {
+		t.Errorf("get error: %s", i.RepoTags[0])
 	}
 
 	if i, err := cache.get("reg.docker.alibaba-inc.com/mysql:5.6.23"); err != nil {
 		t.Fatal(err)
-	} else if i.Name != "reg.docker.alibaba-inc.com/mysql:5.6.23" {
-		t.Errorf("get error: %s", i.Name)
+	} else if i.RepoTags[0] != "reg.docker.alibaba-inc.com/mysql:5.6.23" {
+		t.Errorf("get error: %s", i.RepoTags[0])
 	}
 
 	cache.remove(&types.ImageInfo{
-		Digest: "sha256:03b17f82af79a338571410df9b26670c160175eda81d6e9fd62e3fda6b728928",
-		Name:   "reg.docker.alibaba-inc.com/mysql:5.6.23",
-		ID:     "03b17f82af79",
+		RepoDigests: []string{"reg.docker.alibaba-inc.com/mysql@sha256:03b17f82af79a338571410df9b26670c160175eda81d6e9fd62e3fda6b728928"},
+		RepoTags:    []string{"reg.docker.alibaba-inc.com/mysql:5.6.23"},
+		ID:          "sha256:03b17f82af79a338571410df9b26670c160175eda81d6e9fd62e3fda6b728928",
 	})
 
 	if i, err := cache.get("reg.docker.alibaba-inc.com/mysql:5.6.23"); err == nil {
-		t.Errorf("remove failed: %s", i.Name)
+		t.Errorf("remove failed: %s", i.RepoTags[0])
 	}
 	if i, err := cache.get("03b17f82af79"); err == nil {
-		t.Errorf("remove failed: %s", i.Name)
+		t.Errorf("remove failed: %s", i.RepoTags[0])
 	}
 }

--- a/pkg/reference/def.go
+++ b/pkg/reference/def.go
@@ -19,7 +19,7 @@ type Tagged interface {
 
 // Digested is an object which is digest.
 type Digested interface {
-	Reference
+	Named
 	Digest() string
 }
 
@@ -51,12 +51,15 @@ func (t taggedReference) String() string {
 }
 
 // taggedReference represents the image digest information.
-type digestReference string
+type digestReference struct {
+	Named
+	digest string
+}
 
 func (d digestReference) String() string {
-	return string(d)
+	return d.Name() + "@" + d.digest
 }
 
 func (d digestReference) Digest() string {
-	return string(d)
+	return d.digest
 }

--- a/pkg/reference/parse.go
+++ b/pkg/reference/parse.go
@@ -3,8 +3,6 @@ package reference
 import (
 	"errors"
 	"strings"
-
-	digest "github.com/opencontainers/go-digest"
 )
 
 var (
@@ -17,10 +15,6 @@ var (
 
 // Parse parses ref into Reference.
 func Parse(ref string) (Reference, error) {
-	if _, err := digest.Parse(ref); err == nil {
-		return digestReference(ref), nil
-	}
-
 	return ParseNamedReference(ref)
 }
 
@@ -28,6 +22,16 @@ func Parse(ref string) (Reference, error) {
 func ParseNamedReference(ref string) (Named, error) {
 	if ok := regRef.MatchString(ref); !ok {
 		return nil, ErrInvalid
+	}
+
+	// if ref contains digest information
+	if loc := regDigest.FindStringIndex(ref); loc != nil {
+		name, digest := ref[:loc[0]], ref[loc[0]+1:]
+
+		return digestReference{
+			Named:  namedReference{name},
+			digest: digest,
+		}, nil
 	}
 
 	// if ref contains tag information

--- a/pkg/reference/parse_test.go
+++ b/pkg/reference/parse_test.go
@@ -120,10 +120,13 @@ func TestParse(t *testing.T) {
 			},
 			err: nil,
 		}, {
-			name:     "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
-			input:    "sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc",
-			expected: digestReference("sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc"),
-			err:      nil,
+			name:  "Digest",
+			input: "registry.hub.docker.com/library/busybox@sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac75b7083da748db",
+			expected: digestReference{
+				Named:  namedReference{"registry.hub.docker.com/library/busybox"},
+				digest: "sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac75b7083da748db",
+			},
+			err: nil,
 		},
 	} {
 		ref, err := Parse(tc.input)

--- a/pkg/reference/regexp.go
+++ b/pkg/reference/regexp.go
@@ -30,6 +30,8 @@ var (
 		zeroOrMore(expression("/"), regComponent))
 
 	regTag = expression(`:\w[\w.-]*$`)
+
+	regDigest = expression(`@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`)
 )
 
 // expression converts literal into regexp.

--- a/test/api_image_inspect_test.go
+++ b/test/api_image_inspect_test.go
@@ -34,13 +34,14 @@ func (suite *APIImageInspectSuite) TestImageInspectOk(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// TODO: More specific check is needed
+	repoTag := got.RepoTags[0]
+	repoDigest := got.RepoDigests[0]
 	c.Assert(got.Config, check.NotNil)
-	c.Assert(got.Name, check.Equals, busyboxImage)
 	c.Assert(got.ID, check.NotNil)
 	c.Assert(got.CreatedAt, check.NotNil)
-	c.Assert(got.Digest, check.Matches, "sha256.*")
+	c.Assert(repoTag, check.Equals, busyboxImage)
 	c.Assert(got.Size, check.NotNil)
-	c.Assert(got.Tag, check.Equals, "latest")
+	c.Assert(repoDigest, check.Matches, ".*sha256.*")
 }
 
 // TestImageInspectNotFound tests inspecting non-existing images.

--- a/test/cli_images_test.go
+++ b/test/cli_images_test.go
@@ -60,7 +60,7 @@ func (suite *PouchImagesSuite) TestImagesWorks(c *check.C) {
 	{
 		res := command.PouchRun("images", "--digest").Assert(c, icmd.Success)
 		items := imagesListToKV(res.Combined())[busyboxImage]
-		c.Assert(items[2], check.Equals, image.Digest)
+		c.Assert(items[2], check.Equals, strings.TrimPrefix(image.RepoDigests[0], "registry.hub.docker.com/library/busybox@"))
 	}
 }
 
@@ -90,7 +90,7 @@ func getImageInfo(apiClient client.ImageAPIClient, name string) (types.ImageInfo
 	}
 
 	for _, img := range images {
-		if img.Name == name {
+		if img.RepoTags[0] == name {
 			return img, nil
 		}
 	}
@@ -106,8 +106,8 @@ func (suite *PouchImagesSuite) TestInspectImage(c *check.C) {
 	}
 
 	// inspect image name
-	output = command.PouchRun("image", "inspect", "-f", "{{.Name}}", busyboxImage).Stdout()
-	c.Assert(output, check.Equals, fmt.Sprintf("%s\n", busyboxImage))
+	output = command.PouchRun("image", "inspect", "-f", "{{.RepoTags}}", busyboxImage).Stdout()
+	c.Assert(output, check.Equals, fmt.Sprintf("[%s]\n", busyboxImage))
 }
 
 // TestLoginAndLogout is to test login and logout command

--- a/test/environment/cleanup.go
+++ b/test/environment/cleanup.go
@@ -18,8 +18,8 @@ func PruneAllImages(apiClient client.ImageAPIClient) error {
 
 	for _, img := range images {
 		// force to remove the image
-		if err := apiClient.ImageRemove(ctx, img.Name, true); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("fail to remove image (%s)", img.Name))
+		if err := apiClient.ImageRemove(ctx, img.ID, true); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("fail to remove image (%s)", img.ID))
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: zeppp <zeppp1995@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
To keep consistency with Moby and implement cri methods, we need add repoTags and repoDigests fields to ImageInfo and remove the name field in ImageInfo correspondingly.

### Ⅱ. Does this pull request fix one issue?
fixes part of #696

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
```
-># pouch images
IMAGE ID       IMAGE NAME                                       SIZE
dc8983e47a67   registry.hub.docker.com/library/busybox:1        710.74 KB
dc8983e47a67   registry.hub.docker.com/library/busybox:latest   710.74 KB

-># pouch image inspect dc
{
  "Architecture": "amd64",
  "Config": {
    "Cmd": [
      "sh"
    ],
    "Entrypoint": null,
    "Env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ],
    "Image": "",
    "OnBuild": null,
    "Shell": null
  },
  "CreatedAt": "2018-01-24T04:29:35.590938514Z",
  "ID": "sha256:dc8983e47a67c2a095134a70afacd8716093fb3fe54e229bdf4155d8db08020c",
  "Os": "linux",
  "RepoDigests": [
    "registry.hub.docker.com/library/busybox@sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac75b7083da748db"
  ],
  "RepoTags": [
    "registry.hub.docker.com/library/busybox:latest",
    "registry.hub.docker.com/library/busybox:1"
  ],
  "RootFS": {
    "Layers": [
      "sha256:4febd3792a1fb2153108b4fa50161c6ee5e3d16aa483a63215f936a113a88e9a"
    ],
    "Type": "layers"
  },
  "Size": 727793
}

-># pouch image inspect
busybox@sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac75b7083da748db
{
  "Architecture": "amd64",
  "Config": {
    "Cmd": [
      "sh"
    ],
    "Entrypoint": null,
    "Env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ],
    "Image": "",
    "OnBuild": null,
    "Shell": null
  },
  "CreatedAt": "2018-01-24T04:29:35.590938514Z",
  "ID": "sha256:dc8983e47a67c2a095134a70afacd8716093fb3fe54e229bdf4155d8db08020c",
  "Os": "linux",
  "RepoDigests": [
    "registry.hub.docker.com/library/busybox@sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac75b7083da748db"
  ],
  "RepoTags": [
    "registry.hub.docker.com/library/busybox:latest",
    "registry.hub.docker.com/library/busybox:1"
  ],
  "RootFS": {
    "Layers": [
      "sha256:4febd3792a1fb2153108b4fa50161c6ee5e3d16aa483a63215f936a113a88e9a"
    ],
    "Type": "layers"
  },
  "Size": 727793
}

-># pouch rmi busybox
busybox
root@ubuntu:/home/zeppp# pouch image inspect dc
{
  "Architecture": "amd64",
  "Config": {
    "Cmd": [
      "sh"
    ],
    "Entrypoint": null,
    "Env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ],
    "Image": "",
    "OnBuild": null,
    "Shell": null
  },
  "CreatedAt": "2018-01-24T04:29:35.590938514Z",
  "ID": "sha256:dc8983e47a67c2a095134a70afacd8716093fb3fe54e229bdf4155d8db08020c",
  "Os": "linux",
  "RepoDigests": [],
  "RepoTags": [
    "registry.hub.docker.com/library/busybox:1"
  ],
  "RootFS": {
    "Layers": [
      "sha256:4febd3792a1fb2153108b4fa50161c6ee5e3d16aa483a63215f936a113a88e9a"
    ],
    "Type": "layers"
  },
  "Size": 727793
}

-># pouch images
IMAGE ID       IMAGE NAME                                  SIZE
dc8983e47a67   registry.hub.docker.com/library/busybox:1   710.74 KB

-># pouch rmi busybox:1
busybox:1

-># pouch images
IMAGE ID   IMAGE NAME   SIZE

-># critest -f image validation
Ran 6 of 58 Specs in 25.816 seconds
FAIL! -- 5 Passed | 1 Failed | 0 Pending | 52 Skipped --- FAIL: TestE2ECRI (25.82s)

```

### Ⅴ. Special notes for reviews
This feature takes many changes, so I think we need to discuss the feature implementation to keep quality.
And, please do not merge this.
PTAL @allencloud , if you agree this design, i will move on. 

