### PR TITLE
bugfix: fix check kernel version is wrong

### DIFF
--- a/pkg/quota/quota.go
+++ b/pkg/quota/quota.go
@@ -49,7 +49,7 @@ func NewQuota(name string) BaseQuota {
 		}
 	default:
 		kernelVersion, err := kernel.GetKernelVersion()
-		if err == nil && kernelVersion.Major >= 4 {
+		if err == nil && kernelVersion.Kernel >= 4 {
 			quota = &PrjQuota{
 				quotaIDs:    make(map[uint32]uint32),
 				mountPoints: make(map[uint64]string),


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
check kernel version when setting disk quota driver, it should check
kernel > 4, instead of major > 4.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
For example，the version of kernel is 3.10, and it supports group quota. you can test like this:
```
# cd pouch/test
# go test -check.f TestAliKernelDiskQuotaWorks
```
test will be succeed.

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
