### PR TITLE
feature: add debugger tool for pouch

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/alibaba/pouch/version"
 
 	"github.com/docker/docker/pkg/reexec"
+	"github.com/google/gops/agent"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -110,6 +111,13 @@ func runDaemon() error {
 
 	// initialize log.
 	initLog()
+
+	// import debugger tools for pouch when in debug mode.
+	if cfg.Debug {
+		if err := agent.Listen(agent.Options{}); err != nil {
+			logrus.Fatal(err)
+		}
+	}
 
 	// initialize home dir.
 	dir := cfg.HomeDir

--- a/vendor/github.com/google/gops/LICENSE
+++ b/vendor/github.com/google/gops/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2016 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/google/gops/agent/agent.go
+++ b/vendor/github.com/google/gops/agent/agent.go
@@ -1,0 +1,260 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package agent provides hooks programs can register to retrieve
+// diagnostics data by using gops.
+package agent
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	gosignal "os/signal"
+	"runtime"
+	"runtime/debug"
+	"runtime/pprof"
+	"runtime/trace"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/gops/internal"
+	"github.com/google/gops/signal"
+	"github.com/kardianos/osext"
+)
+
+const defaultAddr = "127.0.0.1:0"
+
+var (
+	mu       sync.Mutex
+	portfile string
+	listener net.Listener
+
+	units = []string{" bytes", "KB", "MB", "GB", "TB", "PB"}
+)
+
+// Options allows configuring the started agent.
+type Options struct {
+	// Addr is the host:port the agent will be listening at.
+	// Optional.
+	Addr string
+
+	// ConfigDir is the directory to store the configuration file,
+	// PID of the gops process, filename, port as well as content.
+	// Optional.
+	ConfigDir string
+
+	// ShutdownCleanup automatically cleans up resources if the
+	// running process receives an interrupt. Otherwise, users
+	// can call Close before shutting down.
+	// Optional.
+	ShutdownCleanup bool
+}
+
+// Listen starts the gops agent on a host process. Once agent started, users
+// can use the advanced gops features. The agent will listen to Interrupt
+// signals and exit the process, if you need to perform further work on the
+// Interrupt signal use the options parameter to configure the agent
+// accordingly.
+//
+// Note: The agent exposes an endpoint via a TCP connection that can be used by
+// any program on the system. Review your security requirements before starting
+// the agent.
+func Listen(opts Options) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if portfile != "" {
+		return fmt.Errorf("gops: agent already listening at: %v", listener.Addr())
+	}
+
+	// new
+	gopsdir := opts.ConfigDir
+	if gopsdir == "" {
+		cfgDir, err := internal.ConfigDir()
+		if err != nil {
+			return err
+		}
+		gopsdir = cfgDir
+	}
+
+	err := os.MkdirAll(gopsdir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	if opts.ShutdownCleanup {
+		gracefulShutdown()
+	}
+
+	addr := opts.Addr
+	if addr == "" {
+		addr = defaultAddr
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	listener = ln
+	port := listener.Addr().(*net.TCPAddr).Port
+	portfile = fmt.Sprintf("%s/%d", gopsdir, os.Getpid())
+	err = ioutil.WriteFile(portfile, []byte(strconv.Itoa(port)), os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	go listen()
+	return nil
+}
+
+func listen() {
+	buf := make([]byte, 1)
+	for {
+		fd, err := listener.Accept()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gops: %v", err)
+			if netErr, ok := err.(net.Error); ok && !netErr.Temporary() {
+				break
+			}
+			continue
+		}
+		if _, err := fd.Read(buf); err != nil {
+			fmt.Fprintf(os.Stderr, "gops: %v", err)
+			continue
+		}
+		if err := handle(fd, buf); err != nil {
+			fmt.Fprintf(os.Stderr, "gops: %v", err)
+			continue
+		}
+		fd.Close()
+	}
+}
+
+func gracefulShutdown() {
+	c := make(chan os.Signal, 1)
+	gosignal.Notify(c, os.Interrupt)
+	go func() {
+		// cleanup the socket on shutdown.
+		<-c
+		Close()
+		os.Exit(1)
+	}()
+}
+
+// Close closes the agent, removing temporary files and closing the TCP listener.
+// If no agent is listening, Close does nothing.
+func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if portfile != "" {
+		os.Remove(portfile)
+		portfile = ""
+	}
+	if listener != nil {
+		listener.Close()
+	}
+}
+
+func formatBytes(val uint64) string {
+	var i int
+	var target uint64
+	for i = range units {
+		target = 1 << uint(10*(i+1))
+		if val < target {
+			break
+		}
+	}
+	if i > 0 {
+		return fmt.Sprintf("%0.2f%s (%d bytes)", float64(val)/(float64(target)/1024), units[i], val)
+	}
+	return fmt.Sprintf("%d bytes", val)
+}
+
+func handle(conn io.ReadWriter, msg []byte) error {
+	switch msg[0] {
+	case signal.StackTrace:
+		return pprof.Lookup("goroutine").WriteTo(conn, 2)
+	case signal.GC:
+		runtime.GC()
+		_, err := conn.Write([]byte("ok"))
+		return err
+	case signal.MemStats:
+		var s runtime.MemStats
+		runtime.ReadMemStats(&s)
+		fmt.Fprintf(conn, "alloc: %v\n", formatBytes(s.Alloc))
+		fmt.Fprintf(conn, "total-alloc: %v\n", formatBytes(s.TotalAlloc))
+		fmt.Fprintf(conn, "sys: %v\n", formatBytes(s.Sys))
+		fmt.Fprintf(conn, "lookups: %v\n", s.Lookups)
+		fmt.Fprintf(conn, "mallocs: %v\n", s.Mallocs)
+		fmt.Fprintf(conn, "frees: %v\n", s.Frees)
+		fmt.Fprintf(conn, "heap-alloc: %v\n", formatBytes(s.HeapAlloc))
+		fmt.Fprintf(conn, "heap-sys: %v\n", formatBytes(s.HeapSys))
+		fmt.Fprintf(conn, "heap-idle: %v\n", formatBytes(s.HeapIdle))
+		fmt.Fprintf(conn, "heap-in-use: %v\n", formatBytes(s.HeapInuse))
+		fmt.Fprintf(conn, "heap-released: %v\n", formatBytes(s.HeapReleased))
+		fmt.Fprintf(conn, "heap-objects: %v\n", s.HeapObjects)
+		fmt.Fprintf(conn, "stack-in-use: %v\n", formatBytes(s.StackInuse))
+		fmt.Fprintf(conn, "stack-sys: %v\n", formatBytes(s.StackSys))
+		fmt.Fprintf(conn, "stack-mspan-inuse: %v\n", formatBytes(s.MSpanInuse))
+		fmt.Fprintf(conn, "stack-mspan-sys: %v\n", formatBytes(s.MSpanSys))
+		fmt.Fprintf(conn, "stack-mcache-inuse: %v\n", formatBytes(s.MCacheInuse))
+		fmt.Fprintf(conn, "stack-mcache-sys: %v\n", formatBytes(s.MCacheSys))
+		fmt.Fprintf(conn, "other-sys: %v\n", formatBytes(s.OtherSys))
+		fmt.Fprintf(conn, "gc-sys: %v\n", formatBytes(s.GCSys))
+		fmt.Fprintf(conn, "next-gc: when heap-alloc >= %v\n", formatBytes(s.NextGC))
+		lastGC := "-"
+		if s.LastGC != 0 {
+			lastGC = fmt.Sprint(time.Unix(0, int64(s.LastGC)))
+		}
+		fmt.Fprintf(conn, "last-gc: %v\n", lastGC)
+		fmt.Fprintf(conn, "gc-pause-total: %v\n", time.Duration(s.PauseTotalNs))
+		fmt.Fprintf(conn, "gc-pause: %v\n", s.PauseNs[(s.NumGC+255)%256])
+		fmt.Fprintf(conn, "num-gc: %v\n", s.NumGC)
+		fmt.Fprintf(conn, "enable-gc: %v\n", s.EnableGC)
+		fmt.Fprintf(conn, "debug-gc: %v\n", s.DebugGC)
+	case signal.Version:
+		fmt.Fprintf(conn, "%v\n", runtime.Version())
+	case signal.HeapProfile:
+		pprof.WriteHeapProfile(conn)
+	case signal.CPUProfile:
+		if err := pprof.StartCPUProfile(conn); err != nil {
+			return err
+		}
+		time.Sleep(30 * time.Second)
+		pprof.StopCPUProfile()
+	case signal.Stats:
+		fmt.Fprintf(conn, "goroutines: %v\n", runtime.NumGoroutine())
+		fmt.Fprintf(conn, "OS threads: %v\n", pprof.Lookup("threadcreate").Count())
+		fmt.Fprintf(conn, "GOMAXPROCS: %v\n", runtime.GOMAXPROCS(0))
+		fmt.Fprintf(conn, "num CPU: %v\n", runtime.NumCPU())
+	case signal.BinaryDump:
+		path, err := osext.Executable()
+		if err != nil {
+			return err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = bufio.NewReader(f).WriteTo(conn)
+		return err
+	case signal.Trace:
+		trace.Start(conn)
+		time.Sleep(5 * time.Second)
+		trace.Stop()
+	case signal.SetGCPercent:
+		perc, err := binary.ReadVarint(bufio.NewReader(conn))
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(conn, "New GC percent set to %v. Previous value was %v.\n", perc, debug.SetGCPercent(int(perc)))
+	}
+	return nil
+}

--- a/vendor/github.com/google/gops/internal/internal.go
+++ b/vendor/github.com/google/gops/internal/internal.go
@@ -1,0 +1,62 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const gopsConfigDirEnvKey = "GOPS_CONFIG_DIR"
+
+func ConfigDir() (string, error) {
+	if configDir := os.Getenv(gopsConfigDirEnvKey); configDir != "" {
+		return configDir, nil
+	}
+
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("APPDATA"), "gops"), nil
+	}
+	homeDir := guessUnixHomeDir()
+	if homeDir == "" {
+		return "", errors.New("unable to get current user home directory: os/user lookup failed; $HOME is empty")
+	}
+	return filepath.Join(homeDir, ".config", "gops"), nil
+}
+
+func guessUnixHomeDir() string {
+	usr, err := user.Current()
+	if err == nil {
+		return usr.HomeDir
+	}
+	return os.Getenv("HOME")
+}
+
+func PIDFile(pid int) (string, error) {
+	gopsdir, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%d", gopsdir, pid), nil
+}
+
+func GetPort(pid int) (string, error) {
+	portfile, err := PIDFile(pid)
+	if err != nil {
+		return "", err
+	}
+	b, err := ioutil.ReadFile(portfile)
+	if err != nil {
+		return "", err
+	}
+	port := strings.TrimSpace(string(b))
+	return port, nil
+}

