### PR TITLE
fix: make swagger version locked 0.12.0 rather than lastet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,11 @@ ENV GOPATH=/go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 # install golint. currently golint has no released version.
-RUN go get -u github.com/golang/lint/golint \
-    && go get -u github.com/go-swagger/go-swagger/cmd/swagger
+RUN go get -u github.com/golang/lint/golint
+
+# install swagger 0.12.0
+RUN wget --quiet -O /bin/swagger https://github.com/go-swagger/go-swagger/releases/download/0.12.0/swagger_linux_amd64 \
+    && chmod +x /bin/swagger
 
 COPY . /go/src/github.com/alibaba/pouch
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In the original Dockerfile, we use command `go get -u github.com/go-swagger/go-swagger/cmd/swagger` to install swagger binary which is already from the newest code. And we cannot guarantee the quality of the latest code ever.

As we had a rule in `hack/generate-swagger-models.sh` that we should use swagger 0.12.0 to meet our requirement, we should always download a binary which is locked to version swagger 0.12.0.

As a result, I change the command to be `wget --quiet -O /bin/swagger https://github.com/go-swagger/go-swagger/releases/download/0.12.0/swagger_linux_amd64`.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
This issue happens almost in all pull requests which we have modified the swagger.yml.
Like https://github.com/alibaba/pouch/pull/879, https://github.com/alibaba/pouch/pull/878, https://github.com/alibaba/pouch/pull/875 and so on

### Ⅲ. Describe how you did it
change a command to finish this


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews


