### PR TITLE
fix: ordinary binary volume binding bugs

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -983,14 +983,12 @@ func (mgr *ContainerManager) parseVolumes(ctx context.Context, c *types.Containe
 			}
 
 			source = mountPath
-		} else {
-			// Create the host path if it doesn't exist.
-			_, err := os.Stat(source)
-			if err != nil && !os.IsNotExist(err) {
+		} else if _, err := os.Stat(source); err != nil {
+			if !os.IsNotExist(err) {
 				return errors.Errorf("failed to stat %q: %v", source, err)
 			}
-			err = os.MkdirAll(source, 0755)
-			if err != nil {
+			// Create the host path if it doesn't exist.
+			if err := os.MkdirAll(source, 0755); err != nil {
 				return errors.Errorf("failed to mkdir %q: %v", source, err)
 			}
 		}

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -687,3 +687,16 @@ func (suite *PouchRunSuite) TestRunAlikernelMemoryForceEmptyCtl(c *check.C) {
 	// TODO: as runc has not implemented it, add test later
 	SkipIfFalse(c, environment.IsAliKernel)
 }
+
+// TestRunWithHostFileVolume tests binding a host file as a volume into container.
+// fixes https://github.com/alibaba/pouch/issues/813
+func (suite *PouchRunSuite) TestRunWithHostFileVolume(c *check.C) {
+	// first create a file on the host
+	filepath := "/tmp/TestRunWithHostFileVolume.md"
+	icmd.RunCommand("touch", filepath).Assert(c, icmd.Success)
+
+	cname := "TestRunWithCPULimit"
+	command.PouchRun("run", "-d", "--name", cname, "-v", fmt.Sprintf("%s:%s", filepath, filepath), busyboxImage).Assert(c, icmd.Success)
+
+	command.PouchRun("rm", "-f", cname).Assert(c, icmd.Success)
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

According to issue #813, I found there would be some improvement in code:
```
} else {
	// Create the host path if it doesn't exist.
	_, err := os.Stat(source)
	if err != nil && !os.IsNotExist(err) {
		return errors.Errorf("failed to stat %q: %v", source, err)
	}
	err = os.MkdirAll(source, 0755)
	if err != nil {
		return errors.Errorf("failed to mkdir %q: %v", source, err)
	}
}
```

In the code above, I found that no matter `_, err := os.Stat(source)` returns a non-nil error or nil, `err = os.MkdirAll(source, 0755)` will always be executed which is unreasonable. If `_, err := os.Stat(source)` returns a nil error, we should regard it as a successful checking and move on.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #813


### Ⅲ. Describe how you did it
None

### Ⅳ. Describe how to verify it
```
touch /tmp/asdfghjkl 
pouch run -d -v /tmp/asdfghjkl:/tmp/asdfghjkl docker.io/library/ubuntu:14.04 sleep 10000
```

### Ⅴ. Special notes for reviews
none

