### PR TITLE
fix: make container ID json name compatible

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2230,7 +2230,8 @@ definitions:
       GET "/containers/json"
     type: "object"
     properties:
-      ID:
+      Id:
+        description: "Container ID"
         type: "string"
       Names:
         type: "array"

--- a/apis/types/container.go
+++ b/apis/types/container.go
@@ -34,8 +34,8 @@ type Container struct {
 	//
 	HostConfig *HostConfig `json:"HostConfig,omitempty"`
 
-	// ID
-	ID string `json:"ID,omitempty"`
+	// Container ID
+	ID string `json:"Id,omitempty"`
 
 	// image
 	Image string `json:"Image,omitempty"`
@@ -74,7 +74,7 @@ type Container struct {
 
 /* polymorph Container HostConfig false */
 
-/* polymorph Container ID false */
+/* polymorph Container Id false */
 
 /* polymorph Container Image false */
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This PR has fixed an incompatible issue in the pouch's API.

When communicating between Pouch client and daemon, we use json type to transfer data. While to be more compatible with moby's API, we need to make the transfer all the same. 

This fix some incompatibility.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
this is related to https://github.com/alibaba/pouch/issues/977


### Ⅲ. Describe how you did it
none


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews
none

