### PR TITLE
refactor: set lxcfs managed by systemd

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -41,6 +41,7 @@ func main() {
 	cli.AddCommand(base, &UpgradeCommand{})
 	cli.AddCommand(base, &TopCommand{})
 	cli.AddCommand(base, &LogsCommand{})
+	cli.AddCommand(base, &RemountLxcfsCommand{})
 
 	// add generate doc command
 	cli.AddCommand(base, &GenDocCommand{})

--- a/cli/remount_lxcfs.go
+++ b/cli/remount_lxcfs.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// remountLxcfsDescription is used to describe remount-lxcfs command in detail and auto generate command doc.
+var remountLxcfsDescription = "\nremount lxcfs in containers."
+
+// RemountLxcfsCommand is used to implement 'ps' command.
+type RemountLxcfsCommand struct {
+	baseCommand
+}
+
+// Init initializes remountLxcfsCommand command.
+func (p *RemountLxcfsCommand) Init(c *Cli) {
+	p.cli = c
+	p.cmd = &cobra.Command{
+		Use:   "remount-lxcfs",
+		Short: "remount lxcfs bind in containers",
+		Long:  remountLxcfsDescription,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.runRemountLxcfs(args)
+		},
+		Example: remountLxcfsExample(),
+	}
+}
+
+// runRemountLxcfs is the entry of remountLxcfsCommand command.
+func (p *RemountLxcfsCommand) runRemountLxcfs(args []string) error {
+	// TODO: get containers which enable lxcfs, and exec remount in them
+	return nil
+}
+
+// remountLxcfsExampleExample shows examples in remount-lxcfs command, and is used in auto-generated cli docs.
+func remountLxcfsExample() string {
+	return `$ pouch remount-lxcfs
+ID       Status
+e42c68   OK
+`
+}

--- a/hack/install_lxcfs_on_centos.sh
+++ b/hack/install_lxcfs_on_centos.sh
@@ -7,6 +7,7 @@
 yes | yum install autotools-dev m4 autoconf2.13 autobook autoconf-archive gnu-standards autoconf-doc libtool
 yes | yum install fuse-devel.$(uname -p)
 yes | yum install pam-devel.$(uname -p)
+yes | yum install fuse.$(uname -p)
 
 TMP=$(mktemp -d)
 trap "rm -rf $TMP" EXIT

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -37,9 +37,6 @@ function install_pouch ()
 			apt-get update
 			apt-get install -y lxcfs
 		fi
-
-		# MUST stop lxcfs service, so pouchd could take over it.
-		service lxcfs stop
 	else
 		sh -x $DIR/hack/install_lxcfs_on_centos.sh
 	fi

--- a/hack/package/rpm/build.sh
+++ b/hack/package/rpm/build.sh
@@ -103,6 +103,7 @@ function build_rpm ()
           -d pam-devel \
           -d fuse-devel \
           -d fuse-libs \
+          -d fuse \
           $BINDIR/=/usr/local/bin/ \
           $SERVICEDIR/=/usr/lib/systemd/system/ \
           $LXC_DIR/usr/local/bin/lxcfs=/usr/bin/lxcfs \

--- a/hack/package/rpm/service/lxcfs.service
+++ b/hack/package/rpm/service/lxcfs.service
@@ -10,6 +10,7 @@ KillMode=process
 Restart=on-failure
 ExecStopPost=-/usr/bin/fusermount -u /var/lib/lxcfs
 Delegate=yes
+ExecStartPost=pouch remount-lxcfs
 
 [Install]
 WantedBy=multi-user.target

--- a/lxcfs/lxcfs.go
+++ b/lxcfs/lxcfs.go
@@ -1,5 +1,13 @@
 package lxcfs
 
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+)
+
 var (
 	// IsLxcfsEnabled Whether to enable lxcfs
 	IsLxcfsEnabled bool
@@ -13,3 +21,31 @@ var (
 	// LxcfsProcFiles is the crucial files in procfs
 	LxcfsProcFiles = []string{"uptime", "swaps", "stat", "diskstats", "meminfo", "cpuinfo"}
 )
+
+// CheckLxcfsMount check if the the mount point of lxcfs exists
+func CheckLxcfsMount() error {
+	isMount := false
+	f, err := os.Open("/proc/1/mountinfo")
+	if err != nil {
+		return fmt.Errorf("Check lxcfs mounts failed: %v", err)
+	}
+	fr := bufio.NewReader(f)
+	for {
+		line, err := fr.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("Check lxcfs mounts failed: %v", err)
+		}
+
+		if bytes.Contains(line, []byte(LxcfsHomeDir)) {
+			isMount = true
+			break
+		}
+	}
+	if isMount == false {
+		return fmt.Errorf("%s is not a mount point, please run \" lxcfs %s \" before Pouchd", LxcfsHomeDir, LxcfsHomeDir)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
To improve availability, lxcfs process should be managed by other process, such as systemd.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how you did it
1. Remove the code of starting lxcfs in Pouchd. 
2. Check if the mount point of lxcfs is existed when starting Pouchd.

### Ⅳ. Describe how to verify it
1. Make sure lxcfs is running, and the mount point of lxcfs is `/var/lib/lxcfs`
2. `pouchd --enable-lxcfs`
3. `pouch run -m 512M --enableLxcfs=true  registry.hub.docker.com/library/busybox:latest head -n 1 /proc/meminfo`
4. The output should be `524288 kB`
### Ⅴ. Special notes for reviews


