### PR TITLE
test: use helloworld image in image test

### DIFF
--- a/test/cli_rmi_test.go
+++ b/test/cli_rmi_test.go
@@ -24,42 +24,42 @@ func (suite *PouchRmiSuite) SetUpSuite(c *check.C) {
 
 // TestRmiWorks tests "pouch rmi" work.
 func (suite *PouchRmiSuite) TestRmiWorks(c *check.C) {
-	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("pull", helloworldImageLatest).Assert(c, icmd.Success)
 
-	command.PouchRun("rmi", busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("rmi", helloworldImageLatest).Assert(c, icmd.Success)
 
 	res := command.PouchRun("images").Assert(c, icmd.Success)
-	if out := res.Combined(); strings.Contains(out, busyboxImage) {
-		c.Fatalf("unexpected output %s: should rm image %s\n", out, busyboxImage)
+	if out := res.Combined(); strings.Contains(out, helloworldImageLatest) {
+		c.Fatalf("unexpected output %s: should rm image %s\n", out, helloworldImageLatest)
 	}
 }
 
 // TestRmiForce tests "pouch rmi -f" work
 func (suite *PouchRmiSuite) TestRmiForce(c *check.C) {
-	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("pull", helloworldImageLatest).Assert(c, icmd.Success)
 
 	// TODO: rmi -f after create/start containers.
-	command.PouchRun("rmi", "-f", busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("rmi", "-f", helloworldImageLatest).Assert(c, icmd.Success)
 
 	res := command.PouchRun("images").Assert(c, icmd.Success)
-	if out := res.Combined(); strings.Contains(out, busyboxImage) {
-		c.Fatalf("unexpected output %s: should rm image %s\n", out, busyboxImage)
+	if out := res.Combined(); strings.Contains(out, helloworldImageLatest) {
+		c.Fatalf("unexpected output %s: should rm image %s\n", out, helloworldImageLatest)
 	}
 }
 
 // TestRmiByImageID tests "pouch rmi {ID}" work.
 func (suite *PouchRmiSuite) TestRmiByImageID(c *check.C) {
-	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("pull", helloworldImageLatest).Assert(c, icmd.Success)
 
 	res := command.PouchRun("images")
 	res.Assert(c, icmd.Success)
-	imageID := imagesListToKV(res.Combined())[busyboxImage][0]
+	imageID := imagesListToKV(res.Combined())[helloworldImageLatest][0]
 
 	command.PouchRun("rmi", imageID).Assert(c, icmd.Success)
 
 	res = command.PouchRun("images").Assert(c, icmd.Success)
-	if out := res.Combined(); strings.Contains(out, busyboxImage) {
-		c.Fatalf("unexpected output %s: should rm image %s\n", out, busyboxImage)
+	if out := res.Combined(); strings.Contains(out, helloworldImageLatest) {
+		c.Fatalf("unexpected output %s: should rm image %s\n", out, helloworldImageLatest)
 	}
 }
 

--- a/test/utils.go
+++ b/test/utils.go
@@ -16,6 +16,7 @@ import (
 const (
 	busyboxImage                = "registry.hub.docker.com/library/busybox:latest"
 	helloworldImage             = "registry.hub.docker.com/library/hello-world"
+	helloworldImageLatest       = "registry.hub.docker.com/library/hello-world:latest"
 	helloworldImageOnlyRepoName = "hello-world"
 
 	GateWay = "192.168.1.1"


### PR DESCRIPTION
Signed-off-by: letty <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
As issue #770 exists, cli_rmi_test.go may fail as following:
```
FAIL: /go/src/github.com/alibaba/pouch/test/cli_rmi_test.go:26: PouchRmiSuite.TestRmiWorks
/go/src/github.com/alibaba/pouch/test/cli_rmi_test.go:29:
    command.PouchRun("rmi", busyboxImage).Assert(c, icmd.Success)
/go/src/github.com/alibaba/pouch/vendor/github.com/gotestyourself/gotestyourself/icmd/command.go:61:
    t.Fatalf("at %s:%d - %s\n", filepath.Base(file), line, err.Error())
... Error: at cli_rmi_test.go:29 - 
Command:  /usr/local/bin/pouch rmi registry.hub.docker.com/library/busybox:latest
ExitCode: 1
Error:    exit status 1
Stdout:   
Stderr:   Error: failed to remove image: {"message":"Unable to remove the image \"registry.hub.docker.com/library/busybox:latest\" (must force) - container a7b06449f842ac02f4d20a6335405b9046a577ab4ba6d18386113762e21cdd50 is using this image"}
Failures:
ExitCode was 1 expected 0
Expected no error
```

So instead of using busybox image, using helloworld image which is usually not used to create container to avoid such kind of failure.
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


