### PR TITLE
bugfix: rm dump ContainerPIDs method

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -104,6 +104,11 @@ func (c *Client) ContainerPID(ctx context.Context, id string) (int, error) {
 
 // ContainerPIDs returns the all processes's ids inside the container.
 func (c *Client) ContainerPIDs(ctx context.Context, id string) ([]int, error) {
+	if !c.lock.Trylock(id) {
+		return nil, errtypes.ErrLockfailed
+	}
+	defer c.lock.Unlock(id)
+
 	pack, err := c.watch.get(id)
 	if err != nil {
 		return nil, err
@@ -449,31 +454,6 @@ func (c *Client) UpdateResources(ctx context.Context, id string, resources types
 	}
 
 	return pack.task.Update(ctx, containerd.WithResources(r))
-}
-
-// GetPidsForContainer returns s list of process IDs running in a container.
-func (c *Client) GetPidsForContainer(ctx context.Context, id string) ([]int, error) {
-	if !c.lock.Trylock(id) {
-		return nil, errtypes.ErrLockfailed
-	}
-	defer c.lock.Unlock(id)
-
-	var pids []int
-
-	pack, err := c.watch.get(id)
-	if err != nil {
-		return nil, err
-	}
-
-	processes, err := pack.task.Pids(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, ps := range processes {
-		pids = append(pids, int(ps.Pid))
-	}
-	return pids, nil
 }
 
 // ResizeContainer changes the size of the TTY of the init process running

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1007,7 +1007,7 @@ func (mgr *ContainerManager) Top(ctx context.Context, name string, psArgs string
 		return nil, fmt.Errorf("container is not running, can not execute top command")
 	}
 
-	pids, err := mgr.Client.GetPidsForContainer(ctx, c.ID())
+	pids, err := mgr.Client.ContainerPIDs(ctx, c.ID())
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get pids of container")
 	}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
In ctrd/container.go we have two functions that are all to get pids in container, so we should delete one of them.

### Ⅱ. Does this pull request fix one issue?



### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


