### PR TITLE
feature: support IntelRdtL3Cbm in pouch container

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -48,6 +48,7 @@ type container struct {
 	blkioDeviceWriteBps  ThrottleBpsDevice
 	blkioDeviceReadIOps  ThrottleIOpsDevice
 	blkioDeviceWriteIOps ThrottleIOpsDevice
+	IntelRdtL3Cbm        string
 }
 
 func (c *container) config() (*types.ContainerCreateConfig, error) {
@@ -66,6 +67,11 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 	}
 
 	memorySwap, err := parseMemorySwap(c.memorySwap)
+	if err != nil {
+		return nil, err
+	}
+
+	intelRdtL3Cbm, err := parseIntelRdt(c.IntelRdtL3Cbm)
 	if err != nil {
 		return nil, err
 	}
@@ -143,6 +149,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 				BlkioDeviceReadIOps:  c.blkioDeviceReadIOps.value(),
 				BlkioDeviceWriteBps:  c.blkioDeviceWriteBps.value(),
 				BlkioDeviceWriteIOps: c.blkioDeviceWriteIOps.value(),
+				IntelRdtL3Cbm:        intelRdtL3Cbm,
 			},
 			EnableLxcfs:   c.enableLxcfs,
 			Privileged:    c.privileged,
@@ -258,6 +265,11 @@ func validateMemorySwappiness(memorySwappiness int64) error {
 		return fmt.Errorf("invalid memory swappiness: %d (its range is -1 or 0-100)", memorySwappiness)
 	}
 	return nil
+}
+
+func parseIntelRdt(intelRdtL3Cbm string) (string, error) {
+	// FIXME: add Intel RDT L3 Cbm validation
+	return intelRdtL3Cbm, nil
 }
 
 func parseRestartPolicy(restartPolicy string) (*types.RestartPolicy, error) {

--- a/cli/container_test.go
+++ b/cli/container_test.go
@@ -436,3 +436,29 @@ func Test_parseNetwork(t *testing.T) {
 		assert.Equal(t, testCase.expect.network.mode, mode)
 	}
 }
+
+func Test_parseIntelRdt(t *testing.T) {
+	type args struct {
+		intelRdtL3Cbm string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseIntelRdt(tt.args.intelRdtL3Cbm)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseIntelRdt() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseIntelRdt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/create.go
+++ b/cli/create.go
@@ -74,6 +74,7 @@ func (cc *CreateCommand) addFlags() {
 	flagSet.Var(&cc.blkioDeviceReadIOps, "device-read-iops", "Limit read rate (IO per second) from a device")
 	flagSet.Var(&cc.blkioDeviceWriteBps, "device-write-bps", "Limit write rate (bytes per second) from a device")
 	flagSet.Var(&cc.blkioDeviceWriteIOps, "device-write-iops", "Limit write rate (IO per second) from a device")
+	flagSet.StringVar(&cc.IntelRdtL3Cbm, "intel-rdt-l3-cbm", "", "Limit container resource for Intel RDT/CAT which introduced in Linux 4.10 kernel")
 }
 
 // runCreate is the entry of create command.

--- a/cli/run.go
+++ b/cli/run.go
@@ -82,6 +82,7 @@ func (rc *RunCommand) addFlags() {
 	flagSet.Var(&rc.blkioDeviceReadIOps, "device-read-iops", "Limit read rate (IO per second) from a device")
 	flagSet.Var(&rc.blkioDeviceWriteBps, "device-write-bps", "Limit write rate (bytes per second) from a device")
 	flagSet.Var(&rc.blkioDeviceWriteIOps, "device-write-iops", "Limit write rate (IO per second) from a device")
+	flagSet.StringVar(&rc.IntelRdtL3Cbm, "intel-rdt-l3-cbm", "", "Limit container resource for Intel RDT/CAT which introduced in Linux 4.10 kernel")
 }
 
 // runRun is the entry of run command.

--- a/daemon/mgr/spec.go
+++ b/daemon/mgr/spec.go
@@ -58,6 +58,9 @@ var setupFunc = []SetupFunc{
 
 	// blkio spec
 	setupBlkio,
+
+	// IntelRdtL3Cbm
+	setupIntelRdt,
 }
 
 // Register is used to registe spec setup function.

--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -117,3 +117,16 @@ func setupCapabilities(ctx context.Context, meta *ContainerMeta, spec *SpecWrapp
 
 	return nil
 }
+
+func setupIntelRdt(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) error {
+	s := spec.s
+	if s.Linux.IntelRdt == nil {
+		s.Linux.IntelRdt = &specs.LinuxIntelRdt{}
+	}
+
+	s.Linux.IntelRdt = &specs.LinuxIntelRdt{
+		L3CacheSchema: meta.HostConfig.IntelRdtL3Cbm,
+	}
+
+	return nil
+}

--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -329,3 +329,20 @@ func (suite *PouchCreateSuite) TestCreateWithUser(c *check.C) {
 	}
 	c.Assert(result.Config.User, check.Equals, user)
 }
+
+// TestCreateWithIntelRdt tests creating container with Intel Rdt.
+func (suite *PouchCreateSuite) TestCreateWithIntelRdt(c *check.C) {
+	name := "TestCreateWithIntelRdt"
+	intelRdt := "L3:<cache_id0>=<cbm0>"
+
+	res := command.PouchRun("create", "--name", name, "--intel-rdt-l3-cbm", intelRdt, busyboxImage)
+	res.Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", name).Stdout()
+
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result.HostConfig.IntelRdtL3Cbm, check.Equals, intelRdt)
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

### Ⅰ. Describe what this PR did

In pouch, we need to support more container isolation options, such as Intel Rdt L3 Cbm. This PR added `IntelRdtL3Cbm ` for pouchd.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
This is related to https://github.com/alibaba/pouch/issues/688


### Ⅲ. Describe how you did it
None


### Ⅳ. Describe how to verify it
None


### Ⅴ. Special notes for reviews
In the following days, I will refactor the spec file in folder mgr. I think the structure of all spec files are a little bit casual, and we need to make it more structured.

This should be tested in AliOS 4.9, and could we make the test configure whether to run according to the type of CI system? Like travis CI, do not run this IntelRdtL3Cbm related test case, and run that in AliOS 4.9 CI system. @Letty5411 