### PR TITLE
feature: add disk quota for container's rootfs

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -295,6 +295,12 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 		State:      meta.State,
 		Config:     meta.Config,
 		HostConfig: meta.HostConfig,
+		GraphDriver: &types.GraphDriverData{
+			Name: "overlay2",
+			Data: map[string]string{
+				"BaseFS": meta.BaseFS,
+			},
+		},
 	}
 
 	if meta.NetworkSettings != nil {

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1697,7 +1697,13 @@ definitions:
           - "systemd"
       InitScript:
         type: "string"
-        description: "Initial script executed in container. The script will be executed before entrypoint or command"        
+        description: "Initial script executed in container. The script will be executed before entrypoint or command"
+      DiskQuota:
+        type: "object"
+        description: "Set disk quota for container"
+        x-nullable: true
+        additionalProperties:
+          type: "string"
  
   ContainerCreateResp:
     description: "response returned by daemon when container create successfully"

--- a/apis/types/container_config.go
+++ b/apis/types/container_config.go
@@ -35,6 +35,9 @@ type ContainerConfig struct {
 	// Command to run specified an array of strings.
 	Cmd []string `json:"Cmd"`
 
+	// Set disk quota for container
+	DiskQuota map[string]string `json:"DiskQuota,omitempty"`
+
 	// The domain name to use for the container.
 	Domainname string `json:"Domainname,omitempty"`
 
@@ -116,6 +119,8 @@ type ContainerConfig struct {
 /* polymorph ContainerConfig AttachStdout false */
 
 /* polymorph ContainerConfig Cmd false */
+
+/* polymorph ContainerConfig DiskQuota false */
 
 /* polymorph ContainerConfig Domainname false */
 

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -86,5 +86,8 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	// cgroup
 	flagSet.StringVarP(&c.cgroupParent, "cgroup-parent", "", "default", "Optional parent cgroup for the container")
 
+	// disk quota
+	flagSet.StringSliceVar(&c.diskQuota, "disk-quota", nil, "Set disk quota for container")
+
 	return c
 }

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -154,7 +154,7 @@ type ContainerMeta struct {
 	State *types.ContainerState `json:"State,omitempty"`
 
 	// BaseFS
-	BaseFS string
+	BaseFS string `json:"BaseFS, omitempty"`
 }
 
 // Key returns container's id.

--- a/daemon/mgr/spec.go
+++ b/daemon/mgr/spec.go
@@ -60,6 +60,7 @@ var setupFunc = []SetupFunc{
 
 	// blkio spec
 	setupBlkio,
+	setupDiskQuota,
 
 	// IntelRdtL3Cbm
 	setupIntelRdt,

--- a/pkg/quota/set_diskquota.go
+++ b/pkg/quota/set_diskquota.go
@@ -1,0 +1,138 @@
+package quota
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker/pkg/reexec"
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	reexec.Register("set-diskquota", processSetQuotaReexec)
+}
+
+// OverlayMount represents the parameters of overlay mount.
+type OverlayMount struct {
+	Merged string
+	Lower  string
+	Upper  string
+	Work   string
+}
+
+func processSetQuotaReexec() {
+	var (
+		err error
+		qid uint32
+	)
+
+	// Return a failure to the calling process via ExitCode
+	defer func() {
+		if err != nil {
+			logrus.Fatalf("%v", err)
+		}
+	}()
+
+	if len(os.Args) != 3 {
+		err = fmt.Errorf("invalid arguments: %v, it should be: %s: <path> <size>", os.Args, os.Args[0])
+		return
+	}
+
+	basefs := os.Args[1]
+	size := os.Args[2]
+
+	logrus.Infof("set diskquota: %v", os.Args)
+
+	overlayfs, err := getOverlay(basefs)
+	if err != nil || overlayfs == nil {
+		logrus.Errorf("failed to get lowerdir: %v", err)
+		return
+	}
+
+	for _, dir := range []string{overlayfs.Upper, overlayfs.Work} {
+		_, err = StartQuotaDriver(dir)
+		if err != nil {
+			logrus.Errorf("failed to start quota driver: %v", err)
+			return
+		}
+
+		qid, err = SetSubtree(dir, qid)
+		if err != nil {
+			logrus.Errorf("failed to set subtree: %v", err)
+			return
+		}
+
+		err = SetDiskQuota(dir, size, int(qid))
+		if err != nil {
+			logrus.Errorf("failed to set disk quota: %v", err)
+		}
+
+		setQuotaForDir(dir, qid)
+	}
+
+	return
+}
+
+func setQuotaForDir(src string, qid uint32) {
+	filepath.Walk(src, func(path string, fd os.FileInfo, err error) error {
+		if err != nil {
+			logrus.Warnf("setQuota walk dir %s get error %v", path, err)
+			return nil
+		}
+		SetFileAttrNoOutput(path, qid)
+		return nil
+	})
+}
+
+func getOverlay(basefs string) (*OverlayMount, error) {
+	overlayfs := &OverlayMount{}
+
+	fd, err := os.Open("/proc/mounts")
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	br := bufio.NewReader(fd)
+	for {
+		line, _, c := br.ReadLine()
+		if c == io.EOF {
+			break
+		}
+
+		parts := strings.Split(string(line), " ")
+		if len(parts) != 6 {
+			continue
+		}
+		if parts[1] != basefs || parts[2] != "overlay" {
+			continue
+		}
+
+		mountParams := strings.Split(parts[3], ",")
+		for _, p := range mountParams {
+			switch {
+			case strings.Contains(p, "lowerdir"):
+				if s := strings.Split(p, "="); len(s) == 2 {
+					overlayfs.Lower = s[1]
+				}
+
+			case strings.Contains(p, "upperdir"):
+				if s := strings.Split(p, "="); len(s) == 2 {
+					overlayfs.Upper = s[1]
+				}
+
+			case strings.Contains(p, "workdir"):
+				if s := strings.Split(p, "="); len(s) == 2 {
+					overlayfs.Work = s[1]
+					break
+				}
+			}
+		}
+	}
+
+	return overlayfs, nil
+}

--- a/test/environment/env.go
+++ b/test/environment/env.go
@@ -58,3 +58,11 @@ func IsHubConnected() bool {
 	// TODO: found a proper way to test if hub address can be connected.
 	return true
 }
+
+// IsDiskQuota checks if it can use disk quota for container.
+func IsDiskQuota() bool {
+	if icmd.RunCommand("which", "quotaon").ExitCode == 0 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add disk quota for container's rootfs. You can use
"--disk-quota" to set rootfs quota when "pouch create" or
"pouch run"

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #805 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
run container with disk quota for rootfs, such as:
```bash
# pouch run --name test --disk-quota 5g -ti  registry.docker-cn.com/library/busybox:latest df -h
Filesystem                Size      Used Available Use% Mounted on
overlay                   5.0G      4.0K      5.0G   0% /
tmpfs                    64.0M         0     64.0M   0% /dev
shm                      64.0M         0     64.0M   0% /dev/shm
tmpfs                    64.0M         0     64.0M   0% /run
tmpfs                    64.0M         0     64.0M   0% /proc/kcore
tmpfs                    64.0M         0     64.0M   0% /proc/timer_list
tmpfs                    64.0M         0     64.0M   0% /proc/sched_debug
tmpfs                     1.9G         0      1.9G   0% /sys/firmware
tmpfs                     1.9G         0      1.9G   0% /proc/scsi
```

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
