### PR TITLE
feature: add cgroupspath flag for pouchd

### DIFF
--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -79,5 +79,8 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringVar(&c.richMode, "rich-mode", "", "Choose one rich container mode. dumb-init(default), systemd, sbin-init")
 	flagSet.StringVar(&c.initScript, "initscript", "", "Initial script executed in container")
 
+	// cgroup
+	flagSet.StringVarP(&c.cgroupParent, "cgroup-parent", "", "default", "Optional parent cgroup for the container")
+
 	return c
 }

--- a/cli/container.go
+++ b/cli/container.go
@@ -56,6 +56,8 @@ type container struct {
 	blkioDeviceWriteIOps ThrottleIOpsDevice
 	IntelRdtL3Cbm        string
 
+	cgroupParent string
+
 	//add for rich container mode
 	rich       bool
 	richMode   string
@@ -170,6 +172,8 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 				BlkioDeviceWriteBps:  c.blkioDeviceWriteBps.value(),
 				BlkioDeviceWriteIOps: c.blkioDeviceWriteIOps.value(),
 				IntelRdtL3Cbm:        intelRdtL3Cbm,
+
+				CgroupParent: c.cgroupParent,
 			},
 			EnableLxcfs:   c.enableLxcfs,
 			Privileged:    c.privileged,

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -63,4 +63,7 @@ type Config struct {
 
 	// Configuration file of pouchd
 	ConfigFile string `json:"config-file,omitempty"`
+
+	// CgroupParent is to set parent cgroup for all containers
+	CgroupParent string `json:"cgroup-parent,omitempty"`
 }

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -476,8 +476,16 @@ func (mgr *ContainerManager) Start(ctx context.Context, id, detachKeys string) (
 		return errors.Wrapf(err, "failed to generate spec: %s", c.ID())
 	}
 
-	// TODO Hardcode for test
-	s.Linux.CgroupsPath = filepath.Join("/", c.ID())
+	var cgroupsParent string
+	if c.meta.HostConfig.CgroupParent != "" {
+		cgroupsParent = c.meta.HostConfig.CgroupParent
+	} else if mgr.Config.CgroupParent != "" {
+		cgroupsParent = mgr.Config.CgroupParent
+	}
+
+	if cgroupsParent != "" {
+		s.Linux.CgroupsPath = filepath.Join(cgroupsParent, c.ID())
+	}
 
 	sw := &SpecWrapper{
 		s:      s,

--- a/main.go
+++ b/main.go
@@ -84,6 +84,9 @@ func setupFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.ImageProxy, "image-proxy", "", "Http proxy to pull image")
 	flagSet.StringVar(&cfg.QuotaDriver, "quota-driver", "", "Set quota driver(grpquota/prjquota), if not set, it will set by kernel version")
 	flagSet.StringVar(&cfg.ConfigFile, "config-file", "/etc/pouch/config.json", "Configuration file of pouchd")
