### PR TITLE
bugfix:  pull a image failed will lead to list images failed

### DIFF
--- a/ctrd/image.go
+++ b/ctrd/image.go
@@ -78,25 +78,33 @@ func (c *Client) ListImages(ctx context.Context, filter ...string) ([]types.Imag
 		digest := descriptor.Digest
 
 		size, err := image.Size(ctx, c.client.ContentStore(), platforms.Default())
+		// occur error, skip it
 		if err != nil {
-			return nil, err
+			logrus.Errorf("failed to get image size %s: %v", image.Name, err)
+			continue
 		}
 
 		refNamed, err := reference.ParseNamedReference(image.Name)
+		// occur error, skip it
 		if err != nil {
-			return nil, err
+			logrus.Errorf("failed to parse image %s: %v", image.Name, err)
+			continue
 		}
 		refTagged := reference.WithDefaultTagIfMissing(refNamed).(reference.Tagged)
 
 		ociImage, err := c.GetOciImage(ctx, image.Name)
+		// occur error, skip it
 		if err != nil {
-			return nil, err
+			logrus.Errorf("failed to get ociImage %s: %v", image.Name, err)
+			continue
 		}
 
 		// fill struct ImageInfo
 		imageInfo, err := ociImageToPouchImage(ociImage)
+		// occur error, skip it
 		if err != nil {
-			return nil, err
+			logrus.Errorf("failed to convert ociImage to pouch image %s: %v", image.Name, err)
+			continue
 		}
 		imageInfo.Tag = refTagged.Tag()
 		imageInfo.Name = image.Name


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
fix: pull a image failed will lead to list images failed
```
root@osboxes:pouch (master) -> pouch images
Error: failed to get image list: {"message":"manifest sha256:bd13a0fc2aa205653032b3fef7895332bbbbc6fc9b0552e42d4b33b4a5481290: not found"}
```

### Ⅱ. Does this pull request fix one issue?
fixes https://github.com/alibaba/pouch/issues/924

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


