### PR TITLE
fix: make no quote in .travis.yml to enable CI failure notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - sudo make -e test
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+  - bash <(curl -s https://codecov.io/bash) || echo Codecov_Did_Not_Collect_Coverage_Reports


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
We usually have CI failure notification in pouch open source project, but I found that recently when pr fails the CI, no reports from @pouchrobot .

I found that in CI robot, we have log like 
`time="2018-02-16T22:49:52Z" level=info msg="{\"id\":342562335,\"number\":\"1701\",\"config\":{\"dist\":\"trusty\",\"sudo\":\"required\",\"language\":\"go\",\"go\":[\"1.9.1\"],\"go_import_path\":\"github.com/alibaba/pouch\",\"notifications\":{\"webhooks\":{\"urls\":[\"http://121.201.63.16:6789/ci_notifications\"],\"on_failure\":\"always\",\"on_error\":\"always\"}},\"before_install\":[\"sudo apt-get update -qq\",\"sudo apt-get install -y -qq autoconf automake\"],\"script\":[\"sudo make -e test\"],\"after_success\":[\"bash <(curl -s https://codecov.io/bash) || echo \"Codecov did not collect coverage reports\"\"],\".result\":\"configured\",\"os\":\"linux\",\"group\":\"stable\"},\"type\":\"pull_request\",\"state\":\"failed\",\"status\":1,\"result\":1,\"status_message\":\"Broken\",\"result_message\":\"Broken\",\"started_at\":\"2018-02-16T22:40:44Z\",\"finished_at\":\"2018-02-16T22:49:51Z\",\"duration\":547,\"build_url\":\"https://travis-ci.org/alibaba/pouch/builds/342562335\",\"commit_id\":101868417,\"commit\":\"d79cd7f640f240de6d8467db681e585a3c9e9f99\",\"base_commit\":\"d79cd7f640f240de6d8467db681e585a3c9e9f99\",\"head_commit\":\"e5863a159956258f678970e6eb96113d8b1e1583\",\"branch\":\"master\",\"message\":\"test: add unit test for container utils\\n\\nSigned-off-by: Allen Sun <allensun.shl@alibaba-inc.com>\",\"compare_url\":\"https://github.com/alibaba/pouch/pull/727\",\"committed_at\":\"2018-02-16T22:39:50Z\",\"author_name\":\"Allen Sun\",\"author_email\":\"allensun.shl@alibaba-inc.com\",\"committer_name\":\"Allen Sun\",\"committer_email\":\"allensun.shl@alibaba-inc.com\",\"pull_request\":true,\"pull_request_number\":727,\"pull_request_title\":\"test: add unit test for container utils\",\"tag\":null,\"repository\":{\"id\":16278323,\"name\":\"pouch\",\"owner_name\":\"alibaba\",\"url\":null},\"matrix\":[{\"id\":342562336,\"repository_id\":16278323,\"parent_id\":342562335,\"number\":\"1701.1\",\"state\":\"failed\",\"config\":{\"dist\":\"trusty\",\"sudo\":\"required\",\"language\":\"go\",\"go\":\"1.9.1\",\"go_import_path\":\"github.com/alibaba/pouch\",\"notifications\":{\"webhooks\":{\"urls\":[\"http://121.201.63.16:6789/ci_notifications\"],\"on_failure\":\"always\",\"on_error\":\"always\"}},\"before_install\":[\"sudo apt-get update -qq\",\"sudo apt-get install -y -qq autoconf automake\"],\"script\":[\"sudo make -e test\"],\"after_success\":[\"bash <(curl -s https://codecov.io/bash) || echo \"Codecov did not collect coverage reports\"\"],\".result\":\"configured\",\"os\":\"linux\",\"group\":\"stable\"},\"status\":1,\"result\":1,\"commit\":\"d79cd7f640f240de6d8467db681e585a3c9e9f99\",\"branch\":\"master\",\"message\":\"test: add unit test for container utils\\n\\nSigned-off-by: Allen Sun <allensun.shl@alibaba-inc.com>\",\"compare_url\":\"https://github.com/alibaba/pouch/pull/727\",\"started_at\":null,\"finished_at\":null,\"committed_at\":\"2018-02-16T22:39:50Z\",\"author_name\":\"Allen Sun\",\"author_email\":\"allensun.shl@alibaba-inc.com\",\"committer_name\":\"Allen Sun\",\"committer_email\":\"allensun.shl@alibaba-inc.com\",\"allow_failure\":false}]}"
time="2018-02-16T22:49:52Z" level=error msg="failed to process ci notification: invalid character 'C' after array element"`

Actually, we have `\"after_success\":[\"bash <(curl -s https://codecov.io/bash) || echo \"Codecov did not collect coverage reports\"\"]` which has quotes in the original text and we cannot parse this.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none

### Ⅲ. Describe how you did it
none


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews
none


