### PR TITLE
feature: sandbox store for cri manager

### DIFF
--- a/daemon/mgr/cri_types.go
+++ b/daemon/mgr/cri_types.go
@@ -1,0 +1,14 @@
+package mgr
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+)
+
+// SandboxMeta represents the sandbox's meta data.
+type SandboxMeta struct {
+	// Config is CRI sandbox config.
+	Config *runtime.PodSandboxConfig
+
+	// NetNSPath is the network namespace used by the sandbox.
+	NetNSPath string
+}


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

We should store the config of sandbox in cri manager.

Because we need some of them when stop or remove the pod and we couldn't get it directly from API.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


