### PR TITLE
bugfix: inspect image by image id with prefix

### DIFF
--- a/daemon/mgr/image_utils.go
+++ b/daemon/mgr/image_utils.go
@@ -2,12 +2,16 @@ package mgr
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/alibaba/pouch/pkg/reference"
 )
 
 // addRegistry add default registry if needed.
 func (mgr *ImageManager) addRegistry(input string) string {
+	// Trim the prefix if the input is image ID with "sha256:".
+	// NOTE: we should make it more elegant and comprehensive.
+	input = strings.TrimPrefix(input, "sha256:")
 	if isNumericID(input) {
 		return input
 	}


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

We should be able to get the information of the image by full image ID like : 
```
[root@pouch-test pouch]# pouch image inspect sha256:5d9d6baef42b5850535f948d717bf71155bd4b352d392e5ca37ea95eaaac25d9
{
    "Architecture": "amd64",
    "Config": {
        "Cmd": [
            "sh"
        ],
        "Entrypoint": null,
.........
```

And this PR is just a quick workaround to make k8s + pouch could work ASAP, we should make it more elegant and systematic :)

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


