### PR TITLE
bugfix: go-swagger version should be 0.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,11 @@ ENV GOPATH=/go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 # install golint. currently golint has no released version.
-RUN go get -u github.com/golang/lint/golint \
-    && go get -u github.com/go-swagger/go-swagger/cmd/swagger
+RUN go get -u github.com/golang/lint/golint
+
+# install go-swagger tool
+RUN curl -o /usr/local/bin/swagger -L'#' https://github.com/go-swagger/go-swagger/releases/download/0.12.0/swagger_$(echo `uname`|tr '[:upper:]' '[:lower:]')_amd64 \
+	&& chmod +x /usr/local/bin/swagger
 
 COPY . /go/src/github.com/alibaba/pouch
 


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
lock go-swagger version to 0.12.0

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


