### PR TITLE
feature: containerd grpc client pool

### DIFF
--- a/ctrd/client_test.go
+++ b/ctrd/client_test.go
@@ -12,7 +12,7 @@ func TestNewClient(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *Client
+		want    APIClient
 		wantErr bool
 	}{
 	// TODO: Add test cases.

--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -26,11 +26,14 @@ var (
 )
 
 type containerPack struct {
-	id            string
-	ch            chan *Message
-	sch           <-chan containerd.ExitStatus
-	container     containerd.Container
-	task          containerd.Task
+	id        string
+	ch        chan *Message
+	sch       <-chan containerd.ExitStatus
+	container containerd.Container
+	task      containerd.Task
+
+	// client is to record which stream client the container connect with
+	client        *WrapperClient
 	skipStopHooks bool
 }
 
@@ -150,12 +153,17 @@ func (c *Client) ProbeContainer(ctx context.Context, id string, timeout time.Dur
 
 // RecoverContainer reload the container from metadata and watch it, if program be restarted.
 func (c *Client) RecoverContainer(ctx context.Context, id string, io *containerio.IO) error {
+	wrapperCli, err := c.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get a containerd grpc client: %v", err)
+	}
+
 	if !c.lock.Trylock(id) {
 		return errtypes.ErrLockfailed
 	}
 	defer c.lock.Unlock(id)
 
-	lc, err := c.client.LoadContainer(ctx, id)
+	lc, err := wrapperCli.client.LoadContainer(ctx, id)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			return errors.Wrap(errtypes.ErrNotfound, "container")
@@ -177,11 +185,13 @@ func (c *Client) RecoverContainer(ctx context.Context, id string, io *containeri
 	if err != nil {
 		return errors.Wrap(err, "failed to wait task")
 	}
+
 	c.watch.add(&containerPack{
 		id:        id,
 		container: lc,
 		task:      task,
 		ch:        make(chan *Message, 1),
+		client:    wrapperCli,
 		sch:       statusCh,
 	})
 
@@ -194,7 +204,12 @@ func (c *Client) DestroyContainer(ctx context.Context, id string, timeout int64)
 	// TODO(ziren): if we just want to stop a container,
 	// we may need lease to lock the snapshot of container,
 	// in case, it be deleted by gc.
-	ctx = leases.WithLease(ctx, c.lease.ID())
+	wrapperCli, err := c.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get a containerd grpc client: %v", err)
+	}
+
+	ctx = leases.WithLease(ctx, wrapperCli.lease.ID())
 
 	if !c.lock.Trylock(id) {
 		return nil, errtypes.ErrLockfailed
@@ -316,8 +331,13 @@ func (c *Client) CreateContainer(ctx context.Context, container *Container) erro
 }
 
 func (c *Client) createContainer(ctx context.Context, ref, id string, container *Container) (err0 error) {
+	wrapperCli, err := c.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get a containerd grpc client: %v", err)
+	}
+
 	// get image
-	img, err := c.client.GetImage(ctx, ref)
+	img, err := wrapperCli.client.GetImage(ctx, ref)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			return errors.Wrap(errtypes.ErrNotfound, "image")
@@ -350,7 +370,7 @@ func (c *Client) createContainer(ctx context.Context, ref, id string, container 
 	}
 	options = append(options, containerd.WithSnapshot(id))
 
-	nc, err := c.client.NewContainer(ctx, id, options...)
+	nc, err := wrapperCli.client.NewContainer(ctx, id, options...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create container, id: %s", id)
 	}
@@ -368,6 +388,9 @@ func (c *Client) createContainer(ctx context.Context, ref, id string, container 
 	if err != nil {
 		return err
 	}
+
+	// add grpc client to pack struct
+	pack.client = wrapperCli
 
 	c.watch.add(pack)
 
@@ -422,7 +445,12 @@ func (c *Client) createTask(ctx context.Context, id string, container containerd
 }
 
 func (c *Client) listContainerStore(ctx context.Context) ([]string, error) {
-	containers, err := c.client.ContainerService().List(ctx)
+	wrapperCli, err := c.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get a containerd grpc client: %v", err)
+	}
+
+	containers, err := wrapperCli.client.ContainerService().List(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/ctrd/snapshot.go
+++ b/ctrd/snapshot.go
@@ -2,6 +2,7 @@ package ctrd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/platforms"
@@ -13,20 +14,24 @@ const defaultSnapshotterName = "overlayfs"
 
 // CreateSnapshot creates a active snapshot with image's name and id.
 func (c *Client) CreateSnapshot(ctx context.Context, id, ref string) error {
-	ctx = leases.WithLease(ctx, c.lease.ID())
+	wrapperCli, err := c.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get a containerd grpc client: %v", err)
+	}
+	ctx = leases.WithLease(ctx, wrapperCli.lease.ID())
 
-	image, err := c.client.ImageService().Get(ctx, ref)
+	image, err := wrapperCli.client.ImageService().Get(ctx, ref)
 	if err != nil {
 		return err
 	}
 
-	diffIDs, err := image.RootFS(ctx, c.client.ContentStore(), platforms.Default())
+	diffIDs, err := image.RootFS(ctx, wrapperCli.client.ContentStore(), platforms.Default())
 	if err != nil {
 		return err
 	}
 
 	parent := identity.ChainID(diffIDs).String()
-	if _, err := c.client.SnapshotService(defaultSnapshotterName).Prepare(ctx, id, parent); err != nil {
+	if _, err := wrapperCli.client.SnapshotService(defaultSnapshotterName).Prepare(ctx, id, parent); err != nil {
 		return err
 	}
 	return nil
@@ -34,7 +39,12 @@ func (c *Client) CreateSnapshot(ctx context.Context, id, ref string) error {
 
 // GetSnapshot returns the snapshot's info by id.
 func (c *Client) GetSnapshot(ctx context.Context, id string) (snapshots.Info, error) {
-	service := c.client.SnapshotService(defaultSnapshotterName)
+	wrapperCli, err := c.Get(ctx)
+	if err != nil {
+		return snapshots.Info{}, fmt.Errorf("failed to get a containerd grpc client: %v", err)
+	}
+
+	service := wrapperCli.client.SnapshotService(defaultSnapshotterName)
 	defer service.Close()
 
 	return service.Stat(ctx, id)
@@ -42,7 +52,12 @@ func (c *Client) GetSnapshot(ctx context.Context, id string) (snapshots.Info, er
 
 // RemoveSnapshot removes the snapshot by id.
 func (c *Client) RemoveSnapshot(ctx context.Context, id string) error {
-	service := c.client.SnapshotService(defaultSnapshotterName)
+	wrapperCli, err := c.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get a containerd grpc client: %v", err)
+	}
+
+	service := wrapperCli.client.SnapshotService(defaultSnapshotterName)
 	defer service.Close()
 
 	return service.Remove(ctx, id)

--- a/ctrd/wrapper_client.go
+++ b/ctrd/wrapper_client.go
@@ -1,0 +1,87 @@
+package ctrd
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/containerd/containerd"
+	"github.com/pkg/errors"
+)
+
+// WrapperClient wrappers containerd grpc client,
+// so that pouch daemon can holds a grpc client pool
+// to improve grpc client performance.
+type WrapperClient struct {
+	client *containerd.Client
+
+	// Lease is a new feature of containerd, We use it to avoid that the images
+	// are removed by garbage collection. If no lease is defined, the downloaded images will
+	// be removed automatically when the container is removed.
+	lease *containerd.Lease
+
+	mux sync.Mutex
+	// streamQuota records the numbers of stream client without be using
+	streamQuota int
+}
+
+func newWrapperClient(cfg Config) (*WrapperClient, error) {
+	options := []containerd.ClientOpt{
+		containerd.WithDefaultNamespace("default"),
+	}
+	cli, err := containerd.New(cfg.Address, options...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to connect containerd")
+	}
+
+	// create a new lease or reuse the existed.
+	var lease containerd.Lease
+
+	leases, err := cli.ListLeases(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+	if len(leases) != 0 {
+		lease = leases[0]
+	} else {
+		if lease, err = cli.CreateLease(context.TODO()); err != nil {
+			return nil, err
+		}
+	}
+
+	return &WrapperClient{
+		client:      cli,
+		lease:       &lease,
+		streamQuota: cfg.MaxStreamsClient,
+	}, nil
+}
+
+// Produce is to release specified numbers of grpc stream client
+// FIXME(ziren): if streamQuota greater than defaultMaxStreamsClient
+// what to do ???
+func (w *WrapperClient) Produce(v int) {
+	w.mux.Lock()
+	defer w.mux.Unlock()
+	w.streamQuota += v
+}
+
+// Consume is to acquire specified numbers of grpc stream client
+func (w *WrapperClient) Consume(v int) error {
+	w.mux.Lock()
+	defer w.mux.Unlock()
+
+	if w.streamQuota < v {
+		return fmt.Errorf("quota is %d, less than %d, can not acquire", w.streamQuota, v)
+	}
+
+	w.streamQuota -= v
+	return nil
+}
+
+// Value is to get the quota
+func (w *WrapperClient) Value() int {
+	w.mux.Lock()
+	defer w.mux.Unlock()
+
+	return w.streamQuota
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,0 +1,66 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+)
+
+// Scheduler is an interface that implement a function
+// choosing an item from a items pool.
+type Scheduler interface {
+	// Return a chosed client
+	Schedule(ctx context.Context) (Factory, error)
+}
+
+// Factory is an interface that can produce and consume
+// "goods"
+type Factory interface {
+	// Value will return the total numbers of goods
+	Value() int
+
+	// Produce will produce numbers of goods
+	Produce(goods int)
+
+	// Consume will consume numbers of goods
+	Consume(goods int) error
+}
+
+// LRUScheduler is a Least Recently Used scheduler.
+type LRUScheduler struct {
+	pool []Factory
+}
+
+// NewLRUScheduler new a LRU scheduler.
+func NewLRUScheduler(pool []Factory) (Scheduler, error) {
+	return &LRUScheduler{
+		pool: pool,
+	}, nil
+}
+
+// Schedule is to choose the next candidate.
+func (lru *LRUScheduler) Schedule(ctx context.Context) (Factory, error) {
+	if len(lru.pool) == 0 {
+		return nil, fmt.Errorf("empty candidate list")
+	}
+
+	var (
+		index = 0
+		least = lru.pool[0].Value()
+	)
+
+	for i := 1; i < len(lru.pool); i++ {
+		v := lru.pool[i].Value()
+		if v > least {
+			index = i
+			least = v
+		}
+	}
+
+	// the max number of goods below 0, resources
+	// have reached the limit.
+	if least <= 0 {
+		return nil, fmt.Errorf("resources exhausted")
+	}
+
+	return lru.pool[index], nil
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,124 @@
+package scheduler
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestNewLRUScheduler(t *testing.T) {
+	type args struct {
+		pool []Factory
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Scheduler
+		wantErr bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewLRUScheduler(tt.args.pool)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewLRUScheduler() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewLRUScheduler() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type testFactory struct {
+	mux sync.Mutex
+
+	data int
+}
+
+func (tf *testFactory) Consume(v int) error {
+	tf.mux.Lock()
+	defer tf.mux.Unlock()
+
+	tf.data -= v
+	return nil
+}
+
+func (tf *testFactory) Produce(v int) {
+	tf.mux.Lock()
+	defer tf.mux.Unlock()
+
+	tf.data += v
+}
+
+func (tf *testFactory) Value() int {
+	tf.mux.Lock()
+	defer tf.mux.Unlock()
+
+	return tf.data
+}
+
+func newTestFactoryPool(ls []int) []Factory {
+	pool := []Factory{}
+	for _, d := range ls {
+		pool = append(pool, &testFactory{
+			data: d,
+		})
+	}
+
+	return pool
+}
+
+func TestLRUScheduler_Schedule(t *testing.T) {
+	type fields struct {
+		pool []Factory
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    Factory
+		wantErr bool
+	}{
+		{name: "test1", fields: fields{pool: newTestFactoryPool([]int{})}, args: args{ctx: context.Background()}, want: nil, wantErr: true},
+		{name: "test1", fields: fields{pool: newTestFactoryPool([]int{1, 2, 3})}, args: args{ctx: context.Background()}, want: &testFactory{data: 3}, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lru := &LRUScheduler{
+				pool: tt.fields.pool,
+			}
+			got, err := lru.Schedule(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LRUScheduler.Schedule() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if (tt.want == nil && got != nil) || (tt.want != nil && got == nil) {
+				t.Errorf("LRUScheduler.Schedule() = %v, want %v", got, tt.want)
+			} else if tt.want == nil && got == nil {
+				return
+			}
+
+			gotTestFactory, ok := got.(*testFactory)
+			if !ok {
+				t.Errorf("LRUScheduler.Schedule() return type is wrong")
+			}
+
+			wantFactory, ok := tt.want.(*testFactory)
+			if !ok {
+				t.Errorf("tt.want not *testFactory")
+			}
+
+			if gotTestFactory.Value() != wantFactory.Value() {
+				t.Errorf("LRUScheduler.Schedule() = %v, want %v", gotTestFactory, wantFactory)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
change ctrd containerd client to client pool to work around the grpc-go client concurrent streams limitation

now we can `pouch run` more then 100 containers

```
time for i in {1..200}; do echo $i; pouch run -d registry.hub.docker.com/library/busybox:latest sleep 100000; done

....

real	1m33.644s
user	0m11.269s
sys	0m2.299s
```

```
root@osboxes:pouch (zr/grpc-pool) -> ps aux | grep containerd-shim | wc -l
202
```

### Ⅱ. Does this pull request fix one issue?
fixes https://github.com/alibaba/pouch/issues/766

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


