### PR TITLE
bugfix: initialize the network log

### DIFF
--- a/daemon/mgr/network.go
+++ b/daemon/mgr/network.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alibaba/pouch/pkg/meta"
 	"github.com/alibaba/pouch/pkg/randomid"
 
+	netlog "github.com/Sirupsen/logrus"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/libnetwork"
 	nwconfig "github.com/docker/libnetwork/config"
@@ -408,17 +409,19 @@ func (nm *NetworkManager) getNetworkSandbox(id string) libnetwork.Sandbox {
 	return sb
 }
 
+// libnetwork's logrus version is different from pouchd,
+// so we need to set libnetwork's logrus addintionly.
 func initNetworkLog(cfg *config.Config) {
 	if cfg.Debug {
-		logrus.SetLevel(logrus.DebugLevel)
+		netlog.SetLevel(netlog.DebugLevel)
 	}
 
-	formatter := &logrus.TextFormatter{
+	formatter := &netlog.TextFormatter{
 		ForceColors:     true,
 		FullTimestamp:   true,
 		TimestampFormat: "2006-01-02 15:04:05.000000000",
 	}
-	logrus.SetFormatter(formatter)
+	netlog.SetFormatter(formatter)
 }
 
 func endpointOptions(n libnetwork.Network, nwconfig *apitypes.NetworkSettings, epConfig *apitypes.EndpointSettings) ([]libnetwork.EndpointOption, error) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
revert commit: 8a70a80
libnetwork's logrus version is different from pouchd, so we need to
set libnetwork's logrus addintionly.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
run pouchd and see network log format

### Ⅴ. Special notes for reviews

also cc @faycheng 

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
