### PR TITLE
[feature] add inspect format for image network and volume

### DIFF
--- a/cli/network.go
+++ b/cli/network.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/cli/inspect"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -252,6 +254,7 @@ var networkInspectDescription = "Inspect a network in pouchd. " +
 // NetworkInspectCommand is used to implement 'network inspect' command.
 type NetworkInspectCommand struct {
 	baseCommand
+	format string
 }
 
 // Init initializes NetworkInspectCommand command.
@@ -275,6 +278,7 @@ func (n *NetworkInspectCommand) Init(c *Cli) {
 // addFlags adds flags for specific command.
 func (n *NetworkInspectCommand) addFlags() {
 	//TODO add flags
+	n.cmd.Flags().StringVarP(&n.format, "format", "f", "", "Format the output using the given go template")
 }
 
 // runNetworkInspect is the entry of NetworkInspectCommand command.
@@ -283,13 +287,12 @@ func (n *NetworkInspectCommand) runNetworkInspect(args []string) error {
 
 	ctx := context.Background()
 	apiClient := n.cli.Client()
-	resp, err := apiClient.NetworkInspect(ctx, name)
-	if err != nil {
-		return err
+
+	getRefFunc := func(ref string) (interface{}, error) {
+		return apiClient.NetworkInspect(ctx, ref)
 	}
 
-	n.cli.Print(resp)
-	return nil
+	return inspect.Inspect(os.Stdout, name, n.format, getRefFunc)
 }
 
 // networkInspectExample shows examples in network inspect command, and is used in auto-generated cli docs.

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/cli/inspect"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -214,6 +216,7 @@ var volumeInspectDescription = "Inspect a volume in pouchd. " +
 // VolumeInspectCommand is used to implement 'volume inspect' command.
 type VolumeInspectCommand struct {
 	baseCommand
+	format string
 }
 
 // Init initializes VolumeInspectCommand command.
@@ -233,7 +236,9 @@ func (v *VolumeInspectCommand) Init(c *Cli) {
 }
 
 // addFlags adds flags for specific command.
-func (v *VolumeInspectCommand) addFlags() {}
+func (v *VolumeInspectCommand) addFlags() {
+	v.cmd.Flags().StringVarP(&v.format, "format", "f", "", "Format the output using the given go template")
+}
 
 // runVolumeInspect is the entry of VolumeInspectCommand command.
 func (v *VolumeInspectCommand) runVolumeInspect(args []string) error {
@@ -244,13 +249,11 @@ func (v *VolumeInspectCommand) runVolumeInspect(args []string) error {
 	ctx := context.Background()
 	apiClient := v.cli.Client()
 
-	resp, err := apiClient.VolumeInspect(ctx, name)
-	if err != nil {
-		return err
+	getRefFunc := func(ref string) (interface{}, error) {
+		return apiClient.VolumeInspect(ctx, ref)
 	}
 
-	v.cli.Print(resp)
-	return nil
+	return inspect.Inspect(os.Stdout, name, v.format, getRefFunc)
 }
 
 // volumeInspectExample shows examples in volume inspect command, and is used in auto-generated cli docs.

--- a/test/cli_images_test.go
+++ b/test/cli_images_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/alibaba/pouch/apis/types"
@@ -9,6 +11,7 @@ import (
 	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
+
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
 	"github.com/pkg/errors"
@@ -91,4 +94,17 @@ func getImageInfo(apiClient client.ImageAPIClient, name string) (types.ImageInfo
 		}
 	}
 	return types.ImageInfo{}, errors.Errorf("image %s not found", name)
+}
+
+// TestInspectImage is to verify the format flag of image inspect command.
+func (suite *PouchImagesSuite) TestInspectImage(c *check.C) {
+	output := command.PouchRun("image", "inspect", busyboxImage).Stdout()
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+
+	// inspect image name
+	output = command.PouchRun("image", "inspect", "-f", "{{.Name}}", busyboxImage).Stdout()
+	c.Assert(output, check.Equals, fmt.Sprintf("%s\n", busyboxImage))
 }

--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"runtime"
 	"strings"
 
+	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
+
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
 )
@@ -24,6 +27,19 @@ func (suite *PouchNetworkSuite) SetUpSuite(c *check.C) {
 
 	// Remove all Containers, in case there are legacy containers connecting network.
 	environment.PruneAllContainers(apiClient)
+}
+
+// TestNetworkInspectFormat tests the inspect format of network works.
+func (suite *PouchNetworkSuite) TestNetworkInspectFormat(c *check.C) {
+	output := command.PouchRun("network", "inspect", "bridge").Stdout()
+	result := &types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+
+	// inspect network name
+	output = command.PouchRun("network", "inspect", "-f", "{{.Name}}", "bridge").Stdout()
+	c.Assert(output, check.Equals, "bridge\n")
 }
 
 // TestNetworkDefault tests the creation of default bridge/none/host network.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add inspect format option for image/network/volume.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
```
#pouch network inspect -f {{.Name}} bridge
bridge

#pouch image inspect -f {{.Name}} docker.io/library/busybox:latest
docker.io/library/busybox:latest
```

### Ⅴ. Special notes for reviews


