### PR TITLE
feature: add bind mode

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -327,6 +327,11 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 		}
 	}
 
+	container.Mounts = []types.MountPoint{}
+	for _, mp := range meta.Mounts {
+		container.Mounts = append(container.Mounts, *mp)
+	}
+
 	return EncodeResponse(rw, http.StatusOK, container)
 }
 

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2838,6 +2838,8 @@ definitions:
     properties:
       Type:
         type: "string"
+      ID:
+        type: "string"
       Name:
         type: "string"
       Source:
@@ -2850,6 +2852,12 @@ definitions:
         type: "string"
       RW:
         type: "boolean"
+      CopyData:
+        type: "boolean"
+      Named:
+        type: "boolean"
+      Replace:
+        type: "string"
       Propagation:
         type: "string"
 

--- a/apis/types/mount_point.go
+++ b/apis/types/mount_point.go
@@ -17,11 +17,17 @@ import (
 
 type MountPoint struct {
 
+	// copy data
+	CopyData bool `json:"CopyData,omitempty"`
+
 	// destination
 	Destination string `json:"Destination,omitempty"`
 
 	// driver
 	Driver string `json:"Driver,omitempty"`
+
+	// ID
+	ID string `json:"ID,omitempty"`
 
 	// mode
 	Mode string `json:"Mode,omitempty"`
@@ -29,11 +35,17 @@ type MountPoint struct {
 	// name
 	Name string `json:"Name,omitempty"`
 
+	// named
+	Named bool `json:"Named,omitempty"`
+
 	// propagation
 	Propagation string `json:"Propagation,omitempty"`
 
 	// r w
 	RW bool `json:"RW,omitempty"`
+
+	// replace
+	Replace string `json:"Replace,omitempty"`
 
 	// source
 	Source string `json:"Source,omitempty"`
@@ -42,17 +54,25 @@ type MountPoint struct {
 	Type string `json:"Type,omitempty"`
 }
 
+/* polymorph MountPoint CopyData false */
+
 /* polymorph MountPoint Destination false */
 
 /* polymorph MountPoint Driver false */
+
+/* polymorph MountPoint ID false */
 
 /* polymorph MountPoint Mode false */
 
 /* polymorph MountPoint Name false */
 
+/* polymorph MountPoint Named false */
+
 /* polymorph MountPoint Propagation false */
 
 /* polymorph MountPoint RW false */
+
+/* polymorph MountPoint Replace false */
 
 /* polymorph MountPoint Source false */
 

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -77,7 +77,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 
 	flagSet.StringVar(&c.utsMode, "uts", "", "UTS namespace to use")
 
-	flagSet.StringSliceVarP(&c.volume, "volume", "v", nil, "Bind mount volumes to container")
+	flagSet.StringSliceVarP(&c.volume, "volume", "v", nil, "Bind mount volumes to container, format is: [source:]<destination>[:mode], [source] can be volume or host's path, <destination> is container's path, [mode] can be \"ro/rw/dr/rr/z/Z/nocopy/private/rprivate/slave/rslave/shared/rshared\"")
 
 	flagSet.StringVarP(&c.workdir, "workdir", "w", "", "Set the working directory in a container")
 

--- a/daemon/mgr/spec_volume.go
+++ b/daemon/mgr/spec_volume.go
@@ -3,7 +3,6 @@ package mgr
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -14,28 +13,43 @@ func setupMounts(ctx context.Context, c *ContainerMeta, spec *SpecWrapper) error
 	if c.HostConfig == nil {
 		return nil
 	}
-	for _, v := range c.HostConfig.Binds {
-		sd := strings.Split(v, ":")
-		lensd := len(sd)
-		if lensd < 2 || lensd > 3 {
-			return fmt.Errorf("unknown bind: %s", v)
-		}
-		opt := []string{"rbind"}
-		if lensd == 3 {
-			opt = append(opt, strings.Split(sd[2], ",")...)
-			// Set rootfs propagation, default setting is private.
-			if strings.Contains(sd[2], "rshared") {
-				s.Linux.RootfsPropagation = "rshared"
+	for _, mp := range c.Mounts {
+		// check duplicate mountpoint
+		for _, sm := range mounts {
+			if sm.Destination == mp.Destination {
+				return fmt.Errorf("duplicate mount point: %s", mp.Destination)
 			}
-			if strings.Contains(sd[2], "rslave") && s.Linux.RootfsPropagation != "rshared" {
+		}
+
+		pg := mp.Propagation
+		rootfspg := s.Linux.RootfsPropagation
+		// Set rootfs propagation, default setting is private.
+		switch pg {
+		case "shared", "rshared":
+			if rootfspg != "shared" && rootfspg != "rshared" {
+				s.Linux.RootfsPropagation = "shared"
+			}
+		case "slave", "rslave":
+			if rootfspg != "shared" && rootfspg != "rshared" && rootfspg != "slave" && rootfspg != "rslave" {
 				s.Linux.RootfsPropagation = "rslave"
 			}
 		}
+
+		opts := []string{"rbind"}
+		if !mp.RW {
+			opts = append(opts, "ro")
+		}
+		if pg != "" {
+			opts = append(opts, pg)
+		}
+
+		// TODO: support copy data.
+
 		mounts = append(mounts, specs.Mount{
-			Destination: sd[1],
-			Source:      sd[0],
+			Source:      mp.Source,
+			Destination: mp.Destination,
 			Type:        "bind",
-			Options:     opt,
+			Options:     opts,
 		})
 	}
 	s.Mounts = mounts


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add bind mode, it contains:
"ro/rw/dr/rr/z/Z/nocopy/private/rprivate/slave/rslave/shared/rshared"

common mode for all bind are: "ro/rw"，"z/Z" will be supported later,
"dr/rr/nocopy" just for volume, dr means direct replace, rr means random replace, nocopy will be supported later.
"private/rprivate/slave/rslave/shared/rshared" just for rootfs.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
see test/cli_volume_test.go:TestVolumeBindReplaceMode

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
