### PR TITLE
bugfix: network device is remaining after container have been removed

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -254,6 +254,12 @@ func (s *Server) getContainers(ctx context.Context, rw http.ResponseWriter, req 
 			HostConfig: m.HostConfig,
 		}
 
+		if m.NetworkSettings != nil {
+			container.NetworkSettings = &types.ContainerNetworkSettings{
+				Networks: m.NetworkSettings.Networks,
+			}
+		}
+
 		containerList = append(containerList, container)
 	}
 	return EncodeResponse(rw, http.StatusOK, containerList)
@@ -275,5 +281,12 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 		Config:     meta.Config,
 		HostConfig: meta.HostConfig,
 	}
+
+	if meta.NetworkSettings != nil {
+		container.NetworkSettings = &types.NetworkSettings{
+			Networks: meta.NetworkSettings.Networks,
+		}
+	}
+
 	return EncodeResponse(rw, http.StatusOK, container)
 }

--- a/cli/container.go
+++ b/cli/container.go
@@ -85,10 +85,9 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 	}
 
 	var networkMode string
-	// FIXME: Temporarily closed.
-	//if len(c.networks) == 0 {
-	//	networkMode = "bridge"
-	//}
+	if len(c.networks) == 0 {
+		networkMode = "bridge"
+	}
 	networkingConfig := &types.NetworkingConfig{
 		EndpointsConfig: map[string]*types.EndpointSettings{},
 	}

--- a/network/mode/init.go
+++ b/network/mode/init.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// NetworkModeInit is used to initilize network mode, include host and nono network.
+// NetworkModeInit is used to initilize network mode, include host and none network.
 func NetworkModeInit(ctx context.Context, config network.Config, manager mgr.NetworkMgr) error {
 	// init none network
 	if n, _ := manager.Get(ctx, "none"); n == nil {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Network device is remaining after container have been removed.
Using "containerManager.Stop" to stop container instead of using
"client.DestroyContainer".

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #758 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
The test steps are same as issue steps.

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
