### PR TITLE
feature: pouch inspect support format flag

### DIFF
--- a/cli/inspect/inspector.go
+++ b/cli/inspect/inspector.go
@@ -1,0 +1,141 @@
+package inspect
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"text/template"
+
+	"github.com/alibaba/pouch/pkg/utils/templates"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// Inspector defines an interface to implement to process elements.
+type Inspector interface {
+	Inspect(typedElement interface{}) error
+	Flush() error
+}
+
+// TemplateInspector uses a template to inspect elements.
+type TemplateInspector struct {
+	outputStream io.Writer
+	buffer       *bytes.Buffer
+	tmpl         *template.Template
+}
+
+// NewTemplateInspector creates a new inspector with a template.
+func NewTemplateInspector(out io.Writer, tmpl *template.Template) Inspector {
+	return &TemplateInspector{
+		outputStream: out,
+		buffer:       new(bytes.Buffer),
+		tmpl:         tmpl,
+	}
+}
+
+// NewTemplateInspectorFromString creates a new TemplateInspector from a string.
+func NewTemplateInspectorFromString(out io.Writer, tmplStr string) (Inspector, error) {
+	if tmplStr == "" {
+		return NewIndentedInspector(out), nil
+	}
+
+	tmpl, err := templates.Parse(tmplStr)
+	if err != nil {
+		return nil, errors.Errorf("Parse template String error: %s", err)
+	}
+	return NewTemplateInspector(out, tmpl), nil
+}
+
+// GetRefFunc is a function which used by Inspect to fetch an object from
+// a reference
+type GetRefFunc func(ref string) (interface{}, error)
+
+// Inspect fetches objects by reference and writes the json representation
+// to the output writer.
+func Inspect(out io.Writer, ref string, tmplStr string, getRef GetRefFunc) error {
+	inspector, err := NewTemplateInspectorFromString(out, tmplStr)
+	if err != nil {
+		return err
+	}
+
+	element, err := getRef(ref)
+	if err != nil {
+		return errors.Errorf("Template parsing error: %v", err)
+	}
+
+	if err := inspector.Inspect(element); err != nil {
+		return err
+	}
+
+	if err := inspector.Flush(); err != nil {
+		logrus.Errorf("%s\n", err)
+	}
+
+	return nil
+}
+
+// Inspect executes the inspect template.
+func (i *TemplateInspector) Inspect(typedElement interface{}) error {
+	buf := new(bytes.Buffer)
+	if err := i.tmpl.Execute(buf, typedElement); err != nil {
+		return errors.Errorf("Template parsing error: %v", err)
+	}
+	i.buffer.Write(buf.Bytes())
+	i.buffer.WriteByte('\n')
+	return nil
+}
+
+// Flush writes the result of inspecting all elements into output stream.
+func (i *TemplateInspector) Flush() error {
+	if i.buffer.Len() == 0 {
+		_, err := io.WriteString(i.outputStream, "\n")
+		return err
+	}
+
+	_, err := io.Copy(i.outputStream, i.buffer)
+	return err
+}
+
+// IndentedInspector uses a buffer to stop the indented representation of an element.
+type IndentedInspector struct {
+	outputStream io.Writer
+	elements     interface{}
+	rawElements  [][]byte
+}
+
+// NewIndentedInspector generates a new IndentedInspector.
+func NewIndentedInspector(outputStream io.Writer) Inspector {
+	return &IndentedInspector{
+		outputStream: outputStream,
+	}
+}
+
+// Inspect writes the raw element with an indented json format.
+func (i *IndentedInspector) Inspect(typedElement interface{}) error {
+	// TODO handle raw elements
+	i.elements = typedElement
+	return nil
+}
+
+// Flush writes the result of inspecting all elements into the output stream.
+func (i *IndentedInspector) Flush() error {
+	// TODO handle raw elements
+	if i.elements == nil {
+		_, err := io.WriteString(i.outputStream, "\n")
+		return err
+	}
+
+	var buffer io.Reader
+	b, err := json.MarshalIndent(i.elements, "", "    ")
+	if err != nil {
+		return err
+	}
+	buffer = bytes.NewReader(b)
+
+	if _, err := io.Copy(i.outputStream, buffer); err != nil {
+		return err
+	}
+	_, err = io.WriteString(i.outputStream, "\n")
+	return err
+}

