### PR TITLE
feature: user configuration for cri manager

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -22,6 +22,7 @@ type container struct {
 	env                  []string
 	entrypoint           string
 	workdir              string
+	user                 string
 	hostname             string
 	cpushare             int64
 	cpusetcpus           string
@@ -120,6 +121,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 			Env:        c.env,
 			Entrypoint: strings.Fields(c.entrypoint),
 			WorkingDir: c.workdir,
+			User:       c.user,
 			Hostname:   strfmt.Hostname(c.hostname),
 			Labels:     labels,
 		},

--- a/cli/create.go
+++ b/cli/create.go
@@ -47,6 +47,7 @@ func (cc *CreateCommand) addFlags() {
 	flagSet.StringSliceVarP(&cc.labels, "label", "l", nil, "Set label for a container")
 	flagSet.StringVar(&cc.entrypoint, "entrypoint", "", "Overwrite the default entrypoint")
 	flagSet.StringVarP(&cc.workdir, "workdir", "w", "", "Set the working directory in a container")
+	flagSet.StringVarP(&cc.user, "user", "u", "", "UID")
 	flagSet.StringVar(&cc.hostname, "hostname", "", "Set container's hostname")
 	flagSet.Int64Var(&cc.cpushare, "cpu-share", 0, "CPU shares")
 	flagSet.StringVar(&cc.cpusetcpus, "cpuset-cpus", "", "CPUs in cpuset")

--- a/cli/run.go
+++ b/cli/run.go
@@ -54,6 +54,7 @@ func (rc *RunCommand) addFlags() {
 	flagSet.StringSliceVarP(&rc.labels, "label", "l", nil, "Set label for a container")
 	flagSet.StringVar(&rc.entrypoint, "entrypoint", "", "Overwrite the default entrypoint")
 	flagSet.StringVarP(&rc.workdir, "workdir", "w", "", "Set the working directory in a container")
+	flagSet.StringVarP(&rc.user, "user", "u", "", "UID")
 	flagSet.BoolVarP(&rc.detach, "detach", "d", false, "Run container in background and print container ID")
 	flagSet.StringVar(&rc.hostname, "hostname", "", "Set container's hostname")
 	flagSet.Int64Var(&rc.cpushare, "cpu-share", 0, "CPU shares")

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -253,6 +253,9 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, confi
 		Cwd:      "/",
 		Env:      c.Config().Env,
 	}
+	if len(execConfig.User) == 0 {
+		setupProcessUser(ctx, c.meta, &SpecWrapper{s: &specs.Spec{Process: process}})
+	}
 
 	return mgr.Client.ExecContainer(ctx, &ctrd.Process{
 		ContainerID: execConfig.ContainerID,

--- a/daemon/mgr/cri_utils.go
+++ b/daemon/mgr/cri_utils.go
@@ -372,8 +372,23 @@ func modifyHostConfig(sc *runtime.LinuxContainerSecurityContext, hostConfig *api
 	return nil
 }
 
+// modifyContainerConfig applies container security context config to pouch's Config.
+func modifyContainerConfig(sc *runtime.LinuxContainerSecurityContext, config *apitypes.ContainerConfig) {
+	if sc == nil {
+		return
+	}
+	if sc.RunAsUser != nil {
+		config.User = strconv.FormatInt(sc.GetRunAsUser().Value, 10)
+	}
+	if sc.RunAsUsername != "" {
+		config.User = sc.RunAsUsername
+	}
+}
+
 // applyContainerSecurityContext updates pouch container options according to security context.
 func applyContainerSecurityContext(lc *runtime.LinuxContainerConfig, podSandboxID string, config *apitypes.ContainerConfig, hc *apitypes.HostConfig) error {
+	modifyContainerConfig(lc.SecurityContext, config)
+
 	err := modifyHostConfig(lc.SecurityContext, hc)
 	if err != nil {
 		return err

--- a/hack/cri-test/test-cri.sh
+++ b/hack/cri-test/test-cri.sh
@@ -23,10 +23,10 @@ POUCH_SOCK="/var/run/pouchcri.sock"
 
 # CRI_FOCUS focuses the test to run.
 # With the CRI manager completes its function, we may need to expand this field.
-CRI_FOCUS=${CRI_FOCUS:-"PodSandbox|AppArmor|Privileged is true|basic operations on container|Runtime info|mount propagation|volume and device"}
+CRI_FOCUS=${CRI_FOCUS:-"PodSandbox|AppArmor|Privileged is true|basic operations on container|Runtime info|mount propagation|volume and device|RunAsUser"}
 
 # CRI_SKIP skips the test to skip.
-CRI_SKIP=${CRI_SKIP:-""}
+CRI_SKIP=${CRI_SKIP:-"RunAsUserName"}
 # REPORT_DIR is the the directory to store test logs.
 REPORT_DIR=${REPORT_DIR:-"/tmp/test-cri"}
 

--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -312,3 +312,20 @@ func (suite *PouchCreateSuite) TestCreateWithWorkDir(c *check.C) {
 
 	// TODO: check the work directory has been created.
 }
+
+// TestCreateWithUser tests creating container with user works.
+func (suite *PouchCreateSuite) TestCreateWithUser(c *check.C) {
+	name := "TestCreateWithUser"
+	user := "1001"
+
+	res := command.PouchRun("create", "--name", name, "--user", user, busyboxImage)
+	res.Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", name).Stdout()
+
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result.Config.User, check.Equals, user)
+}

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -266,6 +266,21 @@ func (suite *PouchRunSuite) TestRunWithSysctls(c *check.C) {
 	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
+// TestRunWithUser is to verify run container with user.
+func (suite *PouchRunSuite) TestRunWithUser(c *check.C) {
+	user := "1001"
+	name := "run-user"
+
+	res := command.PouchRun("run", "--name", name, "--user", user, busyboxImage)
+	res.Assert(c, icmd.Success)
+
+	output := command.PouchRun("exec", name, "id", "-u").Stdout()
+	if !strings.Contains(output, user) {
+		c.Fatalf("failed to run a container with user: %s", output)
+	}
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
+}
+
 // TestRunWithAppArmor is to verify run container with security option AppArmor.
 func (suite *PouchRunSuite) TestRunWithAppArmor(c *check.C) {
 	appArmor := "apparmor=unconfined"

--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -119,6 +119,18 @@ func (suite *PouchStartSuite) TestStartWithWorkDir(c *check.C) {
 	}
 }
 
+// TestStartWithUser starts a container with user.
+func (suite *PouchStartSuite) TestStartWithUser(c *check.C) {
+	name := "start-user"
+	user := "1001"
+
+	command.PouchRun("create", "--name", name, "--user", user, busyboxImage, "id", "-u")
+	output := command.PouchRun("start", "-a", name).Stdout()
+	if !strings.Contains(output, user) {
+		c.Errorf("failed to start a container with user: %s", output)
+	}
+}
+
 // TestStartWithHostname starts a container with hostname.
 func (suite *PouchStartSuite) TestStartWithHostname(c *check.C) {
 	name := "start-hostname"


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Actually the user option is so complicated in docker, it could be in format as follows:
"" | "user" | "uid" | "user:group" | "uid:gid" | "user:gid" | "uid:group"

Hmmm... It is hard to implement all of them in a short time.

With this PR, you could only specify user option with "uid", but in most cases, it is enough 😄 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes part of #635 


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


