### PR TITLE
feature: make logout use default registry

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1215,6 +1215,10 @@ definitions:
           Address / URL of the index server that is used for image search,
           and as a default for user authentication.
         type: "string"
+      DefaultRegistry:
+        description: |
+          default registry can be defined by user.
+        type: "string"
       RegistryConfig:
         $ref: "#/definitions/RegistryServiceConfig"
       HttpProxy:

--- a/apis/types/system_info.go
+++ b/apis/types/system_info.go
@@ -52,6 +52,10 @@ type SystemInfo struct {
 	// Indicates if the daemon is running in debug-mode / with debug-level logging enabled.
 	Debug bool `json:"Debug,omitempty"`
 
+	// default registry can be defined by user.
+	//
+	DefaultRegistry string `json:"DefaultRegistry,omitempty"`
+
 	// Name of the default OCI runtime that is used when starting containers.
 	// The default can be overridden per-container at create time.
 	//
@@ -216,6 +220,8 @@ type SystemInfo struct {
 /* polymorph SystemInfo ContainersStopped false */
 
 /* polymorph SystemInfo Debug false */
+
+/* polymorph SystemInfo DefaultRegistry false */
 
 /* polymorph SystemInfo DefaultRuntime false */
 

--- a/cli/login.go
+++ b/cli/login.go
@@ -56,6 +56,14 @@ func (l *LoginCommand) runLogin(args []string) error {
 
 	ctx := context.Background()
 	apiClient := l.cli.Client()
+
+	// error will be ignored here, cause registry address can be null.
+	if auth.ServerAddress == "" {
+		if info, err := apiClient.SystemInfo(ctx); err == nil {
+			auth.ServerAddress = info.DefaultRegistry
+		}
+	}
+
 	resp, err := apiClient.RegistryLogin(ctx, auth)
 	if err != nil {
 		return err

--- a/credential/file_store.go
+++ b/credential/file_store.go
@@ -50,7 +50,7 @@ func (fs *fileStore) Save(authConfig *types.AuthConfig) error {
 	if serverAddress == "" {
 		serverAddress = defaultRegistry
 	} else {
-		serverAddress = addrTrim(serverAddress)
+		serverAddress = convertHost(serverAddress)
 	}
 
 	fs.configFile.AuthConfigs[serverAddress] = types.AuthConfig{
@@ -70,7 +70,7 @@ func (fs *fileStore) Get(serverAddress string) (types.AuthConfig, error) {
 	if serverAddress == "" {
 		serverAddress = defaultRegistry
 	} else {
-		serverAddress = addrTrim(serverAddress)
+		serverAddress = convertHost(serverAddress)
 	}
 	authConfig, exist := authConfigs[serverAddress]
 	if !exist {
@@ -94,7 +94,7 @@ func (fs *fileStore) Delete(serverAddress string) error {
 		return nil
 	}
 
-	serverAddress = addrTrim(serverAddress)
+	serverAddress = convertHost(serverAddress)
 	delete(fs.configFile.AuthConfigs, serverAddress)
 	return fs.update()
 }
@@ -108,7 +108,7 @@ func (fs *fileStore) Exist(serverAddress string) bool {
 	if serverAddress == "" {
 		serverAddress = defaultRegistry
 	} else {
-		serverAddress = addrTrim(serverAddress)
+		serverAddress = convertHost(serverAddress)
 	}
 	_, exist := fs.configFile.AuthConfigs[serverAddress]
 	return exist

--- a/credential/helpers.go
+++ b/credential/helpers.go
@@ -54,7 +54,7 @@ func homedir() string {
 	return os.Getenv(env)
 }
 
-func addrTrim(addr string) string {
+func convertHost(addr string) string {
 	if strings.HasPrefix(addr, "http://") {
 		addr = strings.TrimPrefix(addr, "http://")
 	}

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -86,6 +86,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		// ID: ,
 		// Images: ,
 		IndexServerAddress: "https://index.docker.io/v1/",
+		DefaultRegistry:    mgr.config.DefaultRegistry,
 		KernelVersion:      kernelVersion,
 		Labels:             mgr.config.Labels,
 		// LiveRestoreEnabled: ,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

1. logout command will get default registry from system info
2. remove default registry with namespace library, make format
from registry.hub.docker.com/library to registry.hub.docker.com

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


