### PR TITLE
fix: url mistake and test incorrectness

### DIFF
--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -39,7 +39,7 @@ func initRoute(s *Server) http.Handler {
 	r.Path(versionMatcher + "/containers/{name:.*}/exec").Methods(http.MethodPost).Handler(s.filter(s.createContainerExec))
 	r.Path(versionMatcher + "/exec/{name:.*}/start").Methods(http.MethodPost).Handler(s.filter(s.startContainerExec))
 	r.Path(versionMatcher + "/containers/{id:.*}/rename").Methods(http.MethodPost).Handler(s.filter(s.renameContainer))
-	r.Path(versionMatcher + "/containers/{id:.*}/restart").Methods(http.MethodPost).Handler(s.filter(s.restartContainer))
+	r.Path(versionMatcher + "/containers/{name:.*}/restart").Methods(http.MethodPost).Handler(s.filter(s.restartContainer))
 	r.Path(versionMatcher + "/containers/{name:.*}/pause").Methods(http.MethodPost).Handler(s.filter(s.pauseContainer))
 	r.Path(versionMatcher + "/containers/{name:.*}/unpause").Methods(http.MethodPost).Handler(s.filter(s.unpauseContainer))
 	r.Path(versionMatcher + "/containers/{name:.*}/update").Methods(http.MethodPost).Handler(s.filter(s.updateContainer))

--- a/test/api_container_restart_test.go
+++ b/test/api_container_restart_test.go
@@ -44,7 +44,7 @@ func (suite *APIContainerRestartSuite) TestAPIContainerRestart(c *check.C) {
 
 // TestAPIRestartStoppedContainer it to verify restarting a stopped container.
 func (suite *APIContainerRestartSuite) TestAPIRestartStoppedContainer(c *check.C) {
-	cname := "TestAPIContainerRestart"
+	cname := "TestAPIRestartStoppedContainer"
 
 	CreateBusyboxContainerOk(c, cname)
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In the original test file test/api_restart_test.go, we have created containers with the same name, so I change one into another one.

In addition, I change the filename from `test/api_restart_test.go` to `test/api_container_restart_test.go`.

What is more, there is bug in router.go which is `r.Path(versionMatcher + "/containers/{id:.*}/restart").Methods(http.MethodPost).Handler(s.filter(s.restartContainer))`. In this line of code, we would make http server to get the container via `id` in the url path. While in code https://github.com/alibaba/pouch/blob/master/apis/server/container_bridge.go#L65, it is finding name using `name := mux.Vars(req)["name"]`. As a result, incompatibility happens. The gotten name will already be empty string and would trigger code `errors.Wrap(errtypes.ErrTooMany, "container: "+nameOrPrefix)` which is in https://github.com/alibaba/pouch/blob/master/daemon/mgr/container_utils.go#L33.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #991 

### Ⅲ. Describe how you did it
none


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews
cc @HusterWan @Letty5411 

