### PR TITLE
feature: add daemon label for Pouch

### DIFF
--- a/apis/server/server.go
+++ b/apis/server/server.go
@@ -19,7 +19,7 @@ import (
 
 // Server is a http server which serves restful api to client.
 type Server struct {
-	Config          config.Config
+	Config          *config.Config
 	ContainerMgr    mgr.ContainerMgr
 	SystemMgr       mgr.SystemMgr
 	ImageMgr        mgr.ImageMgr

--- a/cli/info.go
+++ b/cli/info.go
@@ -89,7 +89,12 @@ func prettyPrintInfo(cli *Cli, info *types.SystemInfo) error {
 	fmt.Fprintln(os.Stdout, "Registry:", info.IndexServerAddress)
 	fmt.Fprintln(os.Stdout, "Experimental:", info.ExperimentalBuild)
 	fmt.Fprintln(os.Stdout, "Debug:", info.Debug)
-	fmt.Fprintln(os.Stdout, "Labels:", info.Labels)
+	if len(info.Labels) != 0 {
+		fmt.Fprintln(os.Stdout, "Labels:")
+		for _, label := range info.Labels {
+			fmt.Fprintf(os.Stdout, "  %s\n", label)
+		}
+	}
 
 	fmt.Fprintln(os.Stdout, "CPUs:", info.NCPU)
 	fmt.Fprintln(os.Stdout, "Total Memory:", info.MemTotal)

--- a/cri/service/cri.go
+++ b/cri/service/cri.go
@@ -14,13 +14,13 @@ import (
 
 // Service serves the kubelet runtime grpc api which will be consumed by kubelet.
 type Service struct {
-	config config.Config
+	config *config.Config
 	server *grpc.Server
 	criMgr mgr.CriMgr
 }
 
 // NewService creates a brand new cri service.
-func NewService(cfg config.Config, criMgr mgr.CriMgr) (*Service, error) {
+func NewService(cfg *config.Config, criMgr mgr.CriMgr) (*Service, error) {
 	s := &Service{
 		config: cfg,
 		server: grpc.NewServer(),

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -1,9 +1,13 @@
 package config
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/alibaba/pouch/client"
 	"github.com/alibaba/pouch/cri"
 	"github.com/alibaba/pouch/network"
+	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/volume"
 )
 
@@ -72,4 +76,28 @@ type Config struct {
 
 	// PluginPath is set the path where plugin so file put
 	PluginPath string `json:"plugin"`
+
+	// Labels is the metadata of daemon
+	Labels []string `json:"labels,omitempty"`
+}
+
+// Validate validates the user input config.
+func (cfg *Config) Validate() error {
+	// deduplicated elements in slice if there is any.
+	cfg.Listen = utils.DeDuplicate(cfg.Listen)
+	cfg.Labels = utils.DeDuplicate(cfg.Labels)
+
+	for _, label := range cfg.Labels {
+		data := strings.SplitN(label, "=", 2)
+		if len(data) != 2 {
+			return fmt.Errorf("daemon label %s must be in format of key=value", label)
+		}
+		if len(data[0]) == 0 || len(data[1]) == 0 {
+			return fmt.Errorf("key and value in daemon label %s cannot be empty", label)
+		}
+	}
+
+	// TODO: add config validation
+
+	return nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -24,7 +24,7 @@ import (
 
 // Daemon refers to a daemon.
 type Daemon struct {
-	config          config.Config
+	config          *config.Config
 	containerStore  *meta.Store
 	containerd      ctrd.APIClient
 	containerMgr    mgr.ContainerMgr
@@ -46,7 +46,7 @@ type router struct {
 }
 
 // NewDaemon constructs a brand new server.
-func NewDaemon(cfg config.Config) *Daemon {
+func NewDaemon(cfg *config.Config) *Daemon {
 	containerStore, err := meta.NewStore(meta.Config{
 		Driver:  "local",
 		BaseDir: path.Join(cfg.HomeDir, "containers"),
@@ -129,25 +129,25 @@ func (d *Daemon) Run() error {
 		}
 	}
 
-	imageMgr, err := internal.GenImageMgr(&d.config, d)
+	imageMgr, err := internal.GenImageMgr(d.config, d)
 	if err != nil {
 		return err
 	}
 	d.imageMgr = imageMgr
 
-	systemMgr, err := internal.GenSystemMgr(&d.config, d)
+	systemMgr, err := internal.GenSystemMgr(d.config, d)
 	if err != nil {
 		return err
 	}
 	d.systemMgr = systemMgr
 
-	volumeMgr, err := internal.GenVolumeMgr(&d.config, d)
+	volumeMgr, err := internal.GenVolumeMgr(d.config, d)
 	if err != nil {
 		return err
 	}
 	d.volumeMgr = volumeMgr
 
-	networkMgr, err := internal.GenNetworkMgr(&d.config, d)
+	networkMgr, err := internal.GenNetworkMgr(d.config, d)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func (d *Daemon) Shutdown() error {
 
 // Config gets config of daemon.
 func (d *Daemon) Config() *config.Config {
-	return &d.config
+	return d.config
 }
 
 // CtrMgr gets manager of container.

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -68,7 +68,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		return nil
 	})
 
-	inf := types.SystemInfo{
+	info := types.SystemInfo{
 		// architecture: ,
 		// CgroupDriver: ,
 		// ContainerdCommit: ,
@@ -87,7 +87,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		// Images: ,
 		IndexServerAddress: "https://index.docker.io/v1/",
 		KernelVersion:      kernelVersion,
-		// Labels: ,
+		Labels:             mgr.config.Labels,
 		// LiveRestoreEnabled: ,
 		// LoggingDriver: ,
 		// MemTotal: ,
@@ -103,7 +103,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		ServerVersion:   version.Version,
 		ListenAddresses: mgr.config.Listen,
 	}
-	return inf, nil
+	return info, nil
 }
 
 // Version shows version of daemon.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -196,3 +196,19 @@ func isEmptyValue(v reflect.Value) bool {
 	}
 	return false
 }
+
+// DeDuplicate make a slice with no duplicated elements.
+func DeDuplicate(input []string) []string {
+	if input == nil {
+		return nil
+	}
+	result := []string{}
+	internal := map[string]struct{}{}
+	for _, value := range input {
+		if _, exist := internal[value]; !exist {
+			internal[value] = struct{}{}
+			result = append(result, value)
+		}
+	}
+	return result
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -195,5 +196,59 @@ func TestMerge(t *testing.T) {
 			}
 			assert.EqualError(err, errMsg)
 		}
+	}
+}
+
+func TestDeDuplicate(t *testing.T) {
+	type args struct {
+		input []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "nil test case",
+			args: args{
+				input: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "two duplicated case",
+			args: args{
+				input: []string{"asdfgh", "asdfgh"},
+			},
+			want: []string{"asdfgh"},
+		},
+		{
+			name: "case with no duplicated",
+			args: args{
+				input: []string{"asdfgh01", "asdfgh02", "asdfgh03", "asdfgh04"},
+			},
+			want: []string{"asdfgh01", "asdfgh02", "asdfgh03", "asdfgh04"},
+		},
+		{
+			name: "case with no duplicated",
+			args: args{
+				input: []string{"asdfgh01", "asdfgh02", "asdfgh01"},
+			},
+			want: []string{"asdfgh01", "asdfgh02"},
+		},
+		{
+			name: "case with 3 duplicated",
+			args: args{
+				input: []string{"asdfgh01", "asdfgh01", "asdfgh01"},
+			},
+			want: []string{"asdfgh01"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DeDuplicate(tt.args.input); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeDuplicate() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/test/cli_upgrade_test.go
+++ b/test/cli_upgrade_test.go
@@ -82,7 +82,7 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeStoppedContainer(c *check.C) {
 	c.Assert(res.Error, check.IsNil)
 
 	if out := res.Combined(); !strings.Contains(out, name) {
-		c.Fatal("unexpected output: %s, expected %s", out, name)
+		c.Fatalf("unexpected output: %s, expected %s", out, name)
 	}
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This PR adds labels for pouch daemon. This makes user can input labels like `pouchd --label a=b --label c=d`,

After that we could use pouch info to get the labels info:
```
Registry: https://index.docker.io/v1/
Experimental: false
Debug: false
Labels: 
    a=b
    c=d
CPUs: 0
Total Memory: 0
Pouch Root Dir: /var/lib/pouch
LiveRestoreEnabled: false
```

I also make the config passing as a pointer rather than copied struct instance.


### Ⅱ. Does this pull request fix one issue?
none


### Ⅲ. Describe how you did it
none

### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

This PR also needs adding daemon integation test.

