### PR TITLE
bugfix: fix volume can be removed when using by container

### DIFF
--- a/apis/server/volume_bridge.go
+++ b/apis/server/volume_bridge.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/alibaba/pouch/apis/types"
@@ -98,6 +99,16 @@ func (s *Server) getVolume(ctx context.Context, rw http.ResponseWriter, req *htt
 
 func (s *Server) removeVolume(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	name := mux.Vars(req)["name"]
+
+	v, err := s.VolumeMgr.Get(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	ref := v.Option("ref")
+	if ref != "" {
+		return fmt.Errorf("failed to remove volume: %s, using by: %s", name, ref)
+	}
 
 	if err := s.VolumeMgr.Remove(ctx, name); err != nil {
 		return err


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
fix volume can be removed when using by container.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it
mark container's id into volume option "ref" when container attach volume, and remove option "ref" when container deatch volume.

### Ⅳ. Describe how to verify it
create volume and run container.
```
# pouch volume create -d local -o mount=/data/volume -o size=1g -n test
CreatedAt:    2018-3-13 19:54:58
Driver:       local
Labels:       map[]
Mountpoint:   /data/volume/test
Name:         test
Scope:
Status:       map[mount:/data/volume sifter:Default size:1g]
# pouch run -d -v test:/mnt registry.docker-cn.com/library/busybox:latest top
a72c17c38b865d325dbf2372ff5b4e44eb618e8301d2e68fb86131612b2b348b
```
check volume option ref
```
# pouch volume inspect test
{
    "CreatedAt": "2018-3-13 19:54:58",
    "Driver": "local",
    "Labels": {
        "backend": "local",
        "hostname": "ubuntu"
    },
    "Mountpoint": "/data/volume/test",
    "Name": "test",
    "Status": {
        "mount": "/data/volume",
        "ref": "a72c17c38b865d325dbf2372ff5b4e44eb618e8301d2e68fb86131612b2b348b",
        "sifter": "Default",
        "size": "1g"
    }
}
```
remove container and then check volume option ref.
```
# pouch rm -f a72c17c38b865d325dbf2372ff5b4e44eb618e8301d2e68fb86131612b2b348b
a72c17c38b865d325dbf2372ff5b4e44eb618e8301d2e68fb86131612b2b348b
# pouch volume inspect test
{
    "CreatedAt": "2018-3-13 19:54:58",
    "Driver": "local",
    "Labels": {
        "backend": "local",
        "hostname": "ubuntu"
    },
    "Mountpoint": "/data/volume/test",
    "Name": "test",
    "Status": {
        "freeTime": "1520942113",
        "mount": "/data/volume",
        "sifter": "Default",
        "size": "1g"
    }
}
# pouch volume rm test
Removed: test
```

### Ⅴ. Special notes for reviews


Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
