### PR TITLE
feature: add container memory isolation options

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1405,20 +1405,34 @@ definitions:
         description: "ScheLatSwitch enables scheduler latency count in cpuacct"
         type: "integer"
         format: "int64"
+        x-nullable: false
+        minimum: 0
+        maximum: 1
       MemoryWmarkRatio:
         description: | 
           MemoryWmarkRatio is an integer value representing this container's memory low water mark percentage. 
-          The value of memory low water mark is memory.limit_in_bytes * MemoryWmarkRatio.
+          The value of memory low water mark is memory.limit_in_bytes * MemoryWmarkRatio. The range is in [0, 100].
         type: "integer"
         format: "int64"
+        x-nullable: true
+        minimum: 0
+        maximum: 100
       MemoryExtra:
-        description: "MemoryExtra is an integer value representing this container's memory high water mark percentage."
+        description: |
+          MemoryExtra is an integer value representing this container's memory high water mark percentage.
+          The range is in [0, 100].
         type: "integer"
         format: "int64"
+        x-nullable: true
+        minimum: 0
+        maximum: 100
       MemoryForceEmptyCtl:
         description: "MemoryForceEmptyCtl represents whether to reclaim the page cache when deleting cgroup."
         type: "integer"
         format: "int64"
+        x-nullable: false
+        minimum: 0
+        maximum: 1
 
   ThrottleDevice:
     type: "object"

