### PR TITLE
feature: add no-trunc flag for 'pouch ps'

### DIFF
--- a/cli/ps.go
+++ b/cli/ps.go
@@ -23,8 +23,9 @@ type PsCommand struct {
 	baseCommand
 
 	// flags for ps command
-	flagAll   bool
-	flagQuiet bool
+	flagAll     bool
+	flagQuiet   bool
+	flagNoTrunc bool
 }
 
 // Init initializes PsCommand command.
@@ -48,6 +49,7 @@ func (p *PsCommand) addFlags() {
 	flagSet := p.cmd.Flags()
 	flagSet.BoolVarP(&p.flagAll, "all", "a", false, "Show all containers (default shows just running)")
 	flagSet.BoolVarP(&p.flagQuiet, "quiet", "q", false, "Only show numeric IDs")
+	flagSet.BoolVar(&p.flagNoTrunc, "no-trunc", false, "Do not truncate output")
 }
 
 // runPs is the entry of PsCommand command.
@@ -65,7 +67,11 @@ func (p *PsCommand) runPs(args []string) error {
 
 	if p.flagQuiet {
 		for _, c := range containers {
-			fmt.Println(c.ID[:6])
+			id := c.ID[:6]
+			if p.flagNoTrunc {
+				id = c.ID
+			}
+			fmt.Println(id)
 		}
 		return nil
 	}
@@ -79,9 +85,13 @@ func (p *PsCommand) runPs(args []string) error {
 			return err
 		}
 
-		display.AddRow([]string{c.Names[0], c.ID[:6], c.Status, created + " ago", c.Image, c.HostConfig.Runtime})
-	}
+		id := c.ID[:6]
+		if p.flagNoTrunc {
+			id = c.ID
+		}
 
+		display.AddRow([]string{c.Names[0], id, c.Status, created + " ago", c.Image, c.HostConfig.Runtime})
+	}
 	display.Flush()
 	return nil
 }
@@ -107,6 +117,21 @@ $ pouch ps -a -q
 faf132
 e42c68
 a8c2ea
+
+$ pouch ps --no-trunc
+Name   ID                                                                 Status        Created        Image                            Runtime
+foo2   692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48   Up 1 minute   1 minute ago   docker.io/library/redis:alpine   runc
+foo    18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5   Up 1 minute   1 minute ago   docker.io/library/redis:alpine   runc
+
+$ pouch ps --no-trunc -q
+692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48
+18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5
+
+$ pouch ps --no-trunc -a
+Name   ID                                                                 Status         Created         Image                            Runtime
+foo3   63fd6371f3d614bb1ecad2780972d5975ca1ab534ec280c5f7d8f4c7b2e9989d   created        2 minutes ago   docker.io/library/redis:alpine   runc
+foo2   692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48   Up 2 minutes   2 minutes ago   docker.io/library/redis:alpine   runc
+foo    18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5   Up 2 minutes   2 minutes ago   docker.io/library/redis:alpine   runc
 `
 }
 


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This pr adds no-trunc flag for 'pouch ps' command.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #903 

### Ⅲ. Describe how you did it
add flag 

### Ⅳ. Describe how to verify it

```
[root@izj6c44nzox6sb97nzgmhyz ~]# pouch ps --no-trunc
Name   ID                                                                 Status        Created        Image                            Runtime
foo2   692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48   Up 1 minute   1 minute ago   docker.io/library/redis:alpine   runc
foo    18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5   Up 1 minute   1 minute ago   docker.io/library/redis:alpine   runc
[root@izj6c44nzox6sb97nzgmhyz ~]# pouch ps --no-trunc -q
692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48
18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5
[root@izj6c44nzox6sb97nzgmhyz ~]# pouch ps --no-trunc -a
Name   ID                                                                 Status         Created         Image                            Runtime
foo3   63fd6371f3d614bb1ecad2780972d5975ca1ab534ec280c5f7d8f4c7b2e9989d   created        2 minutes ago   docker.io/library/redis:alpine   runc
foo2   692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48   Up 2 minutes   2 minutes ago   docker.io/library/redis:alpine   runc
foo    18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5   Up 2 minutes   2 minutes ago   docker.io/library/redis:alpine   runc
```

### Ⅴ. Special notes for reviews


