### PR TITLE
refactor: modify logic in complement image fullname

### DIFF
--- a/daemon/mgr/image_utils.go
+++ b/daemon/mgr/image_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/alibaba/pouch/pkg/reference"
 )
 
-// addRegistry add default registry if needed.
+// addRegistry add default registry and namespace if needed.
 func (mgr *ImageManager) addRegistry(input string) string {
 	// Trim the prefix if the input is image ID with "sha256:".
 	// NOTE: we should make it more elegant and comprehensive.
@@ -17,10 +17,16 @@ func (mgr *ImageManager) addRegistry(input string) string {
 		return input
 	}
 
+	// check if input repo name get library and namespace
 	if _, ok := reference.Domain(input); ok {
 		return input
 	}
-	return filepath.Join(mgr.DefaultRegistry, mgr.DefaultNamespace, input)
+
+	if reference.IsNameOnly(input) {
+		return filepath.Join(mgr.DefaultRegistry, mgr.DefaultNamespace, input)
+	}
+
+	return filepath.Join(mgr.DefaultRegistry, input)
 }
 
 // isNumericID checks whether input is numeric ID

--- a/daemon/mgr/image_utils_test.go
+++ b/daemon/mgr/image_utils_test.go
@@ -1,0 +1,61 @@
+package mgr
+
+import (
+	"testing"
+
+	"github.com/alibaba/pouch/daemon/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func testAddRegistry(t *testing.T) {
+	assert := assert.New(t)
+	type tCase struct {
+		repo   string
+		expect string
+	}
+
+	var (
+		registry = "testRegistry"
+		ns       = "testNS"
+	)
+	// set default registry and namespace
+	imgr, err := NewImageManager(&config.Config{
+		DefaultRegistry:   registry,
+		DefaultRegistryNS: ns,
+	}, nil)
+	assert.NoError(err)
+
+	for _, tc := range []tCase{
+		{
+			repo:   "docker.io/library/busybox",
+			expect: "docker.io/library/busybox",
+		},
+		{
+			repo:   "library/busybox",
+			expect: registry + "/library/busybox",
+		},
+		{
+			repo:   "127.0.0.1:5000/bar",
+			expect: "127.0.0.1:5000/bar",
+		},
+		{
+			repo:   "0.0.0.0/bar",
+			expect: "0.0.0.0/bar",
+		},
+		{
+			repo:   "registry.com/bar",
+			expect: "registry.com/bar",
+		},
+		{
+			repo:   "bar",
+			expect: registry + "/" + ns + "/bar",
+		},
+		{
+			repo:   "foo/bar",
+			expect: registry + "/foo/bar",
+		},
+	} {
+		output := imgr.addRegistry(tc.repo)
+		assert.Equal(tc.expect, output)
+	}
+}

--- a/pkg/reference/parse.go
+++ b/pkg/reference/parse.go
@@ -59,8 +59,8 @@ func WithDefaultTagIfMissing(named Named) Named {
 	return named
 }
 
-// Domain retrieves domain information. Domain include registry address and
-// repository namespace, like registry.hub.docker.com/library/ubuntu.
+// Domain retrieves domain information. Domain include registry address or
+// repository namespace can be included, like registry.hub.docker.com/library.
 func Domain(named string) (string, bool) {
 	i := strings.LastIndexByte(named, '/')
 
@@ -70,4 +70,28 @@ func Domain(named string) (string, bool) {
 		return "", false
 	}
 	return named[:i], true
+}
+
+// splitHostname splits HostName and RemoteName for the given reference.
+// Since we use user defined default registry, if HostName is null, we will return null.
+func splitHostname(ref string) (string, string) {
+	i := strings.IndexRune(ref, '/')
+	if i == -1 || !strings.ContainsAny(ref[:i], ".:") {
+		return "", ref
+	}
+	return ref[:i], ref[i+1:]
+}
+
+// IsNameOnly checks if only image repo name only, like busybox.
+func IsNameOnly(ref string) bool {
+	h, r := splitHostname(ref)
+	if h != "" {
+		return false
+	}
+
+	if strings.Contains(r, "/") {
+		return false
+	}
+
+	return true
 }

--- a/pkg/reference/parse_test.go
+++ b/pkg/reference/parse_test.go
@@ -58,6 +58,16 @@ func TestDomain(t *testing.T) {
 			input:  "nginx",
 			domain: "",
 			ok:     false,
+		}, {
+			name:   "Repo and Name",
+			input:  "fooo/foo/bar",
+			domain: "",
+			ok:     false,
+		}, {
+			name:   "IP Registry",
+			input:  "0.0.0.0/foo/bar",
+			domain: "0.0.0.0/foo",
+			ok:     true,
 		},
 	} {
 		d, ok := Domain(tc.input)
@@ -132,5 +142,60 @@ func TestParse(t *testing.T) {
 		ref, err := Parse(tc.input)
 		assert.Equal(t, tc.err, err, tc.name)
 		assert.Equal(t, tc.expected, ref, tc.name)
+	}
+}
+
+func TestSplitName(t *testing.T) {
+	assert := assert.New(t)
+
+	type ref struct {
+		name       string
+		hostname   string
+		remotename string
+		ok         bool
+	}
+
+	for _, r := range []ref{
+		{
+			name:       "docker.io/library/busybox",
+			hostname:   "docker.io",
+			remotename: "library/busybox",
+			ok:         false,
+		},
+		{
+			name:       "g.com/library/busybox",
+			hostname:   "g.com",
+			remotename: "library/busybox",
+			ok:         false,
+		},
+		{
+			name:       "127.0.0.1:5000/library/busybox",
+			hostname:   "127.0.0.1:5000",
+			remotename: "library/busybox",
+			ok:         false,
+		},
+		{
+			name:       "library/busybox",
+			hostname:   "",
+			remotename: "library/busybox",
+			ok:         false,
+		},
+		{
+			name:       "foo/busybox",
+			hostname:   "",
+			remotename: "foo/busybox",
+			ok:         false,
+		},
+		{
+			name:       "busybox",
+			hostname:   "",
+			remotename: "busybox",
+			ok:         true,
+		},
+	} {
+		hostname, remotename := splitHostname(r.name)
+		assert.Equal(r.hostname, hostname)
+		assert.Equal(r.remotename, remotename)
+		assert.Equal(IsNameOnly(r.name), r.ok)
 	}
 }


### PR DESCRIPTION
since we add user defined registry and repo namespace, we split
image name complement process into two part, one is in pkg/reference,
the other is in daemon/mgr/image_utils.go.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