--- a/apis/types/resources.go
+++ b/apis/types/resources.go
@@ -108,9 +108,15 @@ type Resources struct {
 	Memory int64 `json:"Memory,omitempty"`
 
 	// MemoryExtra is an integer value representing this container's memory high water mark percentage.
-	MemoryExtra int64 `json:"MemoryExtra,omitempty"`
+	// The range is in [0, 100].
+	//
+	// Maximum: 100
+	// Minimum: 0
+	MemoryExtra *int64 `json:"MemoryExtra,omitempty"`
 
 	// MemoryForceEmptyCtl represents whether to reclaim the page cache when deleting cgroup.
+	// Maximum: 1
+	// Minimum: 0
 	MemoryForceEmptyCtl int64 `json:"MemoryForceEmptyCtl,omitempty"`
 
 	// Memory soft limit in bytes.
@@ -125,9 +131,11 @@ type Resources struct {
 	MemorySwappiness *int64 `json:"MemorySwappiness,omitempty"`
 
 	// MemoryWmarkRatio is an integer value representing this container's memory low water mark percentage.
-	// The value of memory low water mark is memory.limit_in_bytes * MemoryWmarkRatio.
+	// The value of memory low water mark is memory.limit_in_bytes * MemoryWmarkRatio. The range is in [0, 100].
 	//
-	MemoryWmarkRatio int64 `json:"MemoryWmarkRatio,omitempty"`
+	// Maximum: 100
+	// Minimum: 0
+	MemoryWmarkRatio *int64 `json:"MemoryWmarkRatio,omitempty"`
 
 	// CPU quota in units of 10<sup>-9</sup> CPUs.
 	NanoCpus int64 `json:"NanoCPUs,omitempty"`
@@ -140,6 +148,8 @@ type Resources struct {
 	PidsLimit int64 `json:"PidsLimit,omitempty"`
 
 	// ScheLatSwitch enables scheduler latency count in cpuacct
+	// Maximum: 1
+	// Minimum: 0
 	ScheLatSwitch int64 `json:"ScheLatSwitch,omitempty"`
 
 	// A list of resource limits to set in the container. For example: `{"Name": "nofile", "Soft": 1024, "Hard": 2048}`"
@@ -261,7 +271,27 @@ func (m *Resources) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateMemoryExtra(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateMemoryForceEmptyCtl(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateMemorySwappiness(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateMemoryWmarkRatio(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateScheLatSwitch(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -465,6 +495,40 @@ func (m *Resources) validateDevices(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *Resources) validateMemoryExtra(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.MemoryExtra) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("MemoryExtra", "body", int64(*m.MemoryExtra), 0, false); err != nil {
+		return err
+	}
+
+	if err := validate.MaximumInt("MemoryExtra", "body", int64(*m.MemoryExtra), 100, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Resources) validateMemoryForceEmptyCtl(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.MemoryForceEmptyCtl) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("MemoryForceEmptyCtl", "body", int64(m.MemoryForceEmptyCtl), 0, false); err != nil {
+		return err
+	}
+
+	if err := validate.MaximumInt("MemoryForceEmptyCtl", "body", int64(m.MemoryForceEmptyCtl), 1, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *Resources) validateMemorySwappiness(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.MemorySwappiness) { // not required
@@ -476,6 +540,40 @@ func (m *Resources) validateMemorySwappiness(formats strfmt.Registry) error {
 	}
 
 	if err := validate.MaximumInt("MemorySwappiness", "body", int64(*m.MemorySwappiness), 100, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Resources) validateMemoryWmarkRatio(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.MemoryWmarkRatio) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("MemoryWmarkRatio", "body", int64(*m.MemoryWmarkRatio), 0, false); err != nil {
+		return err
+	}
+
+	if err := validate.MaximumInt("MemoryWmarkRatio", "body", int64(*m.MemoryWmarkRatio), 100, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Resources) validateScheLatSwitch(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ScheLatSwitch) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("ScheLatSwitch", "body", int64(m.ScheLatSwitch), 0, false); err != nil {
+		return err
+	}
+
+	if err := validate.MaximumInt("ScheLatSwitch", "body", int64(m.ScheLatSwitch), 1, false); err != nil {
 		return err
 	}
 

--- a/cli/container.go
+++ b/cli/container.go
@@ -14,22 +14,28 @@ import (
 )
 
 type container struct {
-	labels               []string
-	name                 string
-	tty                  bool
-	volume               []string
-	runtime              string
-	env                  []string
-	entrypoint           string
-	workdir              string
-	user                 string
-	hostname             string
-	cpushare             int64
-	cpusetcpus           string
-	cpusetmems           string
-	memory               string
-	memorySwap           string
-	memorySwappiness     int64
+	labels           []string
+	name             string
+	tty              bool
+	volume           []string
+	runtime          string
+	env              []string
+	entrypoint       string
+	workdir          string
+	user             string
+	hostname         string
+	cpushare         int64
+	cpusetcpus       string
+	cpusetmems       string
+	memory           string
+	memorySwap       string
+	memorySwappiness int64
+
+	memoryWmarkRatio    int64
+	memoryExtra         int64
+	memoryForceEmptyCtl int64
+	scheLatSwitch       int64
+
 	devices              []string
 	enableLxcfs          bool
 	privileged           bool
@@ -136,13 +142,20 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 			Binds:   c.volume,
 			Runtime: c.runtime,
 			Resources: types.Resources{
-				CPUShares:            c.cpushare,
-				CpusetCpus:           c.cpusetcpus,
-				CpusetMems:           c.cpusetmems,
-				Devices:              deviceMappings,
-				Memory:               memory,
-				MemorySwap:           memorySwap,
-				MemorySwappiness:     &c.memorySwappiness,
+				CPUShares:        c.cpushare,
+				CpusetCpus:       c.cpusetcpus,
+				CpusetMems:       c.cpusetmems,
+				Devices:          deviceMappings,
+				Memory:           memory,
+				MemorySwap:       memorySwap,
+				MemorySwappiness: &c.memorySwappiness,
+				// FIXME: validate in client side
+				MemoryWmarkRatio:    &c.memoryWmarkRatio,
+				MemoryExtra:         &c.memoryExtra,
+				MemoryForceEmptyCtl: c.memoryForceEmptyCtl,
+				ScheLatSwitch:       c.scheLatSwitch,
+
+				// blkio
 				BlkioWeight:          c.blkioWeight,
 				BlkioWeightDevice:    c.blkioWeightDevice.value(),
 				BlkioDeviceReadBps:   c.blkioDeviceReadBps.value(),

--- a/cli/create.go
+++ b/cli/create.go
@@ -50,30 +50,49 @@ func (cc *CreateCommand) addFlags() {
 	flagSet.StringVarP(&cc.workdir, "workdir", "w", "", "Set the working directory in a container")
 	flagSet.StringVarP(&cc.user, "user", "u", "", "UID")
 	flagSet.StringVar(&cc.hostname, "hostname", "", "Set container's hostname")
+
+	// cpu
 	flagSet.Int64Var(&cc.cpushare, "cpu-share", 0, "CPU shares")
 	flagSet.StringVar(&cc.cpusetcpus, "cpuset-cpus", "", "CPUs in cpuset")
 	flagSet.StringVar(&cc.cpusetmems, "cpuset-mems", "", "MEMs in cpuset")
+
+	// memory
 	flagSet.Int64Var(&cc.memorySwappiness, "memory-wappiness", -1, "Container memory swappiness [0, 100]")
 	flagSet.StringVarP(&cc.memory, "memory", "m", "", "Container memory limit")
 	flagSet.StringVar(&cc.memorySwap, "memory-swap", "", "Container swap limit")
+	// alios memory
+	flagSet.Int64Var(&cc.memoryWmarkRatio, "memory-wmark-ratio", 0, "Represent this container's memory low water mark percentage, range in [0, 100]. The value of memory low water mark is memory.limit_in_bytes * MemoryWmarkRatio")
+	flagSet.Int64Var(&cc.memoryExtra, "memory-extra", 0, "Represent container's memory high water mark percentage, range in [0, 100]")
+	flagSet.Int64Var(&cc.memoryForceEmptyCtl, "memory-force-empty-ctl", 0, "Whether to reclaim page cache when deleting the cgroup of container")
+	flagSet.Int64Var(&cc.scheLatSwitch, "sche-lat-switch", 0, "Whether to enable scheduler latency count in cpuacct")
+
 	flagSet.StringSliceVarP(&cc.devices, "device", "", nil, "Add a host device to the container")
 	flagSet.BoolVar(&cc.enableLxcfs, "enableLxcfs", false, "Enable lxcfs")
-	flagSet.BoolVar(&cc.privileged, "privileged", false, "Give extended privileges to the container")
 	flagSet.StringVar(&cc.restartPolicy, "restart", "", "Restart policy to apply when container exits")
+
+	// namespace mode
 	flagSet.StringVar(&cc.ipcMode, "ipc", "", "IPC namespace to use")
 	flagSet.StringVar(&cc.pidMode, "pid", "", "PID namespace to use")
 	flagSet.StringVar(&cc.utsMode, "uts", "", "UTS namespace to use")
+
 	flagSet.StringSliceVar(&cc.sysctls, "sysctl", nil, "Sysctl options")
 	flagSet.StringSliceVar(&cc.networks, "net", nil, "Set networks to container")
 	flagSet.StringSliceVar(&cc.securityOpt, "security-opt", nil, "Security Options")
+
+	// capabilities
+	flagSet.BoolVar(&cc.privileged, "privileged", false, "Give extended privileges to the container")
 	flagSet.StringSliceVar(&cc.capAdd, "cap-add", nil, "Add Linux capabilities")
 	flagSet.StringSliceVar(&cc.capDrop, "cap-drop", nil, "Drop Linux capabilities")
+
+	// blkio
 	flagSet.Uint16Var(&cc.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable")
 	flagSet.Var(&cc.blkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
 	flagSet.Var(&cc.blkioDeviceReadBps, "device-read-bps", "Limit read rate (bytes per second) from a device")
 	flagSet.Var(&cc.blkioDeviceReadIOps, "device-read-iops", "Limit read rate (IO per second) from a device")
 	flagSet.Var(&cc.blkioDeviceWriteBps, "device-write-bps", "Limit write rate (bytes per second) from a device")
 	flagSet.Var(&cc.blkioDeviceWriteIOps, "device-write-iops", "Limit write rate (IO per second) from a device")
+
+	// Intel RDT
 	flagSet.StringVar(&cc.IntelRdtL3Cbm, "intel-rdt-l3-cbm", "", "Limit container resource for Intel RDT/CAT which introduced in Linux 4.10 kernel")
 }
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -58,30 +58,50 @@ func (rc *RunCommand) addFlags() {
 	flagSet.StringVarP(&rc.user, "user", "u", "", "UID")
 	flagSet.BoolVarP(&rc.detach, "detach", "d", false, "Run container in background and print container ID")
 	flagSet.StringVar(&rc.hostname, "hostname", "", "Set container's hostname")
+
+	// cpu
 	flagSet.Int64Var(&rc.cpushare, "cpu-share", 0, "CPU shares")
 	flagSet.StringVar(&rc.cpusetcpus, "cpuset-cpus", "", "CPUs in cpuset")
 	flagSet.StringVar(&rc.cpusetmems, "cpuset-mems", "", "MEMs in cpuset")
+
+	// memory
 	flagSet.Int64Var(&rc.memorySwappiness, "memory-wappiness", -1, "Container memory swappiness [0, 100]")
 	flagSet.StringVarP(&rc.memory, "memory", "m", "", "Container memory limit")
 	flagSet.StringVar(&rc.memorySwap, "memory-swap", "", "Container swap limit")
+	// alios
+	flagSet.Int64Var(&rc.memoryWmarkRatio, "memory-wmark-ratio", 0, "Represent this container's memory low water mark percentage, range in [0, 100]. The value of memory low water mark is memory.limit_in_bytes * MemoryWmarkRatio")
+	flagSet.Int64Var(&rc.memoryExtra, "memory-extra", 0, "Represent container's memory high water mark percentage, range in [0, 100]")
+	flagSet.Int64Var(&rc.memoryForceEmptyCtl, "memory-force-empty-ctl", 0, "Whether to reclaim page cache when deleting the cgroup of container")
+	flagSet.Int64Var(&rc.scheLatSwitch, "sche-lat-switch", 0, "Whether to enable scheduler latency count in cpuacct")
+
 	flagSet.StringSliceVarP(&rc.devices, "device", "", nil, "Add a host device to the container")
 	flagSet.BoolVar(&rc.enableLxcfs, "enableLxcfs", false, "Enable lxcfs")
-	flagSet.BoolVar(&rc.privileged, "privileged", false, "Give extended privileges to the container")
+
 	flagSet.StringVar(&rc.restartPolicy, "restart", "", "Restart policy to apply when container exits")
+
+	// namespace mode
 	flagSet.StringVar(&rc.ipcMode, "ipc", "", "IPC namespace to use")
 	flagSet.StringVar(&rc.pidMode, "pid", "", "PID namespace to use")
 	flagSet.StringVar(&rc.utsMode, "uts", "", "UTS namespace to use")
+
 	flagSet.StringSliceVar(&rc.sysctls, "sysctl", nil, "Sysctl options")
 	flagSet.StringSliceVar(&rc.networks, "net", nil, "Set networks to container")
 	flagSet.StringSliceVar(&rc.securityOpt, "security-opt", nil, "Security Options")
+
+	// capabilities
+	flagSet.BoolVar(&rc.privileged, "privileged", false, "Give extended privileges to the container")
 	flagSet.StringSliceVar(&rc.capAdd, "cap-add", nil, "Add Linux capabilities")
 	flagSet.StringSliceVar(&rc.capDrop, "cap-drop", nil, "Drop Linux capabilities")
+
+	// blkio
 	flagSet.Uint16Var(&rc.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable")
 	flagSet.Var(&rc.blkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
 	flagSet.Var(&rc.blkioDeviceReadBps, "device-read-bps", "Limit read rate (bytes per second) from a device")
 	flagSet.Var(&rc.blkioDeviceReadIOps, "device-read-iops", "Limit read rate (IO per second) from a device")
 	flagSet.Var(&rc.blkioDeviceWriteBps, "device-write-bps", "Limit write rate (bytes per second) from a device")
 	flagSet.Var(&rc.blkioDeviceWriteIOps, "device-write-iops", "Limit write rate (IO per second) from a device")
+
+	// Intel RDT
 	flagSet.StringVar(&rc.IntelRdtL3Cbm, "intel-rdt-l3-cbm", "", "Limit container resource for Intel RDT/CAT which introduced in Linux 4.10 kernel")
 }
 

--- a/daemon/mgr/spec.go
+++ b/daemon/mgr/spec.go
@@ -61,6 +61,9 @@ var setupFunc = []SetupFunc{
 
 	// IntelRdtL3Cbm
 	setupIntelRdt,
+
+	// alios options
+	setupAliOsOption,
 }
 
 // Register is used to registe spec setup function.

--- a/daemon/mgr/spec_alios.go
+++ b/daemon/mgr/spec_alios.go
@@ -1,0 +1,29 @@
+package mgr
+
+import (
+	"context"
+	"strconv"
+)
+
+// setupAliOsOption extracts alios related options from HostConfig and locate them in spec's annotations which will be dealt by vendored runc.
+func setupAliOsOption(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) error {
+	s := spec.s
+
+	r := meta.HostConfig.Resources
+
+	s.Annotations = make(map[string]string)
+
+	if r.MemoryWmarkRatio != nil {
+		s.Annotations["_MEMORY_WATER_MARK_RATIO"] = strconv.FormatInt(*r.MemoryWmarkRatio, 10)
+	}
+
+	if r.MemoryExtra != nil {
+		s.Annotations["_MEMORY_EXTRA"] = strconv.FormatInt(*r.MemoryExtra, 10)
+	}
+
+	s.Annotations["_MEMORY_FORCE_EMPTY_CTL"] = strconv.FormatInt(r.MemoryForceEmptyCtl, 10)
+
+	s.Annotations["_SCHEDULE_LATENCY_SWITCH"] = strconv.FormatInt(r.ScheLatSwitch, 10)
+
+	return nil
+}

--- a/test/api_container_create_test.go
+++ b/test/api_container_create_test.go
@@ -276,3 +276,26 @@ func (suite *APIContainerCreateSuite) TestRestartPolicyAlways(c *check.C) {
 
 	DelContainerForceOk(c, cname)
 }
+
+// TestAliOSOptions tests create container with alios related container isolation options.
+func (suite *APIContainerCreateSuite) TestAliOSOptions(c *check.C) {
+	cname := "TestAliOSOptions"
+	q := url.Values{}
+	q.Add("name", cname)
+	query := request.WithQuery(q)
+
+	obj := map[string]interface{}{
+		"Image": busyboxImage,
+		"HostConfig": map[string]interface{}{
+			"MemoryWmarkRatio":    int64(30),
+			"MemoryExtra":         int64(50),
+			"MemoryForceEmptyCtl": 0,
+			"ScheLatSwitch":       0,
+		},
+	}
+	body := request.WithJSONBody(obj)
+
+	resp, err := request.Post("/containers/create", query, body)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 201)
+}

--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -346,3 +346,24 @@ func (suite *PouchCreateSuite) TestCreateWithIntelRdt(c *check.C) {
 	}
 	c.Assert(result.HostConfig.IntelRdtL3Cbm, check.Equals, intelRdt)
 }
+
+// TestCreateWithAliOSMemoryOptions tests creating container with AliOS container isolation options.
+func (suite *PouchCreateSuite) TestCreateWithAliOSMemoryOptions(c *check.C) {
+	name := "TestCreateWithAliOSMemoryOptions"
+	memoryWmarkRatio := "30"
+	memoryExtra := "50"
+
+	res := command.PouchRun("create", "--name", name, "--memory-wmark-ratio", memoryWmarkRatio, "--memory-extra", memoryExtra, "--memory-force-empty-ctl", "1", "--sche-lat-switch", "1", busyboxImage)
+	res.Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", name).Stdout()
+
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(*result.HostConfig.MemoryWmarkRatio, check.Equals, int64(30))
+	c.Assert(*result.HostConfig.MemoryExtra, check.Equals, int64(50))
+	c.Assert(result.HostConfig.MemoryForceEmptyCtl, check.Equals, int64(1))
+	c.Assert(result.HostConfig.ScheLatSwitch, check.Equals, int64(1))
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>


### Ⅰ. Describe what this PR did

This PR added four alios related container isolation options for pouch. These four options are:

* ScheLatSwitch
* MemoryWmarkRatio
* MemoryExtra
* MemoryForceEmptyCtl

These options are introduced in PR #685 .

This PR made these options supported in Pouch daemon. When supporting, we add these options in the `annotation` filed of spec. And we make runc to deal these options rather than pouch daemon. We make this via passing these data as specified keys, like `_MEMORY_XXX`, like:

* _MEMORY_WATER_MARK_RATIO
* _MEMORY_EXTRA
* _MEMORY_FORCE_EMPTY_CTL
* _SCHEDULE_LATENCY_SWITCH


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
This is related to issue #688 


### Ⅲ. Describe how you did it
None


### Ⅳ. Describe how to verify it
None


### Ⅴ. Special notes for reviews
None


