### PR TITLE
feature: remove endpoint when container stop

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -254,6 +254,12 @@ func (s *Server) getContainers(ctx context.Context, rw http.ResponseWriter, req 
 			HostConfig: m.HostConfig,
 		}
 
+		if m.NetworkSettings != nil {
+			container.NetworkSettings = &types.ContainerNetworkSettings{
+				Networks: m.NetworkSettings.Networks,
+			}
+		}
+
 		containerList = append(containerList, container)
 	}
 	return EncodeResponse(rw, http.StatusOK, containerList)
@@ -275,5 +281,12 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 		Config:     meta.Config,
 		HostConfig: meta.HostConfig,
 	}
+
+	if meta.NetworkSettings != nil {
+		container.NetworkSettings = &types.NetworkSettings{
+			Networks: meta.NetworkSettings.Networks,
+		}
+	}
+
 	return EncodeResponse(rw, http.StatusOK, container)
 }

--- a/cli/container.go
+++ b/cli/container.go
@@ -85,10 +85,9 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 	}
 
 	var networkMode string
-	// FIXME: Temporarily closed.
-	//if len(c.networks) == 0 {
-	//	networkMode = "bridge"
-	//}
+	if len(c.networks) == 0 {
+		networkMode = "bridge"
+	}
 	networkingConfig := &types.NetworkingConfig{
 		EndpointsConfig: map[string]*types.EndpointSettings{},
 	}

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -345,13 +345,12 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 	}
 
 	// set network settings
-	meta.NetworkSettings = &types.NetworkSettings{}
 	networkMode := config.HostConfig.NetworkMode
 	if networkMode == "" {
-		//FIXME: Removing it, when stop container have deleted endpoints
-		//config.HostConfig.NetworkMode = "bridge"
+		config.HostConfig.NetworkMode = "bridge"
 		meta.Config.NetworkDisabled = true
 	}
+	meta.NetworkSettings = new(types.NetworkSettings)
 	if len(config.NetworkingConfig.EndpointsConfig) > 0 {
 		meta.NetworkSettings.Networks = config.NetworkingConfig.EndpointsConfig
 	}
@@ -439,13 +438,15 @@ func (mgr *ContainerManager) Start(ctx context.Context, id, detachKeys string) (
 	}
 
 	// initialise network endpoint
-	for name, endpointSetting := range c.meta.NetworkSettings.Networks {
-		endpoint := mgr.buildContainerEndpoint(c.meta)
-		endpoint.Name = name
-		endpoint.EndpointConfig = endpointSetting
-		if _, err := mgr.NetworkMgr.EndpointCreate(ctx, endpoint); err != nil {
-			logrus.Errorf("failed to create endpoint: %v", err)
-			return err
+	if c.meta.NetworkSettings != nil {
+		for name, endpointSetting := range c.meta.NetworkSettings.Networks {
+			endpoint := mgr.buildContainerEndpoint(c.meta)
+			endpoint.Name = name
+			endpoint.EndpointConfig = endpointSetting
+			if _, err := mgr.NetworkMgr.EndpointCreate(ctx, endpoint); err != nil {
+				logrus.Errorf("failed to create endpoint: %v", err)
+				return err
+			}
 		}
 	}
 
@@ -739,6 +740,19 @@ func (mgr *ContainerManager) markStoppedAndRelease(c *Container, m *ctrd.Message
 	if io := mgr.IOs.Get(c.ID()); io != nil {
 		io.Close()
 		mgr.IOs.Remove(c.ID())
+	}
+
+	// release network
+	if c.meta.NetworkSettings != nil {
+		for name, epConfig := range c.meta.NetworkSettings.Networks {
+			endpoint := mgr.buildContainerEndpoint(c.meta)
+			endpoint.Name = name
+			endpoint.EndpointConfig = epConfig
+			if err := mgr.NetworkMgr.EndpointRemove(context.Background(), endpoint); err != nil {
+				logrus.Errorf("failed to remove endpoint: %v", err)
+				return err
+			}
+		}
 	}
 
 	// update meta

--- a/network/mode/init.go
+++ b/network/mode/init.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// NetworkModeInit is used to initilize network mode, include host and nono network.
+// NetworkModeInit is used to initilize network mode, include host and none network.
 func NetworkModeInit(ctx context.Context, config network.Config, manager mgr.NetworkMgr) error {
 	// init none network
 	if n, _ := manager.Get(ctx, "none"); n == nil {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Remove endpoint when container stop and clean endpoint configure.
Add network information in get container/containers apis.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how you did it
remove endpoint when container is stopping, and then clean endpoint information.

### Ⅳ. Describe how to verify it
The container is running, there is a veth on p0 bridge, when container have been stopped, the veth will disapper on p0 bridge.
```bash
# pouch run --name test -d --net bridge registry.hub.docker.com/library/busybox:latest top
c6c765c103a20a21f2443074719815c375ab8c877ba2b787c31de704df7b52a6

# brctl show
bridge name	bridge id		STP enabled	interfaces
p0		8000.7a240a202b81	no		veth2ceb5e4

# pouch stop test

# brctl show
bridge name	bridge id		STP enabled	interfaces
p0		8000.000000000000	no
```

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
