### PR TITLE
bugfix: handle image format 'namespace/name:tag' correctly

### DIFF
--- a/pkg/reference/parse.go
+++ b/pkg/reference/parse.go
@@ -59,17 +59,18 @@ func WithDefaultTagIfMissing(named Named) Named {
 	return named
 }
 
-// Domain retrieves domain information. Domain include registry address or
-// repository namespace can be included, like registry.hub.docker.com/library.
-func Domain(named string) (string, bool) {
-	i := strings.LastIndexByte(named, '/')
+// Domain retrieves domain information. Domain include registry address and
+// repository namespace, like registry.hub.docker.com/library/ubuntu.
+func Domain(imageRef string) (string, bool) {
+	i := strings.LastIndexByte(imageRef, '/')
 
-	// FIXME: The domain should contain the . or :, how to handle the case
-	// which image name contains . or :?
-	if i == -1 || !strings.ContainsAny(named, ".:") {
+	// NOTE: in the following two conditions, imageRef doesn't contain domain:
+	// 1. No '/' in imageRef.
+	// 2. Apart from the name, the rest of imageRef should contain '.' or ':'.
+	if i == -1 || !strings.ContainsAny(imageRef[:i], ".:") {
 		return "", false
 	}
-	return named[:i], true
+	return imageRef[:i], true
 }
 
 // splitHostname splits HostName and RemoteName for the given reference.

--- a/pkg/reference/parse_test.go
+++ b/pkg/reference/parse_test.go
@@ -68,6 +68,11 @@ func TestDomain(t *testing.T) {
 			input:  "0.0.0.0/foo/bar",
 			domain: "0.0.0.0/foo",
 			ok:     true,
+		}, {
+			name:   "Namespace and Name",
+			input:  "google/cadvisor:latest",
+			domain: "",
+			ok:     false,
 		},
 	} {
 		d, ok := Domain(tc.input)

--- a/test/cli_pull_test.go
+++ b/test/cli_pull_test.go
@@ -56,6 +56,11 @@ func (suite *PouchPullSuite) TestPullWorks(c *check.C) {
 	// without registry
 	withoutRegistry := "busybox:latest"
 	checkPull(withoutRegistry, latest)
+
+	// image with namespace but without registry
+	cadvisor := "registry.hub.docker.com/google/cadvisor:latest"
+	cadvisorWithoutRegistry := "google/cadvisor:latest"
+	checkPull(cadvisorWithoutRegistry, cadvisor)
 }
 
 // TestPullInWrongWay pulls in wrong way.


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

With this PR, we could pull image like "google/cadvisor:latest" correctly.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