--- a/vendor/github.com/google/gops/signal/signal.go
+++ b/vendor/github.com/google/gops/signal/signal.go
@@ -1,0 +1,38 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package signal contains signals used to communicate to the gops agents.
+package signal
+
+const (
+	// StackTrace represents a command to print stack trace.
+	StackTrace = byte(0x1)
+
+	// GC runs the garbage collector.
+	GC = byte(0x2)
+
+	// MemStats reports memory stats.
+	MemStats = byte(0x3)
+
+	// Version prints the Go version.
+	Version = byte(0x4)
+
+	// HeapProfile starts `go tool pprof` with the current memory profile.
+	HeapProfile = byte(0x5)
+
+	// CPUProfile starts `go tool pprof` with the current CPU profile
+	CPUProfile = byte(0x6)
+
+	// Stats returns Go runtime statistics such as number of goroutines, GOMAXPROCS, and NumCPU.
+	Stats = byte(0x7)
+
+	// Trace starts the Go execution tracer, waits 5 seconds and launches the trace tool.
+	Trace = byte(0x8)
+
+	// BinaryDump returns running binary file.
+	BinaryDump = byte(0x9)
+
+	// SetGCPercent sets the garbage collection target percentage.
+	SetGCPercent = byte(0x10)
+)

--- a/vendor/github.com/kardianos/osext/LICENSE
+++ b/vendor/github.com/kardianos/osext/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/kardianos/osext/README.md
+++ b/vendor/github.com/kardianos/osext/README.md
@@ -1,0 +1,21 @@
+### Extensions to the "os" package.
+
+[![GoDoc](https://godoc.org/github.com/kardianos/osext?status.svg)](https://godoc.org/github.com/kardianos/osext)
+
+## Find the current Executable and ExecutableFolder.
+
+As of go1.8 the Executable function may be found in `os`. The Executable function
+in the std lib `os` package is used if available.
+
+There is sometimes utility in finding the current executable file
+that is running. This can be used for upgrading the current executable
+or finding resources located relative to the executable file. Both
+working directory and the os.Args[0] value are arbitrary and cannot
+be relied on; os.Args[0] can be "faked".
+
+Multi-platform and supports:
+ * Linux
+ * OS X
+ * Windows
+ * Plan 9
+ * BSDs.

--- a/vendor/github.com/kardianos/osext/osext.go
+++ b/vendor/github.com/kardianos/osext/osext.go
@@ -1,0 +1,33 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Extensions to the standard "os" package.
+package osext // import "github.com/kardianos/osext"
+
+import "path/filepath"
+
+var cx, ce = executableClean()
+
+func executableClean() (string, error) {
+	p, err := executable()
+	return filepath.Clean(p), err
+}
+
+// Executable returns an absolute path that can be used to
+// re-invoke the current program.
+// It may not be valid after the current program exits.
+func Executable() (string, error) {
+	return cx, ce
+}
+
+// Returns same path as Executable, returns just the folder
+// path. Excludes the executable name and any trailing slash.
+func ExecutableFolder() (string, error) {
+	p, err := Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Dir(p), nil
+}

--- a/vendor/github.com/kardianos/osext/osext_go18.go
+++ b/vendor/github.com/kardianos/osext/osext_go18.go
@@ -1,0 +1,9 @@
+//+build go1.8,!openbsd
+
+package osext
+
+import "os"
+
+func executable() (string, error) {
+	return os.Executable()
+}

--- a/vendor/github.com/kardianos/osext/osext_plan9.go
+++ b/vendor/github.com/kardianos/osext/osext_plan9.go
@@ -1,0 +1,22 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build !go1.8
+
+package osext
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+)
+
+func executable() (string, error) {
+	f, err := os.Open("/proc/" + strconv.Itoa(os.Getpid()) + "/text")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return syscall.Fd2path(int(f.Fd()))
+}

--- a/vendor/github.com/kardianos/osext/osext_procfs.go
+++ b/vendor/github.com/kardianos/osext/osext_procfs.go
@@ -1,0 +1,36 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.8,android !go1.8,linux !go1.8,netbsd !go1.8,solaris !go1.8,dragonfly
+
+package osext
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+func executable() (string, error) {
+	switch runtime.GOOS {
+	case "linux", "android":
+		const deletedTag = " (deleted)"
+		execpath, err := os.Readlink("/proc/self/exe")
+		if err != nil {
+			return execpath, err
+		}
+		execpath = strings.TrimSuffix(execpath, deletedTag)
+		execpath = strings.TrimPrefix(execpath, deletedTag)
+		return execpath, nil
+	case "netbsd":
+		return os.Readlink("/proc/curproc/exe")
+	case "dragonfly":
+		return os.Readlink("/proc/curproc/file")
+	case "solaris":
+		return os.Readlink(fmt.Sprintf("/proc/%d/path/a.out", os.Getpid()))
+	}
+	return "", errors.New("ExecPath not implemented for " + runtime.GOOS)
+}

--- a/vendor/github.com/kardianos/osext/osext_sysctl.go
+++ b/vendor/github.com/kardianos/osext/osext_sysctl.go
@@ -1,0 +1,126 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.8,darwin !go1.8,freebsd openbsd
+
+package osext
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+var initCwd, initCwdErr = os.Getwd()
+
+func executable() (string, error) {
+	var mib [4]int32
+	switch runtime.GOOS {
+	case "freebsd":
+		mib = [4]int32{1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1}
+	case "darwin":
+		mib = [4]int32{1 /* CTL_KERN */, 38 /* KERN_PROCARGS */, int32(os.Getpid()), -1}
+	case "openbsd":
+		mib = [4]int32{1 /* CTL_KERN */, 55 /* KERN_PROC_ARGS */, int32(os.Getpid()), 1 /* KERN_PROC_ARGV */}
+	}
+
+	n := uintptr(0)
+	// Get length.
+	_, _, errNum := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errNum != 0 {
+		return "", errNum
+	}
+	if n == 0 { // This shouldn't happen.
+		return "", nil
+	}
+	buf := make([]byte, n)
+	_, _, errNum = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errNum != 0 {
+		return "", errNum
+	}
+	if n == 0 { // This shouldn't happen.
+		return "", nil
+	}
+
+	var execPath string
+	switch runtime.GOOS {
+	case "openbsd":
+		// buf now contains **argv, with pointers to each of the C-style
+		// NULL terminated arguments.
+		var args []string
+		argv := uintptr(unsafe.Pointer(&buf[0]))
+	Loop:
+		for {
+			argp := *(**[1 << 20]byte)(unsafe.Pointer(argv))
+			if argp == nil {
+				break
+			}
+			for i := 0; uintptr(i) < n; i++ {
+				// we don't want the full arguments list
+				if string(argp[i]) == " " {
+					break Loop
+				}
+				if argp[i] != 0 {
+					continue
+				}
+				args = append(args, string(argp[:i]))
+				n -= uintptr(i)
+				break
+			}
+			if n < unsafe.Sizeof(argv) {
+				break
+			}
+			argv += unsafe.Sizeof(argv)
+			n -= unsafe.Sizeof(argv)
+		}
+		execPath = args[0]
+		// There is no canonical way to get an executable path on
+		// OpenBSD, so check PATH in case we are called directly
+		if execPath[0] != '/' && execPath[0] != '.' {
+			execIsInPath, err := exec.LookPath(execPath)
+			if err == nil {
+				execPath = execIsInPath
+			}
+		}
+	default:
+		for i, v := range buf {
+			if v == 0 {
+				buf = buf[:i]
+				break
+			}
+		}
+		execPath = string(buf)
+	}
+
+	var err error
+	// execPath will not be empty due to above checks.
+	// Try to get the absolute path if the execPath is not rooted.
+	if execPath[0] != '/' {
+		execPath, err = getAbs(execPath)
+		if err != nil {
+			return execPath, err
+		}
+	}
+	// For darwin KERN_PROCARGS may return the path to a symlink rather than the
+	// actual executable.
+	if runtime.GOOS == "darwin" {
+		if execPath, err = filepath.EvalSymlinks(execPath); err != nil {
+			return execPath, err
+		}
+	}
+	return execPath, nil
+}
+
+func getAbs(execPath string) (string, error) {
+	if initCwdErr != nil {
+		return execPath, initCwdErr
+	}
+	// The execPath may begin with a "../" or a "./" so clean it first.
+	// Join the two paths, trailing and starting slashes undetermined, so use
+	// the generic Join function.
+	return filepath.Join(initCwd, filepath.Clean(execPath)), nil
+}

--- a/vendor/github.com/kardianos/osext/osext_windows.go
+++ b/vendor/github.com/kardianos/osext/osext_windows.go
@@ -1,0 +1,36 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build !go1.8
+
+package osext
+
+import (
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+)
+
+var (
+	kernel                = syscall.MustLoadDLL("kernel32.dll")
+	getModuleFileNameProc = kernel.MustFindProc("GetModuleFileNameW")
+)
+
+// GetModuleFileName() with hModule = NULL
+func executable() (exePath string, err error) {
+	return getModuleFileName()
+}
+
+func getModuleFileName() (string, error) {
+	var n uint32
+	b := make([]uint16, syscall.MAX_PATH)
+	size := uint32(len(b))
+
+	r0, _, e1 := getModuleFileNameProc.Call(0, uintptr(unsafe.Pointer(&b[0])), uintptr(size))
+	n = uint32(r0)
+	if n == 0 {
+		return "", e1
+	}
+	return string(utf16.Decode(b[0:n])), nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -568,6 +568,24 @@
 			"revisionTime": "2017-11-08T19:22:26Z"
 		},
 		{
+			"checksumSHA1": "mLmwamaqyrVUNOmTAGaSpnO1YJQ=",
+			"path": "github.com/google/gops/agent",
+			"revision": "160b358b10d6123169a895090938b088c8f78dc9",
+			"revisionTime": "2018-03-11T05:24:15Z"
+		},
+		{
+			"checksumSHA1": "4/oP9EPM60f4djEKTtRqMJPaeOo=",
+			"path": "github.com/google/gops/internal",
+			"revision": "160b358b10d6123169a895090938b088c8f78dc9",
+			"revisionTime": "2018-03-11T05:24:15Z"
+		},
+		{
+			"checksumSHA1": "jKzg09NDPfnmGeZhp+YSVaq4cb0=",
+			"path": "github.com/google/gops/signal",
+			"revision": "160b358b10d6123169a895090938b088c8f78dc9",
+			"revisionTime": "2018-03-11T05:24:15Z"
+		},
+		{
 			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
 			"path": "github.com/gorilla/context",
 			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
@@ -584,6 +602,12 @@
 			"path": "github.com/gotestyourself/gotestyourself/icmd",
 			"revision": "b5461758462b97cff258bf388ca42110f529d747",
 			"revisionTime": "2017-11-07T15:27:38Z"
+		},
+		{
+			"checksumSHA1": "gEjGS03N1eysvpQ+FCHTxPcbxXc=",
+			"path": "github.com/kardianos/osext",
+			"revision": "ae77be60afb1dcacde03767a8c37337fad28ac14",
+			"revisionTime": "2017-05-10T13:15:34Z"
 		},
 		{
 			"checksumSHA1": "jHOLsfeMPcX84YQB2MXBqXFntBg=",


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
add gops debug tool for pouch

### Ⅱ. Does this pull request fix one issue?
fixes https://github.com/alibaba/pouch/issues/863
### Ⅲ. Describe how you did it

### Ⅳ. Describe how to verify it
first, install gops tool on your compute:
```
$ go get -u github.com/google/gops
```
second, get pouchd process id, `gops` will print all golang process on your machine.
```
$ gops
```
last, print the pouchd process stack
```
$ gops stack $PID
```

### Ⅴ. Special notes for reviews
print process goroutine stack just like blow
```
goroutine 863 [select, 2 minutes]:
github.com/alibaba/pouch/vendor/google.golang.org/grpc/transport.wait(0x7f74e0e4c0c8, 0xc420bb42a0, 0x0, 0x0, 0xc4203e0480, 0xc4203680e0, 0x0, 0x0, 0xc420408420)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/vendor/google.golang.org/grpc/transport/transport.go:635 +0x181
github.com/alibaba/pouch/vendor/google.golang.org/grpc/transport.(*http2Client).NewStream(0xc420471800, 0x7f74e0e4c0c8, 0xc420bb4270, 0xc4210dfe50, 0x243c980, 0xc420471800, 0x0)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/vendor/google.golang.org/grpc/transport/http2_client.go:366 +0x7f5
github.com/alibaba/pouch/vendor/google.golang.org/grpc.invoke(0x7f74e0e4c0c8, 0xc420bb4270, 0x1afb67f, 0x29, 0x19e66a0, 0xc4202966c0, 0x19e6780, 0xc420a96f38, 0xc420092d00, 0x0, ...)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/vendor/google.golang.org/grpc/call.go:246 +0x69a
github.com/alibaba/pouch/vendor/github.com/containerd/containerd.namespaceInterceptor.unary(0x1ad0b10, 0x7, 0x7f74e0e4c0c8, 0xc420bb4180, 0x1afb67f, 0x29, 0x19e66a0, 0xc4202966c0, 0x19e6780, 0xc420a96f38, ...)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/vendor/github.com/containerd/containerd/grpc.go:18 +0xf4
github.com/alibaba/pouch/vendor/github.com/containerd/containerd.(namespaceInterceptor).(github.com/alibaba/pouch/vendor/github.com/containerd/containerd.unary)-fm(0x7f74e0e4c0c8, 0xc420bb4180, 0x1afb67f, 0x29, 0x19e66a0, 0xc4202966c0, 0x19e6780, 0xc420a96f38, 0xc420092d00, 0x1b31200, ...)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/vendor/github.com/containerd/containerd/grpc.go:34 +0xf4
github.com/alibaba/pouch/vendor/google.golang.org/grpc.Invoke(0x7f74e0e4c0c8, 0xc420bb4180, 0x1afb67f, 0x29, 0x19e66a0, 0xc4202966c0, 0x19e6780, 0xc420a96f38, 0xc420092d00, 0x0, ...)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/vendor/google.golang.org/grpc/call.go:141 +0xdd
github.com/alibaba/pouch/vendor/github.com/containerd/containerd/api/services/images/v1.(*imagesClient).Get(0xc420a96f30, 0x7f74e0e4c0c8, 0xc420bb4180, 0xc4202966c0, 0x0, 0x0, 0x0, 0xc42191ca00, 0xc420409100, 0xc420409230)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/vendor/github.com/containerd/containerd/api/services/images/v1/images.pb.go:226 +0xd2
github.com/alibaba/pouch/vendor/github.com/containerd/containerd.(*remoteImages).Get(0xc4202966b0, 0x2436ea0, 0xc420bb4180, 0xc42020a090, 0x2e, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/vendor/github.com/containerd/containerd/image_store.go:26 +0x12f
github.com/alibaba/pouch/ctrd.(*Client).CreateSnapshot(0xc4203e26e0, 0x2436ea0, 0xc420bb4180, 0xc4201cbc80, 0x40, 0xc42020a090, 0x2e, 0x0, 0x0)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/ctrd/snapshot.go:20 +0x1f9
github.com/alibaba/pouch/daemon/mgr.(*ContainerManager).Create(0xc42012eaf0, 0x2436de0, 0xc42175d000, 0xc4201cbc80, 0x6, 0xc420ab5760, 0x0, 0x0, 0x0)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/daemon/mgr/container.go:340 +0x417
github.com/alibaba/pouch/apis/server.(*Server).createContainer(0xc42013e2e8, 0x2436de0, 0xc42175d000, 0x2435c60, 0xc42050f7a0, 0xc420433500, 0x3, 0x3)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/apis/server/container_bridge.go:131 +0x2da
github.com/alibaba/pouch/apis/server.(*Server).(github.com/alibaba/pouch/apis/server.createContainer)-fm(0x2436de0, 0xc42175d000, 0x2435c60, 0xc42050f7a0, 0xc420433500, 0xc420433500, 0xc421bcdad0)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/apis/server/router.go:29 +0x5c
github.com/alibaba/pouch/apis/server.(*Server).filter.func1(0x2435c60, 0xc42050f7a0, 0xc420433500)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/apis/server/router.go:115 +0x2ae
net/http.HandlerFunc.ServeHTTP(0xc4211f7800, 0x2435c60, 0xc42050f7a0, 0xc420433500)
    /usr/local/go/src/net/http/server.go:1918 +0x44
github.com/alibaba/pouch/vendor/github.com/gorilla/mux.(*Router).ServeHTTP(0xc421a12360, 0x2435c60, 0xc42050f7a0, 0xc420433500)
    /tmp/pouchbuild/src/github.com/alibaba/pouch/vendor/github.com/gorilla/mux/mux.go:133 +0xed
net/http.serverHandler.ServeHTTP(0xc4211e7520, 0x2435c60, 0xc42050f7a0, 0xc420433300)
    /usr/local/go/src/net/http/server.go:2619 +0xb4
net/http.(*conn).serve(0xc42023d180, 0x2436de0, 0xc42175ce80)
    /usr/local/go/src/net/http/server.go:1801 +0x71d
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:2720 +0x288
```

