### PR TITLE
fix: make intel RDT compatible with legacy machines

### DIFF
--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -120,12 +120,11 @@ func setupCapabilities(ctx context.Context, meta *ContainerMeta, spec *SpecWrapp
 
 func setupIntelRdt(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper) error {
 	s := spec.s
-	if s.Linux.IntelRdt == nil {
-		s.Linux.IntelRdt = &specs.LinuxIntelRdt{}
-	}
 
-	s.Linux.IntelRdt = &specs.LinuxIntelRdt{
-		L3CacheSchema: meta.HostConfig.IntelRdtL3Cbm,
+	if meta.HostConfig.IntelRdtL3Cbm != "" {
+		s.Linux.IntelRdt = &specs.LinuxIntelRdt{
+			L3CacheSchema: meta.HostConfig.IntelRdtL3Cbm,
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>


### Ⅰ. Describe what this PR did

On a machine which does not support intel RDT, it would fail when creating a container:

```
root@ubuntu:/sys/fs/cgroup/memory/default# pouch run -d -m 20m registry.hub.docker.com/library/busybox:latest sleep 40
Error: failed to run container 11981b: {"message":"failed to create task, container id: 11981bee17b4a067ecd75d84b1598bcf6f5fa859d4ad119db40295d83de44869: OCI runtime create failed: intelRdt is specified in config, but Intel RDT feature is not supported or enabled: unknown"}
```

So the code base should not assign value when the RDT is empty.

This PR fixes this bug.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none

### Ⅲ. Describe how you did it
None


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews
/cc @Letty5411 


