### PR TITLE
bugfix: set quota by kernel version

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -54,4 +54,7 @@ type Config struct {
 
 	// ImageProxy is a http proxy to pull image
 	ImageProxy string `json:"image-proxy,omitempty"`
+
+	// QuotaDriver is used to set the driver of Quota
+	QuotaDriver string
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/lxcfs"
 	"github.com/alibaba/pouch/pkg/exec"
+	"github.com/alibaba/pouch/pkg/quota"
 	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/version"
 
@@ -72,6 +73,7 @@ func setupFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.LxcfsHome, "lxcfs-home", "/var/lib/lxc/lxcfs", "Specify the mount dir of lxcfs")
 	flagSet.StringVar(&cfg.DefaultRegistry, "default-registry", "registry.hub.docker.com/library/", "Default Image Registry")
 	flagSet.StringVar(&cfg.ImageProxy, "image-proxy", "", "Http proxy to pull image")
+	flagSet.StringVar(&cfg.QuotaDriver, "quota-driver", "", "Set quota driver(grpquota/prjquota), if not set, it will set by kernel version")
 }
 
 // runDaemon prepares configs, setups essential details and runs pouchd daemon.
@@ -122,6 +124,10 @@ func runDaemon() error {
 				"-l", utils.If(cfg.Debug, "debug", "info").(string),
 			},
 		},
+	}
+
+	if cfg.QuotaDriver != "" {
+		quota.SetQuotaDriver(cfg.QuotaDriver)
 	}
 
 	if err := checkLxcfsCfg(); err != nil {

--- a/pkg/kernel/kernel.go
+++ b/pkg/kernel/kernel.go
@@ -1,0 +1,46 @@
+package kernel
+
+import (
+	"fmt"
+
+	"github.com/alibaba/pouch/pkg/exec"
+	"github.com/pkg/errors"
+)
+
+// VersionInfo holds information about the kernel.
+type VersionInfo struct {
+	Kernel int    // Version of the kernel (e.g. 4.1.2-generic -> 4)
+	Major  int    // Major part of the kernel version (e.g. 4.1.2-generic -> 1)
+	Minor  int    // Minor part of the kernel version (e.g. 4.1.2-generic -> 2)
+	Flavor string // Flavor of the kernel version (e.g. 4.1.2-generic -> generic)
+}
+
+// String returns the kernel version's string format.
+func (k *VersionInfo) String() string {
+	return fmt.Sprintf("%d.%d.%d-%s", k.Kernel, k.Major, k.Minor, k.Flavor)
+}
+
+// GetKernelVersion returns the kernel version info.
+func GetKernelVersion() (*VersionInfo, error) {
+	var (
+		kernel, major, minor int
+		flavor               string
+	)
+
+	_, stdout, _, err := exec.Run(0, "uname", "-r")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to run command uname -r")
+	}
+
+	parsed, _ := fmt.Sscanf(stdout, "%d.%d.%d-%s", &kernel, &major, &minor, &flavor)
+	if parsed < 3 {
+		return nil, fmt.Errorf("Can't parse kernel version, release: %s" + stdout)
+	}
+
+	return &VersionInfo{
+		Kernel: kernel,
+		Major:  major,
+		Minor:  minor,
+		Flavor: flavor,
+	}, nil
+}

--- a/pkg/kernel/kernel_test.go
+++ b/pkg/kernel/kernel_test.go
@@ -1,0 +1,14 @@
+package kernel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetKernelVersion(t *testing.T) {
+	version, err := GetKernelVersion()
+	assert.Equal(t, nil, err)
+
+	println(version.String())
+}

--- a/pkg/quota/grpquota.go
+++ b/pkg/quota/grpquota.go
@@ -1,4 +1,4 @@
-package local
+package quota
 
 import (
 	"fmt"

--- a/pkg/quota/prjquota.go
+++ b/pkg/quota/prjquota.go
@@ -1,4 +1,4 @@
-package local
+package quota
 
 import (
 	"fmt"

--- a/volume/modules/local/local.go
+++ b/volume/modules/local/local.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alibaba/pouch/pkg/quota"
 	"github.com/alibaba/pouch/volume/driver"
 	"github.com/alibaba/pouch/volume/types"
 )
@@ -113,8 +114,8 @@ func (p *Local) Attach(ctx driver.Context, v *types.Volume, s *types.Storage) er
 	}
 
 	if size != "" && size != "0" {
-		StartQuotaDriver(mountPath)
-		if ex := SetDiskQuota(mountPath, size, 0); ex != nil {
+		quota.StartQuotaDriver(mountPath)
+		if ex := quota.SetDiskQuota(mountPath, size, 0); ex != nil {
 			return ex
 		}
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Modify quota driver by kernel version, if kernel version >= 4.0, quota
uses prjquota, otherwise using grpquota.
Add quota config, when running pouchd, you can use quota-driver to set
the driver of quota. Currently, it supports "prjquota" and "grpquota."

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #798 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