+
+	// cgroup-path flag is to set parent cgroup for all containers, default is "default" staying with containerd's configuration.
+	flagSet.StringVar(&cfg.CgroupParent, "cgroup-parent", "default", "Set parent cgroup for all containers")
 }
 
 // parse flags

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"time"
@@ -402,7 +403,7 @@ func (suite *PouchRunSuite) TestRunWithLimitedMemory(c *check.C) {
 
 	// test if cgroup has record the real value
 	containerID := result.ID
-	path := fmt.Sprintf("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", containerID)
+	path := fmt.Sprintf("/sys/fs/cgroup/memory/default/%s/memory.limit_in_bytes", containerID)
 
 	checkFileContains(c, path, "104857600")
 
@@ -426,7 +427,7 @@ func (suite *PouchRunSuite) TestRunWithMemoryswap(c *check.C) {
 
 	// test if cgroup has record the real value
 	containerID := result.ID
-	path := fmt.Sprintf("/sys/fs/cgroup/memory/%s/memory.memsw.limit_in_bytes", containerID)
+	path := fmt.Sprintf("/sys/fs/cgroup/memory/default/%s/memory.memsw.limit_in_bytes", containerID)
 	checkFileContains(c, path, "209715200")
 
 	// remove the container
@@ -449,7 +450,7 @@ func (suite *PouchRunSuite) TestRunWithMemoryswappiness(c *check.C) {
 
 	// test if cgroup has record the real value
 	containerID := result.ID
-	path := fmt.Sprintf("/sys/fs/cgroup/memory/%s/memory.swappiness", containerID)
+	path := fmt.Sprintf("/sys/fs/cgroup/memory/default/%s/memory.swappiness", containerID)
 	checkFileContains(c, path, "70")
 
 	command.PouchRun("rm", "-f", cname).Assert(c, icmd.Success)
@@ -475,15 +476,15 @@ func (suite *PouchRunSuite) TestRunWithCPULimit(c *check.C) {
 	// test if cgroup has record the real value
 	containerID := result.ID
 	{
-		path := fmt.Sprintf("/sys/fs/cgroup/cpuset/%s/cpuset.cpus", containerID)
+		path := fmt.Sprintf("/sys/fs/cgroup/cpuset/default/%s/cpuset.cpus", containerID)
 		checkFileContains(c, path, "0")
 	}
 	{
-		path := fmt.Sprintf("/sys/fs/cgroup/cpuset/%s/cpuset.mems", containerID)
+		path := fmt.Sprintf("/sys/fs/cgroup/cpuset/default/%s/cpuset.mems", containerID)
 		checkFileContains(c, path, "0")
 	}
 	{
-		path := fmt.Sprintf("/sys/fs/cgroup/cpu/%s/cpu.shares", containerID)
+		path := fmt.Sprintf("/sys/fs/cgroup/cpu/default/%s/cpu.shares", containerID)
 		checkFileContains(c, path, "1000")
 	}
 
@@ -508,7 +509,7 @@ func (suite *PouchRunSuite) TestRunBlockIOWeight(c *check.C) {
 	// test if cgroup has record the real value
 	containerID := result.ID
 	{
-		path := fmt.Sprintf("/sys/fs/cgroup/blkio/%s/blkio.weight", containerID)
+		path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.weight", containerID)
 		checkFileContains(c, path, "100")
 	}
 	command.PouchRun("rm", "-f", cname).Assert(c, icmd.Success)
@@ -538,7 +539,7 @@ func (suite *PouchRunSuite) TestRunBlockIOWeightDevice(c *check.C) {
 	// test if cgroup has record the real value
 	//containerID := result.ID
 	//{
-	//	path := fmt.Sprintf("/sys/fs/cgroup/blkio/%s/blkio.weight_device", containerID)
+	//	path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.weight_device", containerID)
 	//	checkFileContains(c, path, "100")
 	//}
 	command.PouchRun("rm", "-f", cname).Assert(c, icmd.Success)
@@ -568,7 +569,7 @@ func (suite *PouchRunSuite) TestRunDeviceReadBps(c *check.C) {
 	// test if cgroup has record the real value
 	containerID := result.ID
 	{
-		path := fmt.Sprintf("/sys/fs/cgroup/blkio/%s/blkio.throttle.read_bps_device", containerID)
+		path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.throttle.read_bps_device", containerID)
 		checkFileContains(c, path, "1048576")
 	}
 	command.PouchRun("rm", "-f", cname).Assert(c, icmd.Success)
@@ -598,7 +599,7 @@ func (suite *PouchRunSuite) TestRunDeviceWriteBps(c *check.C) {
 	// test if cgroup has record the real value
 	containerID := result.ID
 	{
-		path := fmt.Sprintf("/sys/fs/cgroup/blkio/%s/blkio.throttle.write_bps_device", containerID)
+		path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.throttle.write_bps_device", containerID)
 		checkFileContains(c, path, "1048576")
 	}
 	command.PouchRun("rm", "-f", cname).Assert(c, icmd.Success)
@@ -628,7 +629,7 @@ func (suite *PouchRunSuite) TestRunDeviceReadIops(c *check.C) {
 	// test if cgroup has record the real value
 	containerID := result.ID
 	{
-		path := fmt.Sprintf("/sys/fs/cgroup/blkio/%s/blkio.throttle.read_iops_device", containerID)
+		path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.throttle.read_iops_device", containerID)
 		checkFileContains(c, path, "1000")
 	}
 	command.PouchRun("rm", "-f", cname).Assert(c, icmd.Success)
@@ -658,7 +659,7 @@ func (suite *PouchRunSuite) TestRunDeviceWriteIops(c *check.C) {
 	// test if cgroup has record the real value
 	containerID := result.ID
 	{
-		path := fmt.Sprintf("/sys/fs/cgroup/blkio/%s/blkio.throttle.write_iops_device", containerID)
+		path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.throttle.write_iops_device", containerID)
 		checkFileContains(c, path, "1000")
 	}
 	command.PouchRun("rm", "-f", cname).Assert(c, icmd.Success)
@@ -699,4 +700,48 @@ func (suite *PouchRunSuite) TestRunWithHostFileVolume(c *check.C) {
 	command.PouchRun("run", "-d", "--name", cname, "-v", fmt.Sprintf("%s:%s", filepath, filepath), busyboxImage).Assert(c, icmd.Success)
 
 	command.PouchRun("rm", "-f", cname).Assert(c, icmd.Success)
+}
+
+// TestRunWithCgroupParent tests running container with --cgroup-parent.
+func (suite *PouchRunSuite) TestRunWithCgroupParent(c *check.C) {
+	// cgroup-parent relative path
+	testRunWithCgroupParent(c, "pouch", "TestRunWithRelativePathOfCgroupParent")
+
+	// cgroup-parent absolute path
+	testRunWithCgroupParent(c, "/pouch/test", "TestRunWithAbsolutePathOfCgroupParent")
+}
+
+func testRunWithCgroupParent(c *check.C, cgroupParent, name string) {
+	command.PouchRun("run", "-d", "-m", "300M", "--cgroup-parent", cgroupParent, "--name", name, busyboxImage).Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", name).Stdout()
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	containerID := result.ID
+
+	// this code slice may not robust, but for this test case is enough.
+	if strings.HasPrefix(cgroupParent, "/") {
+		cgroupParent = cgroupParent[1:]
+	}
+
+	if cgroupParent == "" {
+		cgroupParent = "default"
+	}
+
+	file := "/sys/fs/cgroup/memory/" + cgroupParent + "/" + containerID + "/memory.limit_in_bytes"
+	if _, err := os.Stat(file); err != nil {
+		c.Fatalf("container %s cgroup mountpoint not exists", containerID)
+	}
+
+	out, err := exec.Command("cat", file).Output()
+	if err != nil {
+		c.Fatalf("execute cat command failed: %v", err)
+	}
+
+	if !strings.Contains(string(out), "314572800") {
+		c.Fatalf("unexpected output %s expected %s\n", string(out), "314572800")
+	}
+
 }

--- a/test/cli_update_test.go
+++ b/test/cli_update_test.go
@@ -52,7 +52,7 @@ func (suite *PouchUpdateSuite) TestUpdateRunningContainer(c *check.C) {
 	}
 	containerID := result.ID
 
-	file := "/sys/fs/cgroup/memory/" + containerID + "/memory.limit_in_bytes"
+	file := "/sys/fs/cgroup/memory/default/" + containerID + "/memory.limit_in_bytes"
 	if _, err := os.Stat(file); err != nil {
 		c.Fatalf("container %s cgroup mountpoint not exists", containerID)
 	}
@@ -86,7 +86,7 @@ func (suite *PouchUpdateSuite) TestUpdateStoppedContainer(c *check.C) {
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 
-	file := "/sys/fs/cgroup/memory/" + containerID + "/memory.limit_in_bytes"
+	file := "/sys/fs/cgroup/memory/default/" + containerID + "/memory.limit_in_bytes"
 	if _, err := os.Stat(file); err != nil {
 		c.Fatalf("container %s cgroup mountpoint not exists", containerID)
 	}


### PR DESCRIPTION
Signed-off-by: HusterWan zirenwan@gmail.com

### Ⅰ. Describe what this PR did
add --cgroup-parent flag for pouchd , cgroup-parent is to set parent cgroup for all containers

start pouchd with cgroup-parent flag
```
pouchd --cgroup-parent test --debug

```
create a new container
```
[root@osboxes pouch]# pouch run -d -m 20m --name test-cgroupParents registry.hub.docker.com/library/busybox:latest
a8bea71cf77dcadaef5016677805af4fa6b6dd63c937ba79d34dacf6c73ee0ae
```
watch new container's cgroup parent path
```
[root@osboxes pouch]# cat /sys/fs/cgroup/memory/test/a8bea71cf77dcadaef5016677805af4fa6b6dd63c937ba79d34dacf6c73ee0ae/
cgroup.clone_children               memory.kmem.tcp.max_usage_in_bytes  memory.oom_control
cgroup.event_control                memory.kmem.tcp.usage_in_bytes      memory.pressure_level
cgroup.procs                        memory.kmem.usage_in_bytes          memory.soft_limit_in_bytes
memory.failcnt                      memory.limit_in_bytes               memory.stat
memory.force_empty                  memory.max_usage_in_bytes           memory.swappiness
memory.kmem.failcnt                 memory.memsw.failcnt                memory.usage_in_bytes
memory.kmem.limit_in_bytes          memory.memsw.limit_in_bytes         memory.use_hierarchy
memory.kmem.max_usage_in_bytes      memory.memsw.max_usage_in_bytes     notify_on_release
memory.kmem.slabinfo                memory.memsw.usage_in_bytes         tasks
memory.kmem.tcp.failcnt             memory.move_charge_at_immigrate
memory.kmem.tcp.limit_in_bytes      memory.numa_stat
```

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


