### PR TITLE
test: add unit test cases for safe map in pkg

### DIFF
--- a/pkg/collect/safe_map.go
+++ b/pkg/collect/safe_map.go
@@ -8,14 +8,14 @@ type SafeMap struct {
 	inner map[string]interface{}
 }
 
-// NewSafeMap generate a instance of SafeMap type.
+// NewSafeMap generates a instance of SafeMap type.
 func NewSafeMap() *SafeMap {
 	return &SafeMap{
 		inner: make(map[string]interface{}, 16),
 	}
 }
 
-// Get return a value from inner map safely.
+// Get returns a value from inner map safely.
 func (m *SafeMap) Get(k string) *Value {
 	m.RLock()
 	defer m.RUnlock()
@@ -25,7 +25,7 @@ func (m *SafeMap) Get(k string) *Value {
 	return &Value{v, ok}
 }
 
-// Put store a key-value pair into inner map safely.
+// Put stores a key-value pair into inner map safely.
 func (m *SafeMap) Put(k string, v interface{}) {
 	m.Lock()
 	defer m.Unlock()
@@ -45,44 +45,56 @@ type Value struct {
 	ok   bool
 }
 
-// Result return the origin data and status in map.
+// Result returns the origin data and status in map.
 func (v *Value) Result() (interface{}, bool) {
 	return v.data, v.ok
 }
 
-// Exist return the data exist in map or not.
+// Exist returns the data exist in map or not.
 func (v *Value) Exist() bool {
 	return v.ok
 }
 
-// String return data as string.
+// String returns data as string.
 func (v *Value) String() (string, bool) {
 	if !v.ok || v.data == nil {
 		return "", v.ok
 	}
-	return v.data.(string), v.ok
+	if result, ok := v.data.(string); ok {
+		return result, ok
+	}
+	return "", false
 }
 
-// Int return data as int.
+// Int returns data as int.
 func (v *Value) Int() (int, bool) {
 	if !v.ok || v.data == nil {
 		return 0, v.ok
 	}
-	return v.data.(int), v.ok
+	if result, ok := v.data.(int); ok {
+		return result, ok
+	}
+	return 0, false
 }
 
-// Int32 return data as int32.
+// Int32 returns data as int32.
 func (v *Value) Int32() (int32, bool) {
 	if !v.ok || v.data == nil {
 		return 0, v.ok
 	}
-	return v.data.(int32), v.ok
+	if result, ok := v.data.(int32); ok {
+		return result, ok
+	}
+	return 0, false
 }
 
-// Int64 return data as int64.
+// Int64 returns data as int64.
 func (v *Value) Int64() (int64, bool) {
 	if !v.ok || v.data == nil {
 		return 0, v.ok
 	}
-	return v.data.(int64), v.ok
+	if result, ok := v.data.(int64); ok {
+		return result, ok
+	}
+	return 0, false
 }

--- a/pkg/collect/safe_map_test.go
+++ b/pkg/collect/safe_map_test.go
@@ -1,0 +1,329 @@
+package collect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeMapPutAndGet(t *testing.T) {
+	safeMap := NewSafeMap()
+	assert.Equal(t, len(safeMap.inner), 0)
+
+	safeMap.Put("key", "value")
+	assert.Equal(t, len(safeMap.inner), 1)
+
+	value := safeMap.Get("key")
+	assert.Equal(t, len(safeMap.inner), 1)
+	assert.Equal(t, value.ok, true)
+	assert.Equal(t, value.data, "value")
+
+	// there is no key named non-exist
+	value = safeMap.Get("non-exist")
+	assert.Equal(t, len(safeMap.inner), 1)
+	assert.Equal(t, value.ok, false)
+	assert.Equal(t, value.data, nil)
+
+	// get key twice
+	value = safeMap.Get("key")
+	assert.Equal(t, len(safeMap.inner), 1)
+	assert.Equal(t, value.ok, true)
+	assert.Equal(t, value.data, "value")
+
+	// put the same key with a new value
+	safeMap.Put("key", "value2")
+	assert.Equal(t, len(safeMap.inner), 1)
+
+	// get key twice, and be supposed to get new value
+	value = safeMap.Get("key")
+	assert.Equal(t, len(safeMap.inner), 1)
+	assert.Equal(t, value.ok, true)
+	assert.Equal(t, value.data, "value2")
+
+	// put new keys with new value
+	safeMap.Put("key2", []string{"asdfgh", "123344"})
+	assert.Equal(t, len(safeMap.inner), 2)
+
+	value = safeMap.Get("key2")
+	assert.Equal(t, len(safeMap.inner), 2)
+	assert.Equal(t, value.ok, true)
+	assert.Equal(t, value.data, []string{"asdfgh", "123344"})
+}
+
+func TestSafeMapRemove(t *testing.T) {
+	safeMap := NewSafeMap()
+	assert.Equal(t, len(safeMap.inner), 0)
+	// remove a non-existence key
+	safeMap.Remove("key")
+	assert.Equal(t, len(safeMap.inner), 0)
+
+	safeMap.Put("key", "value")
+	assert.Equal(t, len(safeMap.inner), 1)
+
+	safeMap.Remove("key")
+	assert.Equal(t, len(safeMap.inner), 0)
+}
+
+func TestResult(t *testing.T) {
+	value := &Value{
+		data: "asdf",
+		ok:   true,
+	}
+
+	data, ok := value.Result()
+	assert.Equal(t, data, "asdf")
+	assert.Equal(t, ok, true)
+}
+
+func TestExist(t *testing.T) {
+	testCases := []*Value{
+		{
+			data: "asdf",
+			ok:   true,
+		},
+		{
+			data: []string{"asd"},
+			ok:   true,
+		},
+		{
+			data: nil,
+			ok:   false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.Exist(), testCase.ok)
+	}
+}
+
+func TestString(t *testing.T) {
+	type Result struct {
+		str string
+		ok  bool
+	}
+	testCases := []struct {
+		value  *Value
+		result Result
+	}{
+		{
+			value: &Value{
+				data: "asdf",
+				ok:   true,
+			},
+			result: Result{
+				str: "asdf",
+				ok:  true,
+			},
+		},
+		{
+			value: &Value{
+				data: []string{"asdf"},
+				ok:   true,
+			},
+			result: Result{
+				str: "",
+				ok:  false,
+			},
+		},
+		{
+			value: &Value{
+				data: 11,
+				ok:   true,
+			},
+			result: Result{
+				str: "",
+				ok:  false,
+			},
+		},
+		{
+			value: &Value{
+				data: nil,
+				ok:   false,
+			},
+			result: Result{
+				str: "",
+				ok:  false,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		str, ok := testCase.value.String()
+		assert.Equal(t, str, testCase.result.str)
+		assert.Equal(t, ok, testCase.result.ok)
+	}
+}
+
+func TestInt(t *testing.T) {
+	type Result struct {
+		result int
+		ok     bool
+	}
+	testCases := []struct {
+		value  *Value
+		result Result
+	}{
+		{
+			value: &Value{
+				data: "asdf",
+				ok:   true,
+			},
+			result: Result{
+				result: 0,
+				ok:     false,
+			},
+		},
+		{
+			value: &Value{
+				data: []string{"asdf"},
+				ok:   true,
+			},
+			result: Result{
+				result: 0,
+				ok:     false,
+			},
+		},
+		{
+			value: &Value{
+				data: int(11),
+				ok:   true,
+			},
+			result: Result{
+				result: int(11),
+				ok:     true,
+			},
+		},
+		{
+			value: &Value{
+				data: nil,
+				ok:   false,
+			},
+			result: Result{
+				result: 0,
+				ok:     false,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		result, ok := testCase.value.Int()
+		assert.Equal(t, result, testCase.result.result)
+		assert.Equal(t, ok, testCase.result.ok)
+	}
+}
+
+func TestInt32(t *testing.T) {
+	type Result struct {
+		result int32
+		ok     bool
+	}
+	testCases := []struct {
+		value  *Value
+		result Result
+	}{
+		{
+			value: &Value{
+				data: "asdf",
+				ok:   true,
+			},
+			result: Result{
+				result: 0,
+				ok:     false,
+			},
+		},
+		{
+			value: &Value{
+				data: []string{"asdf"},
+				ok:   true,
+			},
+			result: Result{
+				result: 0,
+				ok:     false,
+			},
+		},
+		{
+			value: &Value{
+				data: int32(11),
+				ok:   true,
+			},
+			result: Result{
+				result: int32(11),
+				ok:     true,
+			},
+		},
+		{
+			value: &Value{
+				data: nil,
+				ok:   false,
+			},
+			result: Result{
+				result: 0,
+				ok:     false,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		result, ok := testCase.value.Int32()
+		assert.Equal(t, result, testCase.result.result)
+		assert.Equal(t, ok, testCase.result.ok)
+	}
+}
+
+func TestInt64(t *testing.T) {
+	type Result struct {
+		result int64
+		ok     bool
+	}
+	testCases := []struct {
+		value  *Value
+		result Result
+	}{
+		{
+			value: &Value{
+				data: "asdf",
+				ok:   true,
+			},
+			result: Result{
+				result: 0,
+				ok:     false,
+			},
+		},
+		{
+			value: &Value{
+				data: []string{"asdf"},
+				ok:   true,
+			},
+			result: Result{
+				result: 0,
+				ok:     false,
+			},
+		},
+		{
+			value: &Value{
+				data: int64(11),
+				ok:   true,
+			},
+			result: Result{
+				result: int64(11),
+				ok:     true,
+			},
+		},
+		{
+			value: &Value{
+				data: nil,
+				ok:   false,
+			},
+			result: Result{
+				result: 0,
+				ok:     false,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		result, ok := testCase.value.Int64()
+		assert.Equal(t, result, testCase.result.result)
+		assert.Equal(t, ok, testCase.result.ok)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This PR adds unit tests for pkg safe map.

And it also fixes some potential bugs in pkg safemap.

`return v.data.(string), v.ok` will panic if v.data has a type of non-string. So we need to refactor that to be 
```
	if result, ok := v.data.(int64); ok {
		return result, ok
	}
	return 0, false
```


### Ⅱ. Does this pull request fix one issue?
none


### Ⅲ. Describe how you did it
none


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews


