### PR TITLE
feature: add rich container mode

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1078,7 +1078,21 @@ definitions:
         type: "array"
         items:
           type: "string"
-  
+      Rich:
+        type: "boolean"
+        description: "Whether to start container in rich container mode. (default false)"
+        x-nullable: false
+      RichMode:
+        type: "string"
+        description: "Choose one rich container mode.(default dumb-init)"
+        enum:
+          - "dumb-init"
+          - "sbin-init"
+          - "systemd"
+      InitScript:
+        type: "string"
+        description: "Initial script executed in container. The script will be executed before entrypoint or command"        
+ 
   ContainerCreateResp:
     description: "response returned by daemon when container create successfully"
     type: "object"
@@ -1291,20 +1305,6 @@ definitions:
             description: "Whether to enable lxcfs."
             type: "boolean"
             x-nullable: false
-          Rich:
-            type: "boolean"
-            description: "Whether to start container in rich container mode. (default false)"
-            x-nullable: false
-          RichMode:
-            type: "string"
-            description: "Choose one rich container mode.(default dumb-init)"
-            enum:
-             - "dumb-init"
-             - "sbin-init"
-             - "systemd"
-          InitScript:
-            type: "string"
-            description: "Initial script executed in container. The script will be executed before entrypoint or command"
       - $ref: "#/definitions/Resources"
 
   Resources:

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1291,6 +1291,20 @@ definitions:
             description: "Whether to enable lxcfs."
             type: "boolean"
             x-nullable: false
+          Rich:
+            type: "boolean"
+            description: "Whether to start container in rich container mode. (default false)"
+            x-nullable: false
+          RichMode:
+            type: "string"
+            description: "Choose one rich container mode.(default dumb-init)"
+            enum:
+             - "dumb-init"
+             - "sbin-init"
+             - "systemd"
+          InitScript:
+            type: "string"
+            description: "Initial script executed in container. The script will be executed before entrypoint or command"
       - $ref: "#/definitions/Resources"
 
   Resources:

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1305,6 +1305,20 @@ definitions:
             description: "Whether to enable lxcfs."
             type: "boolean"
             x-nullable: false
+          Rich:
+            type: "boolean"
+            description: "Whether to start container in rich container mode. (default false)"
+            x-nullable: false
+          RichMode:
+            type: "string"
+            description: "Choose one rich container mode.(default dumb-init)"
+            enum:
+             - "dumb-init"
+             - "sbin-init"
+             - "systemd"
+          InitScript:
+            type: "string"
+            description: "Initial script executed in container. The script will be executed before entrypoint or command"
       - $ref: "#/definitions/Resources"
 
   Resources:

--- a/apis/types/container_config.go
+++ b/apis/types/container_config.go
@@ -58,6 +58,9 @@ type ContainerConfig struct {
 	// Required: true
 	Image string `json:"Image"`
 
+	// Initial script executed in container. The script will be executed before entrypoint or command
+	InitScript string `json:"InitScript,omitempty"`
+
 	// User-defined key/value metadata.
 	Labels map[string]string `json:"Labels,omitempty"`
 
@@ -72,6 +75,12 @@ type ContainerConfig struct {
 
 	// Open `stdin`
 	OpenStdin bool `json:"OpenStdin,omitempty"`
+
+	// Whether to start container in rich container mode. (default false)
+	Rich bool `json:"Rich,omitempty"`
+
+	// Choose one rich container mode.(default dumb-init)
+	RichMode string `json:"RichMode,omitempty"`
 
 	// Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell.
 	Shell []string `json:"Shell"`
@@ -120,6 +129,8 @@ type ContainerConfig struct {
 
 /* polymorph ContainerConfig Image false */
 
+/* polymorph ContainerConfig InitScript false */
+
 /* polymorph ContainerConfig Labels false */
 
 /* polymorph ContainerConfig MacAddress false */
@@ -129,6 +140,10 @@ type ContainerConfig struct {
 /* polymorph ContainerConfig OnBuild false */
 
 /* polymorph ContainerConfig OpenStdin false */
+
+/* polymorph ContainerConfig Rich false */
+
+/* polymorph ContainerConfig RichMode false */
 
 /* polymorph ContainerConfig Shell false */
 
@@ -181,6 +196,11 @@ func (m *ContainerConfig) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateOnBuild(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateRichMode(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -298,6 +318,49 @@ func (m *ContainerConfig) validateOnBuild(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.OnBuild) { // not required
 		return nil
+	}
+
+	return nil
+}
+
+var containerConfigTypeRichModePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["dumb-init","sbin-init","systemd"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		containerConfigTypeRichModePropEnum = append(containerConfigTypeRichModePropEnum, v)
+	}
+}
+
+const (
+	// ContainerConfigRichModeDumbInit captures enum value "dumb-init"
+	ContainerConfigRichModeDumbInit string = "dumb-init"
+	// ContainerConfigRichModeSbinInit captures enum value "sbin-init"
+	ContainerConfigRichModeSbinInit string = "sbin-init"
+	// ContainerConfigRichModeSystemd captures enum value "systemd"
+	ContainerConfigRichModeSystemd string = "systemd"
+)
+
+// prop value enum
+func (m *ContainerConfig) validateRichModeEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, containerConfigTypeRichModePropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *ContainerConfig) validateRichMode(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.RichMode) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateRichModeEnum("RichMode", "body", m.RichMode); err != nil {
+		return err
 	}
 
 	return nil

--- a/apis/types/host_config.go
+++ b/apis/types/host_config.go
@@ -69,9 +69,6 @@ type HostConfig struct {
 	// A list of additional groups that the container process will run as.
 	GroupAdd []string `json:"GroupAdd"`
 
-	// Initial script executed in container. The script will be executed before entrypoint or command
-	InitScript string `json:"InitScript,omitempty"`
-
 	// IPC sharing mode for the container. Possible values are:
 	// - `"none"`: own private IPC namespace, with /dev/shm not mounted
 	// - `"private"`: own private IPC namespace
@@ -118,12 +115,6 @@ type HostConfig struct {
 
 	// Restart policy to be used to manage the container
 	RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
-
-	// Whether to start container in rich container mode. (default false)
-	Rich bool `json:"Rich,omitempty"`
-
-	// Choose one rich container mode.(default dumb-init)
-	RichMode string `json:"RichMode,omitempty"`
 
 	// Runtime to use with this container.
 	Runtime string `json:"Runtime,omitempty"`
@@ -192,8 +183,6 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 
 		GroupAdd []string `json:"GroupAdd,omitempty"`
 
-		InitScript string `json:"InitScript,omitempty"`
-
 		IpcMode string `json:"IpcMode,omitempty"`
 
 		Isolation string `json:"Isolation,omitempty"`
@@ -217,10 +206,6 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 		ReadonlyRootfs bool `json:"ReadonlyRootfs,omitempty"`
 
 		RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
-
-		Rich bool `json:"Rich,omitempty"`
-
-		RichMode string `json:"RichMode,omitempty"`
 
 		Runtime string `json:"Runtime,omitempty"`
 
@@ -272,8 +257,6 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 
 	m.GroupAdd = data.GroupAdd
 
-	m.InitScript = data.InitScript
-
 	m.IpcMode = data.IpcMode
 
 	m.Isolation = data.Isolation
@@ -297,10 +280,6 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 	m.ReadonlyRootfs = data.ReadonlyRootfs
 
 	m.RestartPolicy = data.RestartPolicy
-
-	m.Rich = data.Rich
-
-	m.RichMode = data.RichMode
 
 	m.Runtime = data.Runtime
 
@@ -362,8 +341,6 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 
 		GroupAdd []string `json:"GroupAdd,omitempty"`
 
-		InitScript string `json:"InitScript,omitempty"`
-
 		IpcMode string `json:"IpcMode,omitempty"`
 
 		Isolation string `json:"Isolation,omitempty"`
@@ -387,10 +364,6 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 		ReadonlyRootfs bool `json:"ReadonlyRootfs,omitempty"`
 
 		RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
-
-		Rich bool `json:"Rich,omitempty"`
-
-		RichMode string `json:"RichMode,omitempty"`
 
 		Runtime string `json:"Runtime,omitempty"`
 
@@ -439,8 +412,6 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 
 	data.GroupAdd = m.GroupAdd
 
-	data.InitScript = m.InitScript
-
 	data.IpcMode = m.IpcMode
 
 	data.Isolation = m.Isolation
@@ -464,10 +435,6 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 	data.ReadonlyRootfs = m.ReadonlyRootfs
 
 	data.RestartPolicy = m.RestartPolicy
-
-	data.Rich = m.Rich
-
-	data.RichMode = m.RichMode
 
 	data.Runtime = m.Runtime
 
@@ -561,10 +528,6 @@ func (m *HostConfig) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRestartPolicy(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateRichMode(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -782,40 +745,6 @@ func (m *HostConfig) validateRestartPolicy(formats strfmt.Registry) error {
 			}
 			return err
 		}
-	}
-
-	return nil
-}
-
-var hostConfigTypeRichModePropEnum []interface{}
-
-func init() {
-	var res []string
-	if err := json.Unmarshal([]byte(`["dumb-init","sbin-init","systemd"]`), &res); err != nil {
-		panic(err)
-	}
-	for _, v := range res {
-		hostConfigTypeRichModePropEnum = append(hostConfigTypeRichModePropEnum, v)
-	}
-}
-
-// property enum
-func (m *HostConfig) validateRichModeEnum(path, location string, value string) error {
-	if err := validate.Enum(path, location, value, hostConfigTypeRichModePropEnum); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (m *HostConfig) validateRichMode(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.RichMode) { // not required
-		return nil
-	}
-
-	// value enum
-	if err := m.validateRichModeEnum("RichMode", "body", m.RichMode); err != nil {
-		return err
 	}
 
 	return nil

--- a/apis/types/host_config.go
+++ b/apis/types/host_config.go
@@ -69,6 +69,9 @@ type HostConfig struct {
 	// A list of additional groups that the container process will run as.
 	GroupAdd []string `json:"GroupAdd"`
 
+	// Initial script executed in container. The script will be executed before entrypoint or command
+	InitScript string `json:"InitScript,omitempty"`
+
 	// IPC sharing mode for the container. Possible values are:
 	// - `"none"`: own private IPC namespace, with /dev/shm not mounted
 	// - `"private"`: own private IPC namespace
@@ -115,6 +118,12 @@ type HostConfig struct {
 
 	// Restart policy to be used to manage the container
 	RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
+
+	// Whether to start container in rich container mode. (default false)
+	Rich bool `json:"Rich,omitempty"`
+
+	// Choose one rich container mode.(default dumb-init)
+	RichMode string `json:"RichMode,omitempty"`
 
 	// Runtime to use with this container.
 	Runtime string `json:"Runtime,omitempty"`
@@ -183,6 +192,8 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 
 		GroupAdd []string `json:"GroupAdd,omitempty"`
 
+		InitScript string `json:"InitScript,omitempty"`
+
 		IpcMode string `json:"IpcMode,omitempty"`
 
 		Isolation string `json:"Isolation,omitempty"`
@@ -206,6 +217,10 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 		ReadonlyRootfs bool `json:"ReadonlyRootfs,omitempty"`
 
 		RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
+
+		Rich bool `json:"Rich,omitempty"`
+
+		RichMode string `json:"RichMode,omitempty"`
 
 		Runtime string `json:"Runtime,omitempty"`
 
@@ -257,6 +272,8 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 
 	m.GroupAdd = data.GroupAdd
 
+	m.InitScript = data.InitScript
+
 	m.IpcMode = data.IpcMode
 
 	m.Isolation = data.Isolation
@@ -280,6 +297,10 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 	m.ReadonlyRootfs = data.ReadonlyRootfs
 
 	m.RestartPolicy = data.RestartPolicy
+
+	m.Rich = data.Rich
+
+	m.RichMode = data.RichMode
 
 	m.Runtime = data.Runtime
 
@@ -341,6 +362,8 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 
 		GroupAdd []string `json:"GroupAdd,omitempty"`
 
+		InitScript string `json:"InitScript,omitempty"`
+
 		IpcMode string `json:"IpcMode,omitempty"`
 
 		Isolation string `json:"Isolation,omitempty"`
@@ -364,6 +387,10 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 		ReadonlyRootfs bool `json:"ReadonlyRootfs,omitempty"`
 
 		RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
+
+		Rich bool `json:"Rich,omitempty"`
+
+		RichMode string `json:"RichMode,omitempty"`
 
 		Runtime string `json:"Runtime,omitempty"`
 
@@ -412,6 +439,8 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 
 	data.GroupAdd = m.GroupAdd
 
+	data.InitScript = m.InitScript
+
 	data.IpcMode = m.IpcMode
 
 	data.Isolation = m.Isolation
@@ -435,6 +464,10 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 	data.ReadonlyRootfs = m.ReadonlyRootfs
 
 	data.RestartPolicy = m.RestartPolicy
+
+	data.Rich = m.Rich
+
+	data.RichMode = m.RichMode
 
 	data.Runtime = m.Runtime
 
@@ -528,6 +561,10 @@ func (m *HostConfig) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRestartPolicy(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRichMode(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -745,6 +782,40 @@ func (m *HostConfig) validateRestartPolicy(formats strfmt.Registry) error {
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+var hostConfigTypeRichModePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["dumb-init","sbin-init","systemd"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		hostConfigTypeRichModePropEnum = append(hostConfigTypeRichModePropEnum, v)
+	}
+}
+
+// property enum
+func (m *HostConfig) validateRichModeEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, hostConfigTypeRichModePropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *HostConfig) validateRichMode(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.RichMode) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateRichModeEnum("RichMode", "body", m.RichMode); err != nil {
+		return err
 	}
 
 	return nil

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -75,5 +75,9 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 
 	flagSet.StringVarP(&c.workdir, "workdir", "w", "", "Set the working directory in a container")
 
+	flagSet.BoolVar(&c.rich, "rich", false, "Start container in rich container mode. (default false)")
+	flagSet.StringVar(&c.richMode, "rich-mode", "", "Choose one rich container mode. dumb-init(default), systemd, sbin-init")
+	flagSet.StringVar(&c.initScript, "initscript", "", "Initial script executed in container")
+
 	return c
 }

--- a/cli/container.go
+++ b/cli/container.go
@@ -55,6 +55,11 @@ type container struct {
 	blkioDeviceReadIOps  ThrottleIOpsDevice
 	blkioDeviceWriteIOps ThrottleIOpsDevice
 	IntelRdtL3Cbm        string
+
+	//add for rich container mode
+	rich		     bool
+	richMode	     string
+	initScript	     string
 }
 
 func (c *container) config() (*types.ContainerCreateConfig, error) {
@@ -135,6 +140,9 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 			User:       c.user,
 			Hostname:   strfmt.Hostname(c.hostname),
 			Labels:     labels,
+			Rich:	    c.rich,
+			RichMode:   c.richMode,
+			InitScript: c.initScript,
 		},
 
 		HostConfig: &types.HostConfig{

--- a/cli/container.go
+++ b/cli/container.go
@@ -57,9 +57,9 @@ type container struct {
 	IntelRdtL3Cbm        string
 
 	//add for rich container mode
-	rich		     bool
-	richMode	     string
-	initScript	     string
+	rich       bool
+	richMode   string
+	initScript string
 }
 
 func (c *container) config() (*types.ContainerCreateConfig, error) {

--- a/cli/container.go
+++ b/cli/container.go
@@ -140,7 +140,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 			User:       c.user,
 			Hostname:   strfmt.Hostname(c.hostname),
 			Labels:     labels,
-			Rich:	    c.rich,
+			Rich:       c.rich,
 			RichMode:   c.richMode,
 			InitScript: c.initScript,
 		},

--- a/daemon/mgr/container_rich_mode.go
+++ b/daemon/mgr/container_rich_mode.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	richModeEnv = "rich_mode=true"
+	richModeEnv       = "rich_mode=true"
 	richModeLaunchEnv = "rich_mode_launch_manner"
 
 	//for ali internal
@@ -16,9 +16,9 @@ const (
 
 func richContainerModeEnv(c *ContainerMeta) []string {
 	var (
-		ret         	     = []string{}
-		setRichMode          = false
-		richMode             = ""
+		ret         = []string{}
+		setRichMode = false
+		richMode    = ""
 	)
 
 	envs := c.Config.Env

--- a/daemon/mgr/container_rich_mode.go
+++ b/daemon/mgr/container_rich_mode.go
@@ -13,7 +13,7 @@ const(
 	inter_rich_mode_env = "ali_run_mode=common_vm"
 )
 
-func richContainerMode(c *ContainerMeta) []string {
+func richContainerModeEnv(c *ContainerMeta) []string {
 	var(
 		ret []string = []string{}
 		setRichMode = false
@@ -26,6 +26,7 @@ func richContainerMode(c *ContainerMeta) []string {
 	for _,e := range envs {
 		if e == inter_rich_mode_env {
 			setRichMode = true
+			richMode = types.ContainerConfigRichModeSystemd
 			break
 		}
 	}
@@ -49,3 +50,4 @@ func richContainerMode(c *ContainerMeta) []string {
 
 	return ret
 }
+

--- a/daemon/mgr/container_rich_mode.go
+++ b/daemon/mgr/container_rich_mode.go
@@ -2,11 +2,12 @@ package mgr
 
 import (
 	"fmt"
+
 	"github.com/alibaba/pouch/apis/types"
 )
 
-const(
-	rich_mode_env = "rich_mode=true"
+const (
+	rich_mode_env        = "rich_mode=true"
 	rich_mode_launch_env = "rich_mode_launch_manner"
 
 	//for ali internal
@@ -14,16 +15,16 @@ const(
 )
 
 func richContainerModeEnv(c *ContainerMeta) []string {
-	var(
-		ret []string = []string{}
-		setRichMode = false
-		richMode = ""
+	var (
+		ret         []string = []string{}
+		setRichMode          = false
+		richMode             = ""
 	)
 
 	envs := c.Config.Env
 
 	//if set inter_rich_mode_env, you can also run in rich container mode
-	for _,e := range envs {
+	for _, e := range envs {
 		if e == inter_rich_mode_env {
 			setRichMode = true
 			richMode = types.ContainerConfigRichModeSystemd
@@ -50,4 +51,3 @@ func richContainerModeEnv(c *ContainerMeta) []string {
 
 	return ret
 }
-

--- a/daemon/mgr/container_rich_mode.go
+++ b/daemon/mgr/container_rich_mode.go
@@ -1,0 +1,51 @@
+package mgr
+
+import (
+	"fmt"
+	"github.com/alibaba/pouch/apis/types"
+)
+
+const(
+	rich_mode_env = "rich_mode=true"
+	rich_mode_launch_env = "rich_mode_launch_manner"
+
+	//for ali internal
+	inter_rich_mode_env = "ali_run_mode=common_vm"
+)
+
+func richContainerMode(c *ContainerMeta) []string {
+	var(
+		ret []string = []string{}
+		setRichMode = false
+		richMode = ""
+	)
+
+	envs := c.Config.Env
+
+	//if set inter_rich_mode_env, you can also run in rich container mode
+	for _,e := range envs {
+		if e == inter_rich_mode_env {
+			setRichMode = true
+			break
+		}
+	}
+
+	if c.Config.Rich {
+		setRichMode = true
+	}
+
+	if c.Config.RichMode != "" {
+		richMode = c.Config.RichMode
+	}
+
+	//if not set rich mode manner, default set dumb-init
+	if richMode == "" {
+		richMode = types.ContainerConfigRichModeDumbInit
+	}
+
+	if setRichMode {
+		ret = append(ret, rich_mode_env, fmt.Sprintf("%s=%s", rich_mode_launch_env, richMode))
+	}
+
+	return ret
+}

--- a/daemon/mgr/container_rich_mode.go
+++ b/daemon/mgr/container_rich_mode.go
@@ -7,16 +7,16 @@ import (
 )
 
 const (
-	rich_mode_env        = "rich_mode=true"
-	rich_mode_launch_env = "rich_mode_launch_manner"
+	richModeEnv = "rich_mode=true"
+	richModeLaunchEnv = "rich_mode_launch_manner"
 
 	//for ali internal
-	inter_rich_mode_env = "ali_run_mode=common_vm"
+	interRichModeEnv = "ali_run_mode=common_vm"
 )
 
 func richContainerModeEnv(c *ContainerMeta) []string {
 	var (
-		ret         []string = []string{}
+		ret         	     = []string{}
 		setRichMode          = false
 		richMode             = ""
 	)
@@ -25,7 +25,7 @@ func richContainerModeEnv(c *ContainerMeta) []string {
 
 	//if set inter_rich_mode_env, you can also run in rich container mode
 	for _, e := range envs {
-		if e == inter_rich_mode_env {
+		if e == interRichModeEnv {
 			setRichMode = true
 			richMode = types.ContainerConfigRichModeSystemd
 			break
@@ -46,7 +46,7 @@ func richContainerModeEnv(c *ContainerMeta) []string {
 	}
 
 	if setRichMode {
-		ret = append(ret, rich_mode_env, fmt.Sprintf("%s=%s", rich_mode_launch_env, richMode))
+		ret = append(ret, richModeEnv, fmt.Sprintf("%s=%s", richModeLaunchEnv, richMode))
 	}
 
 	return ret

--- a/daemon/mgr/container_rich_mode_test.go
+++ b/daemon/mgr/container_rich_mode_test.go
@@ -1,15 +1,17 @@
 package mgr
 
 import (
-	"github.com/alibaba/pouch/apis/types"
-	"testing"
 	"strings"
+	"testing"
+
+	"github.com/alibaba/pouch/apis/types"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func convertEnvArrayToMap(envs []string) map[string]string {
 	m := map[string]string{}
-	for _,e := range envs {
+	for _, e := range envs {
 		kvs := strings.Split(e, "=")
 		if len(kvs) == 2 {
 			m[kvs[0]] = kvs[1]
@@ -19,7 +21,7 @@ func convertEnvArrayToMap(envs []string) map[string]string {
 	return m
 }
 
-func TestRichModeSet(t *testing.T)  {
+func TestRichModeSet(t *testing.T) {
 	c := &ContainerMeta{
 		Config: &types.ContainerConfig{
 			Rich: true,
@@ -44,7 +46,7 @@ func TestRichModeSet(t *testing.T)  {
 	//test set rich mode manner, not set rich mode
 	c = &ContainerMeta{
 		Config: &types.ContainerConfig{
-			Rich: false,
+			Rich:     false,
 			RichMode: types.ContainerConfigRichModeSystemd,
 		},
 	}
@@ -54,7 +56,7 @@ func TestRichModeSet(t *testing.T)  {
 	//test set rich mode manner
 	c = &ContainerMeta{
 		Config: &types.ContainerConfig{
-			Rich: true,
+			Rich:     true,
 			RichMode: types.ContainerConfigRichModeSystemd,
 		},
 	}
@@ -76,5 +78,3 @@ func TestRichModeSet(t *testing.T)  {
 	assert.Equal(t, "true", mEnvs5["rich_mode"])
 	assert.Equal(t, types.ContainerConfigRichModeSystemd, mEnvs5[rich_mode_launch_env])
 }
-
-

--- a/daemon/mgr/container_rich_mode_test.go
+++ b/daemon/mgr/container_rich_mode_test.go
@@ -1,0 +1,80 @@
+package mgr
+
+import (
+	"github.com/alibaba/pouch/apis/types"
+	"testing"
+	"strings"
+	"github.com/stretchr/testify/assert"
+)
+
+func convertEnvArrayToMap(envs []string) map[string]string {
+	m := map[string]string{}
+	for _,e := range envs {
+		kvs := strings.Split(e, "=")
+		if len(kvs) == 2 {
+			m[kvs[0]] = kvs[1]
+		}
+	}
+
+	return m
+}
+
+func TestRichModeSet(t *testing.T)  {
+	c := &ContainerMeta{
+		Config: &types.ContainerConfig{
+			Rich: true,
+		},
+	}
+
+	envs1 := richContainerModeEnv(c)
+	mEnvs1 := convertEnvArrayToMap(envs1)
+
+	assert.Equal(t, "true", mEnvs1["rich_mode"])
+	assert.Equal(t, types.ContainerConfigRichModeDumbInit, mEnvs1[rich_mode_launch_env])
+
+	//test not set rich mode
+	c = &ContainerMeta{
+		Config: &types.ContainerConfig{
+			Rich: false,
+		},
+	}
+	envs2 := richContainerModeEnv(c)
+	assert.Equal(t, 0, len(envs2))
+
+	//test set rich mode manner, not set rich mode
+	c = &ContainerMeta{
+		Config: &types.ContainerConfig{
+			Rich: false,
+			RichMode: types.ContainerConfigRichModeSystemd,
+		},
+	}
+	envs3 := richContainerModeEnv(c)
+	assert.Equal(t, 0, len(envs3))
+
+	//test set rich mode manner
+	c = &ContainerMeta{
+		Config: &types.ContainerConfig{
+			Rich: true,
+			RichMode: types.ContainerConfigRichModeSystemd,
+		},
+	}
+	envs4 := richContainerModeEnv(c)
+	mEnvs4 := convertEnvArrayToMap(envs4)
+	assert.Equal(t, "true", mEnvs4["rich_mode"])
+	assert.Equal(t, types.ContainerConfigRichModeSystemd, mEnvs4[rich_mode_launch_env])
+
+	//test set rich mode by env
+	c = &ContainerMeta{
+		Config: &types.ContainerConfig{
+			Env: []string{
+				inter_rich_mode_env,
+			},
+		},
+	}
+	envs5 := richContainerModeEnv(c)
+	mEnvs5 := convertEnvArrayToMap(envs5)
+	assert.Equal(t, "true", mEnvs5["rich_mode"])
+	assert.Equal(t, types.ContainerConfigRichModeSystemd, mEnvs5[rich_mode_launch_env])
+}
+
+

--- a/daemon/mgr/container_rich_mode_test.go
+++ b/daemon/mgr/container_rich_mode_test.go
@@ -32,7 +32,7 @@ func TestRichModeSet(t *testing.T) {
 	mEnvs1 := convertEnvArrayToMap(envs1)
 
 	assert.Equal(t, "true", mEnvs1["rich_mode"])
-	assert.Equal(t, types.ContainerConfigRichModeDumbInit, mEnvs1[rich_mode_launch_env])
+	assert.Equal(t, types.ContainerConfigRichModeDumbInit, mEnvs1[richModeLaunchEnv])
 
 	//test not set rich mode
 	c = &ContainerMeta{
@@ -63,18 +63,18 @@ func TestRichModeSet(t *testing.T) {
 	envs4 := richContainerModeEnv(c)
 	mEnvs4 := convertEnvArrayToMap(envs4)
 	assert.Equal(t, "true", mEnvs4["rich_mode"])
-	assert.Equal(t, types.ContainerConfigRichModeSystemd, mEnvs4[rich_mode_launch_env])
+	assert.Equal(t, types.ContainerConfigRichModeSystemd, mEnvs4[richModeLaunchEnv])
 
 	//test set rich mode by env
 	c = &ContainerMeta{
 		Config: &types.ContainerConfig{
 			Env: []string{
-				inter_rich_mode_env,
+				interRichModeEnv,
 			},
 		},
 	}
 	envs5 := richContainerModeEnv(c)
 	mEnvs5 := convertEnvArrayToMap(envs5)
 	assert.Equal(t, "true", mEnvs5["rich_mode"])
-	assert.Equal(t, types.ContainerConfigRichModeSystemd, mEnvs5[rich_mode_launch_env])
+	assert.Equal(t, types.ContainerConfigRichModeSystemd, mEnvs5[richModeLaunchEnv])
 }

--- a/daemon/mgr/spec.go
+++ b/daemon/mgr/spec.go
@@ -64,6 +64,9 @@ var setupFunc = []SetupFunc{
 
 	// annotations in spec
 	setupAnnotations,
+
+	//hook
+	setupHook,
 }
 
 // Register is used to registe spec setup function.

--- a/daemon/mgr/spec_hook.go
+++ b/daemon/mgr/spec_hook.go
@@ -7,29 +7,31 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+//if set rich mode, set initscript
 func setupHook(ctx context.Context, c *ContainerMeta, spec *SpecWrapper) error {
-	//if set rich mode, set initscript
-	if c.Config.Rich && c.Config.InitScript != "" {
-		args := strings.Fields(c.Config.InitScript)
-		if args == nil || len(args) == 0 {
-			return nil
-		}
-
-		if spec.s.Hooks == nil {
-			spec.s.Hooks = &specs.Hooks{}
-		}
-
-		if spec.s.Hooks.Prestart == nil {
-			spec.s.Hooks.Prestart = []specs.Hook{}
-		}
-
-		preStartHook := specs.Hook{
-			Path: args[0],
-			Args: args[1:],
-		}
-
-		spec.s.Hooks.Prestart = append(spec.s.Hooks.Prestart, preStartHook)
+	if !c.Config.Rich || c.Config.InitScript == "" {
+		return nil
 	}
+
+	args := strings.Fields(c.Config.InitScript)
+	if len(args) == 0 {
+		return nil
+	}
+
+	if spec.s.Hooks == nil {
+		spec.s.Hooks = &specs.Hooks{}
+	}
+
+	if spec.s.Hooks.Prestart == nil {
+		spec.s.Hooks.Prestart = []specs.Hook{}
+	}
+
+	preStartHook := specs.Hook{
+		Path: args[0],
+		Args: args[1:],
+	}
+
+	spec.s.Hooks.Prestart = append(spec.s.Hooks.Prestart, preStartHook)
 
 	return nil
 }

--- a/daemon/mgr/spec_hook.go
+++ b/daemon/mgr/spec_hook.go
@@ -1,0 +1,35 @@
+package mgr
+
+import (
+	"context"
+	"strings"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func setupHook(ctx context.Context, c *ContainerMeta, spec *SpecWrapper) error {
+	//if set rich mode, set initscript
+	if c.Config.Rich && c.Config.InitScript != "" {
+		args := strings.Fields(c.Config.InitScript)
+		if args == nil || len(args) == 0 {
+			return nil
+		}
+
+		if spec.s.Hooks == nil {
+			spec.s.Hooks = &specs.Hooks{}
+		}
+
+		if spec.s.Hooks.Prestart == nil {
+			spec.s.Hooks.Prestart = []specs.Hook{}
+		}
+
+		preStartHook := specs.Hook{
+			Path: args[0],
+			Args: args[1:],
+		}
+
+		spec.s.Hooks.Prestart = append(spec.s.Hooks.Prestart, preStartHook)
+	}
+
+	return nil
+}

--- a/daemon/mgr/spec_process.go
+++ b/daemon/mgr/spec_process.go
@@ -35,7 +35,7 @@ func setupProcessEnv(ctx context.Context, c *ContainerMeta, spec *SpecWrapper) e
 	}
 
 	//set env for rich container mode
-	s.Process.Env = append(s.Process.Env, richContainerMode(c)...)
+	s.Process.Env = append(s.Process.Env, richContainerModeEnv(c)...)
 
 	return nil
 }

--- a/daemon/mgr/spec_process.go
+++ b/daemon/mgr/spec_process.go
@@ -33,6 +33,10 @@ func setupProcessEnv(ctx context.Context, c *ContainerMeta, spec *SpecWrapper) e
 	} else {
 		s.Process.Env = append(s.Process.Env, c.Config.Env...)
 	}
+
+	//set env for rich container mode
+	s.Process.Env = append(s.Process.Env, richContainerMode(c)...)
+
 	return nil
 }
 


### PR DESCRIPTION
1.Describe what this PR did

In pouch, we can start container in rich container mode by cli flag or API.
If by pouch client, we can set --rich flag to set rich container mode, and set --rich-mode to select which manner to init container, we support systemd, /sbin/init and dumb-init to init container.
If set dumb-init to init container, please install dumb-init in machines, https://github.com/Yelp/dumb-init/tree/v1.2.1
if set systemd or /sbin/init, we need to install systemd or /sbin/init in image.
Otherwise, we need to install runc modified by us to support it, referring to https://github.com/alibaba/runc/tree/v1.0.0-rc4-1.

2.Does this pull request fix one issue?

3.Describe how you did it

4.Describe how to verify it

5.Special notes for reviews