### PR TITLE
feature: pouch info print information enhance

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1317,6 +1317,13 @@ definitions:
           - "name=seccomp,profile=default"
           - "name=selinux"
           - "name=userns"
+      ListenAddresses:
+        description: "List of addresses the pouchd listens on"
+        type: "array"
+        items:
+          type: "string"
+        example:
+          - ["unix:///var/run/pouchd.sock", "tcp://0.0.0.0:4243"]
 
   RegistryServiceConfig:
     description: |

--- a/apis/types/system_info.go
+++ b/apis/types/system_info.go
@@ -122,6 +122,9 @@ type SystemInfo struct {
 	//
 	Labels []string `json:"Labels"`
 
+	// List of addresses the pouchd listens on
+	ListenAddresses []string `json:"ListenAddresses"`
+
 	// Indicates if live restore is enabled.
 	// If enabled, containers are kept running when the daemon is shutdown
 	// or upon daemon start if running containers are detected.
@@ -236,6 +239,8 @@ type SystemInfo struct {
 
 /* polymorph SystemInfo Labels false */
 
+/* polymorph SystemInfo ListenAddresses false */
+
 /* polymorph SystemInfo LiveRestoreEnabled false */
 
 /* polymorph SystemInfo LoggingDriver false */
@@ -282,6 +287,11 @@ func (m *SystemInfo) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateLabels(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateListenAddresses(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -384,6 +394,15 @@ func (m *SystemInfo) validateDriverStatus(formats strfmt.Registry) error {
 func (m *SystemInfo) validateLabels(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Labels) { // not required
+		return nil
+	}
+
+	return nil
+}
+
+func (m *SystemInfo) validateListenAddresses(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ListenAddresses) { // not required
 		return nil
 	}
 

--- a/cli/info.go
+++ b/cli/info.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+
+	"github.com/alibaba/pouch/apis/types"
 
 	"github.com/spf13/cobra"
 )
@@ -47,44 +50,108 @@ func (v *InfoCommand) runInfo() error {
 		return fmt.Errorf("failed to get system info: %v", err)
 	}
 
-	v.cli.Print(result)
+	return prettyPrintInfo(v.cli, result)
+}
+
+func prettyPrintInfo(cli *Cli, info *types.SystemInfo) error {
+	fmt.Fprintln(os.Stdout, "Containers:", info.Containers)
+	fmt.Fprintln(os.Stdout, "Running:", info.ContainersRunning)
+	fmt.Fprintln(os.Stdout, "Paused:", info.ContainersPaused)
+	fmt.Fprintln(os.Stdout, "Stopped:", info.ContainersStopped)
+	fmt.Fprintln(os.Stdout, "Images: ", info.Images)
+	fmt.Fprintln(os.Stdout, "ID:", info.ID)
+	fmt.Fprintln(os.Stdout, "Name:", info.Name)
+	fmt.Fprintln(os.Stdout, "Server Version:", info.ServerVersion)
+	fmt.Fprintln(os.Stdout, "Storage Driver:", info.Driver)
+	fmt.Fprintln(os.Stdout, "Driver Status:", info.DriverStatus)
+	fmt.Fprintln(os.Stdout, "Logging Driver:", info.LoggingDriver)
+	fmt.Fprintln(os.Stdout, "Cgroup Driver:", info.CgroupDriver)
+	if len(info.Runtimes) > 0 {
+		fmt.Fprintln(os.Stdout, "Runtimes:")
+		for name := range info.Runtimes {
+			fmt.Fprintf(os.Stdout, "%s", name)
+		}
+		fmt.Fprint(os.Stdout, "\n")
+		fmt.Fprintln(os.Stdout, "Default Runtime:", info.DefaultRuntime)
+	}
+	fmt.Fprintln(os.Stdout, "runc:", info.RuncCommit)
+	fmt.Fprintln(os.Stdout, "containerd:", info.ContainerdCommit)
+
+	// Kernel info
+	fmt.Fprintln(os.Stdout, "Security Options:", info.SecurityOptions)
+	fmt.Fprintln(os.Stdout, "Kernel Version:", info.KernelVersion)
+	fmt.Fprintln(os.Stdout, "Operating System:", info.OperatingSystem)
+	fmt.Fprintln(os.Stdout, "OSType:", info.OSType)
+	fmt.Fprintln(os.Stdout, "Architecture:", info.Architecture)
+
+	fmt.Fprintln(os.Stdout, "HTTP Proxy:", info.HTTPProxy)
+	fmt.Fprintln(os.Stdout, "HTTPS Proxy:", info.HTTPSProxy)
+	fmt.Fprintln(os.Stdout, "Registry:", info.IndexServerAddress)
+	fmt.Fprintln(os.Stdout, "Experimental:", info.ExperimentalBuild)
+	fmt.Fprintln(os.Stdout, "Debug:", info.Debug)
+	fmt.Fprintln(os.Stdout, "Labels:", info.Labels)
+
+	fmt.Fprintln(os.Stdout, "CPUs:", info.NCPU)
+	fmt.Fprintln(os.Stdout, "Total Memory:", info.MemTotal)
+	fmt.Fprintln(os.Stdout, "Pouch Root Dir:", info.PouchRootDir)
+	fmt.Fprintln(os.Stdout, "LiveRestoreEnabled:", info.LiveRestoreEnabled)
+	if info.RegistryConfig != nil && (len(info.RegistryConfig.InsecureRegistryCIDRs) > 0 || len(info.RegistryConfig.IndexConfigs) > 0) {
+		fmt.Fprintln(os.Stdout, "Insecure Registries:")
+		for _, registry := range info.RegistryConfig.IndexConfigs {
+			if !registry.Secure {
+				fmt.Fprintln(os.Stdout, " "+registry.Name)
+			}
+		}
+
+		for _, registry := range info.RegistryConfig.InsecureRegistryCIDRs {
+			fmt.Fprintf(os.Stdout, " %s\n", registry)
+		}
+	}
+
+	if info.RegistryConfig != nil && len(info.RegistryConfig.Mirrors) > 0 {
+		fmt.Fprintln(os.Stdout, "Registry Mirrors:")
+		for _, mirror := range info.RegistryConfig.Mirrors {
+			fmt.Fprintln(os.Stdout, " "+mirror)
+		}
+	}
+
+	fmt.Fprintln(os.Stdout, "Daemon Listen Addresses:", info.ListenAddresses)
+
 	return nil
 }
 
 // infoExample shows examples in info command, and is used in auto-generated cli docs.
 func infoExample() string {
 	return `$ pouch info
+Containers: 1
+Running: 1
+Paused: 0
+Stopped: 0
+Images:  0
 ID:
 Name:
-OperatingSystem:
-PouchRootDir:         /var/lib/pouch
-ServerVersion:        0.3-dev
-ContainersRunning:    0
-Debug:                false
-DriverStatus:         []
-Labels:               []
-Containers:           0
-DefaultRuntime:       runc
-Driver:
-ExperimentalBuild:    false
-KernelVersion:        3.10.0-693.11.6.el7.x86_64
-OSType:               linux
-CgroupDriver:
-ContainerdCommit:     <nil>
-ContainersPaused:     0
-LoggingDriver:
-SecurityOptions:      []
-NCPU:                 0
-RegistryConfig:       <nil>
-RuncCommit:           <nil>
-ContainersStopped:    0
-HTTPSProxy:
-IndexServerAddress:   https://index.docker.io/v1/
-LiveRestoreEnabled:   false
-Runtimes:             map[]
+Server Version: 0.3-dev
+Storage Driver:
+Driver Status: []
+Logging Driver:
+Cgroup Driver:
+runc: <nil>
+containerd: <nil>
+Security Options: []
+Kernel Version: 3.10.0-693.17.1.el7.x86_64
+Operating System:
+OSType: linux
 Architecture:
-HTTPProxy:
-Images:               0
-MemTotal:             0
+HTTP Proxy:
+HTTPS Proxy:
+Registry: https://index.docker.io/v1/
+Experimental: false
+Debug: true
+Labels: []
+CPUs: 0
+Total Memory: 0
+Pouch Root Dir: /var/lib/pouch
+LiveRestoreEnabled: false
+Daemon Listen Addresses: [unix:///var/run/pouchd.sock]
 `
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -135,7 +135,7 @@ func (d *Daemon) Run() error {
 	}
 	d.imageMgr = imageMgr
 
-	systemMgr, err := internal.GenSystemMgr(&d.config)
+	systemMgr, err := internal.GenSystemMgr(&d.config, d)
 	if err != nil {
 		return err
 	}

--- a/internal/generator.go
+++ b/internal/generator.go
@@ -29,8 +29,8 @@ func GenContainerMgr(ctx context.Context, d DaemonProvider) (mgr.ContainerMgr, e
 }
 
 // GenSystemMgr generates a SystemMgr instance according to config cfg.
-func GenSystemMgr(cfg *config.Config) (mgr.SystemMgr, error) {
-	return mgr.NewSystemManager(cfg)
+func GenSystemMgr(cfg *config.Config, d DaemonProvider) (mgr.SystemMgr, error) {
+	return mgr.NewSystemManager(cfg, d.MetaStore())
 }
 
 // GenImageMgr generates a ImageMgr instance according to config cfg.


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
    1. pretty print pouch info
    2. add daemon listen address in info
    3. add container count ing info

### Ⅱ. Does this pull request fix one issue?
fixes: https://github.com/alibaba/pouch/issues/920
fix part of https://github.com/alibaba/pouch/issues/894

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
```
root@osboxes:pouch (zr/info-completion *) -> pouch info
Containers: 1
Running: 1
Paused: 0
Stopped: 0
Images:  0
Server Version: 0.3-dev
Storage Driver:
Driver Status: []
Logging Driver:
Cgroup Driver:
runc: <nil>
containerd: <nil>
Security Options: []
Kernel Version: 3.10.0-693.17.1.el7.x86_64
Operating System:
OSType: linux
Architecture:
HTTP Proxy:
HTTPS Proxy:
Registry: https://index.docker.io/v1/
Experimental: false
Debug: true
Labels: []
CPUs: 0
Total Memory: 0
Name:
ID:
Pouch Root Dir: /var/lib/pouch
LiveRestoreEnabled: false
Daemon Listen Addresses: [unix:///var/run/pouchd.sock]
```

### Ⅴ. Special notes for reviews