--- a/cli/inspect/inspector_test.go
+++ b/cli/inspect/inspector_test.go
@@ -1,0 +1,271 @@
+package inspect
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestNewTemplateInspector(t *testing.T) {
+	type args struct {
+		tmpl *template.Template
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Inspector
+		wantOut string
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			if got := NewTemplateInspector(out, tt.args.tmpl); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewTemplateInspector() = %v, want %v", got, tt.want)
+			}
+			if gotOut := out.String(); gotOut != tt.wantOut {
+				t.Errorf("NewTemplateInspector() = %v, want %v", gotOut, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestNewTemplateInspectorFromString(t *testing.T) {
+	type args struct {
+		tmplStr string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Inspector
+		wantOut string
+		wantErr bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			got, err := NewTemplateInspectorFromString(out, tt.args.tmplStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewTemplateInspectorFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewTemplateInspectorFromString() = %v, want %v", got, tt.want)
+			}
+			if gotOut := out.String(); gotOut != tt.wantOut {
+				t.Errorf("NewTemplateInspectorFromString() = %v, want %v", gotOut, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestInspect(t *testing.T) {
+	// Prepare test data
+	type testElement struct {
+		ID string `json:"Id"`
+	}
+
+	getRefFunc := func(ref string) (interface{}, error) {
+		return testElement{
+			ID: "id",
+		}, nil
+	}
+
+	type args struct {
+		references string
+		tmplStr    string
+		getRef     GetRefFunc
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantOut string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "testInspectDefault",
+			args: args{
+				references: "test",
+				tmplStr:    "",
+				getRef:     getRefFunc,
+			},
+			wantOut: "id",
+			wantErr: false,
+		}, {
+			name: "testInspectTemplate",
+			args: args{
+				references: "test",
+				tmplStr:    "{{.ID}}",
+				getRef:     getRefFunc,
+			},
+			wantOut: "id",
+			wantErr: false,
+		}, {
+			name: "testInspectTemplateError",
+			args: args{
+				references: "test",
+				tmplStr:    "{{.Id}}",
+				getRef:     getRefFunc,
+			},
+			wantOut: "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			if err := Inspect(out, tt.args.references, tt.args.tmplStr, tt.args.getRef); (err != nil) != tt.wantErr {
+				t.Errorf("Inspect() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if gotOut := out.String(); !strings.Contains(gotOut, tt.wantOut) {
+				t.Errorf("Inspect() = %v, want %v", gotOut, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestTemplateInspector_Inspect(t *testing.T) {
+	type fields struct {
+		outputStream io.Writer
+		buffer       *bytes.Buffer
+		tmpl         *template.Template
+	}
+	type args struct {
+		typedElement interface{}
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &TemplateInspector{
+				outputStream: tt.fields.outputStream,
+				buffer:       tt.fields.buffer,
+				tmpl:         tt.fields.tmpl,
+			}
+			if err := i.Inspect(tt.args.typedElement); (err != nil) != tt.wantErr {
+				t.Errorf("TemplateInspector.Inspect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTemplateInspector_Flush(t *testing.T) {
+	type fields struct {
+		outputStream io.Writer
+		buffer       *bytes.Buffer
+		tmpl         *template.Template
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &TemplateInspector{
+				outputStream: tt.fields.outputStream,
+				buffer:       tt.fields.buffer,
+				tmpl:         tt.fields.tmpl,
+			}
+			if err := i.Flush(); (err != nil) != tt.wantErr {
+				t.Errorf("TemplateInspector.Flush() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewIndentedInspector(t *testing.T) {
+	tests := []struct {
+		name             string
+		want             Inspector
+		wantOutputStream string
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputStream := &bytes.Buffer{}
+			if got := NewIndentedInspector(outputStream); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewIndentedInspector() = %v, want %v", got, tt.want)
+			}
+			if gotOutputStream := outputStream.String(); gotOutputStream != tt.wantOutputStream {
+				t.Errorf("NewIndentedInspector() = %v, want %v", gotOutputStream, tt.wantOutputStream)
+			}
+		})
+	}
+}
+
+func TestIndentedInspector_Inspect(t *testing.T) {
+	type fields struct {
+		outputStream io.Writer
+		elements     []interface{}
+		rawElements  [][]byte
+	}
+	type args struct {
+		typedElement interface{}
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &IndentedInspector{
+				outputStream: tt.fields.outputStream,
+				elements:     tt.fields.elements,
+				rawElements:  tt.fields.rawElements,
+			}
+			if err := i.Inspect(tt.args.typedElement); (err != nil) != tt.wantErr {
+				t.Errorf("IndentedInspector.Inspect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIndentedInspector_Flush(t *testing.T) {
+	type fields struct {
+		outputStream io.Writer
+		elements     []interface{}
+		rawElements  [][]byte
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &IndentedInspector{
+				outputStream: tt.fields.outputStream,
+				elements:     tt.fields.elements,
+				rawElements:  tt.fields.rawElements,
+			}
+			if err := i.Flush(); (err != nil) != tt.wantErr {
+				t.Errorf("IndentedInspector.Flush() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cli/update.go
+++ b/cli/update.go
@@ -26,7 +26,7 @@ func (uc *UpdateCommand) Init(c *Cli) {
 		Use:   "update [OPTIONS] CONTAINER",
 		Short: "Update the configurations of a container",
 		Long:  updateDescription,
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return uc.updateRun(args)
 		},

--- a/pkg/utils/templates/templates.go
+++ b/pkg/utils/templates/templates.go
@@ -1,0 +1,33 @@
+package templates
+
+import (
+	"encoding/json"
+	"strings"
+	"text/template"
+)
+
+// basicFunctions are the set of initial
+// functions provided to every template.
+var basicFunctions = template.FuncMap{
+	"json": func(v interface{}) string {
+		a, _ := json.Marshal(v)
+		return string(a)
+	},
+	"split": strings.Split,
+	"join":  strings.Join,
+	"title": strings.Title,
+	"lower": strings.ToLower,
+	"upper": strings.ToUpper,
+}
+
+// Parse creates a new annonymous template with the basic functions
+// and parses the given format.
+func Parse(format string) (*template.Template, error) {
+	return NewParse("", format)
+}
+
+// NewParse creates a new tagged template with the basic functions
+// and parses the given format.
+func NewParse(tag, format string) (*template.Template, error) {
+	return template.New(tag).Funcs(basicFunctions).Parse(format)
+}

--- a/pkg/utils/templates/templates_test.go
+++ b/pkg/utils/templates/templates_test.go
@@ -1,0 +1,28 @@
+package templates
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	tm, err := Parse(`{{join (split . ":") "/"}}`)
+	assert.NoError(t, err)
+
+	var b bytes.Buffer
+	assert.NoError(t, tm.Execute(&b, "text:with:colon"))
+	want := "text/with/colon"
+	assert.Equal(t, want, b.String())
+}
+
+func TestNewParse(t *testing.T) {
+	tm, err := NewParse("test", "this is a {{ . }}")
+	assert.NoError(t, err)
+
+	var b bytes.Buffer
+	assert.NoError(t, tm.Execute(&b, "string"))
+	want := "this is a string"
+	assert.Equal(t, want, b.String())
+}

--- a/test/cli_inspect_test.go
+++ b/test/cli_inspect_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// PouchInspectSuite is the test suite for inspect CLI.
+type PouchInspectSuite struct{}
+
+func init() {
+	check.Suite(&PouchInspectSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each test suite.
+func (suite *PouchInspectSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	environment.PruneAllContainers(apiClient)
+
+	command.PouchRun("pull", busyboxImage).Assert(c, icmd.Success)
+}
+
+// TearDownTest does cleanup work in the end of each test.
+func (suite *PouchInspectSuite) TearDownTest(c *check.C) {
+}
+
+// TestInspectFormat is to verify the format flag of inspect command.
+func (suite *PouchInspectSuite) TestInspectFormat(c *check.C) {
+	name := "inspect-format-print"
+
+	command.PouchRun("create", "-m", "30M", "--name", name, busyboxImage).Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", name).Stdout()
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	containerID := result.ID
+
+	// inspect Container ID
+	output = command.PouchRun("inspect", "-f", "{{.ID}}", name).Stdout()
+	c.Assert(output, check.Equals, fmt.Sprintf("%s\n", containerID))
+
+	// inspect Memory
+	output = command.PouchRun("inspect", "-f", "{{.HostConfig.Memory}}", name).Stdout()
+	c.Assert(output, check.Equals, fmt.Sprintf("%d\n", result.HostConfig.Memory))
+
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
+}
+
+// TestInspectWrongFormat is to verify using wrong format flag of inspect command.
+func (suite *PouchInspectSuite) TestInspectWrongFormat(c *check.C) {
+	name := "inspect-wrong-format-print"
+
+	command.PouchRun("create", "-m", "30M", "--name", name, busyboxImage).Assert(c, icmd.Success)
+
+	res := command.PouchRun("inspect", "-f", "{{.NotExists}}", name)
+	c.Assert(res.Error, check.NotNil)
+
+	expectString := "Template parsing error"
+	if out := res.Combined(); !strings.Contains(out, expectString) {
+		c.Fatalf("unexpected output %s expected %s", out, expectString)
+	}
+
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
+
+}


### PR DESCRIPTION
Signed-off-by: HusterWan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
pouch inspect support format flag

### Ⅱ. Does this pull request fix one issue?
fixes https://github.com/alibaba/pouch/issues/801

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
```
root@osboxes:wanziren -> pouch inspect  68d0d2
{
    "Args": null,
    "Config": {
        "Cmd": [
            "sh"
        ],
        "Entrypoint": null,
        "Env": [
            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
        ],
        "Image": "registry.hub.docker.com/library/busybox:latest",
        "OnBuild": null,
        "Shell": null
    },
    "Created": "2018-03-07T10:08:51.916962435Z",
    "HostConfig": {
        "NetworkMode": "bridge",
        "RestartPolicy": {
            "Name": "no"
        },
        "Runtime": "runc",
        "BlkioDeviceReadBps": null,
        "BlkioDeviceReadIOps": null,
        "BlkioDeviceWriteBps": null,
        "BlkioDeviceWriteIOps": null,
        "BlkioWeightDevice": null,
        "CgroupParent": "/cgroup-parent/test",
        "DeviceCgroupRules": null,
        "Devices": [],
        "Memory": 20971520,
        "MemoryExtra": 0,
        "MemorySwappiness": -1,
        "MemoryWmarkRatio": 0,
        "Ulimits": null
    },
    "Id": "201d65bd4c864870d29bbebd414449b11ad12e70890aa4d582b88db5e294d743",
    "Image": "registry.hub.docker.com/library/busybox:latest",
    "Mounts": null,
    "Name": "test-2",
    "NetworkSettings": {
        "Networks": {
            "bridge": {
                "Aliases": null,
                "EndpointID": "14493b224b035fa85a7da321f690b0f4235e0c25a055c938286d0b0939b12b51",
                "Gateway": "172.17.0.1",
                "IPAddress": "172.17.0.3/24",
                "IPPrefixLen": 24,
                "Links": null,
                "MacAddress": "02:42:ac:11:00:03",
                "NetworkID": "6f72c7d10f4c07e8744ff846d522a8641c0786e102bfbda20fb4f9a2190bf65b"
            }
        },
        "SecondaryIPAddresses": null,
        "SecondaryIPv6Addresses": null
    },
    "State": {
        "Pid": 21838,
        "StartedAt": "2018-03-07T10:08:52.285987108Z",
        "Status": "running"
    }
}
```

```
root@osboxes:wanziren -> pouch inspect --format {{.ID}} 68d0d2
68d0d29ebe038a6761565c2bf31c774adcd66cce3d42eaf7e63b2479d37b139e
```

```
root@osboxes:wanziren -> pouch inspect --format {{.State.Pid}} 68d0d2
5396
```
### Ⅴ. Special notes for reviews


