### PR TITLE
[WIP] feature: add pre-create hook in container creation

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -66,4 +66,7 @@ type Config struct {
 
 	// CgroupParent is to set parent cgroup for all containers
 	CgroupParent string `json:"cgroup-parent,omitempty"`
+
+	// Pre-create hook to execute before every container creation
+	PreCreateHook string `json:"pre-create-hook,omitempty"`
 }

--- a/main.go
+++ b/main.go
@@ -87,6 +87,8 @@ func setupFlags(cmd *cobra.Command) {
 
 	// cgroup-path flag is to set parent cgroup for all containers, default is "default" staying with containerd's configuration.
 	flagSet.StringVar(&cfg.CgroupParent, "cgroup-parent", "default", "Set parent cgroup for all containers")
+
+	flagSet.StringVar(&cfg.PreCreateHook, "pre-create", "", "Pre-create hook configuration in daemon to execute before every container creation")
 }
 
 // parse flags


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This PR adds functionality of pre create hook into Pouch. What I did in details:

* add a new flag `pre-create` in pouch daemon side;
* run pre-create hook at the very beginning of container creation if pre-create hook is set.

There is definitely important communication between pouch daemon and the specific pre-create hook. The communication standard is that:

* Pouch daemon marshal a types.ContainerCreateConfig into []byte;
* Pouch takes advantages of the []data to be a string to input to the pre create hook;
* pre-create hook accepts the input string, deals with it, and outputs an []byte.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes https://github.com/alibaba/pouch/issues/807


### Ⅲ. Describe how you did it
None


### Ⅳ. Describe how to verify it
Not tested yet. Will test this soon


### Ⅴ. Special notes for reviews
@yyb196 


