### PR TITLE
bugfix: container name not equals input params

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -231,3 +231,43 @@ func CombineErrors(errs []error, formatErrMsg FormatErrMsgFunc) error {
 	combinedErrMsg := strings.Join(errMsgs, "\n")
 	return errors.New(combinedErrMsg)
 }
+
+// Contains check if a interface in a interface slice.
+func Contains(input []interface{}, value interface{}) (bool, error) {
+	if value == nil || len(input) == 0 {
+		return false, nil
+	}
+
+	if reflect.TypeOf(input[0]) != reflect.TypeOf(value) {
+		return false, fmt.Errorf("interface type not equals")
+	}
+
+	switch v := value.(type) {
+	case int, int64, float64, string:
+		for _, v := range input {
+			if v == value {
+				return true, nil
+			}
+		}
+		return false, nil
+	// TODO: add more types
+	default:
+		r := reflect.TypeOf(v)
+		return false, fmt.Errorf("Not support: %s", r)
+	}
+}
+
+// StringInSlice checks if a string in the slice.
+func StringInSlice(input []string, str string) bool {
+	if str == "" || len(input) == 0 {
+		return false
+	}
+
+	result := make([]interface{}, len(input))
+	for i, v := range input {
+		result[i] = v
+	}
+
+	exists, _ := Contains(result, str)
+	return exists
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -277,5 +277,61 @@ func TestCombineErrors(t *testing.T) {
 	if combinedErr.Error() != expectedErrMsg {
 		t.Errorf("get error: expected: %s, but was: %s", expectedErrMsg, combinedErr)
 	}
+}
 
+func TestContains(t *testing.T) {
+	type args struct {
+		input []interface{}
+		value interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{name: "test1", args: args{input: []interface{}{1, 2}, value: "1"}, want: false, wantErr: true},
+		{name: "test2", args: args{input: []interface{}{"1", "2"}, value: "1"}, want: true, wantErr: false},
+		{name: "test3", args: args{input: []interface{}{"1", "2"}, value: "3"}, want: false, wantErr: false},
+		{name: "test4", args: args{input: []interface{}{1, 2}, value: 1}, want: true, wantErr: false},
+		{name: "test5", args: args{input: []interface{}{1, 2}, value: 3}, want: false, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Contains(tt.args.input, tt.args.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Contains() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringInSlice(t *testing.T) {
+	type args struct {
+		str   string
+		input []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{name: "TestInSlice", args: args{input: []string{"foo", "bar"}, str: "foo"}, want: true},
+		{name: "TestNotInSlice", args: args{input: []string{"goods", "bar"}, str: "foo"}, want: false},
+		{name: "TestEmptyStr", args: args{input: []string{"foo", "bar"}, str: ""}, want: false},
+		{name: "TestEmptySlice", args: args{input: []string{}, str: "bar"}, want: false},
+		{name: "TestAllEmpty", args: args{input: []string{}, str: ""}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StringInSlice(tt.args.input, tt.args.str); got != tt.want {
+				t.Errorf("StringInSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
if one image has multi tags, we will choose a tag name random(`list[0]`), that may not equals to input image name

### Ⅱ. Does this pull request fix one issue?
fixes https://github.com/alibaba/pouch/issues/1001

### Ⅲ. Describe how you did it
there are some tricks:
pre-condition: if a image has multi tags:
```
root@osboxes:test (zr/revert-#997 *) -> pouch image inspect 50dcd054e8fe
{
    "Architecture": "amd64",
    "Config": {
        "Cmd": [
            "sh"
        ],
        "Entrypoint": null,
        "Env": [
            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
        ],
        "Image": "",
        "OnBuild": null,
        "Shell": null
    },
    "CreatedAt": "2018-02-28T22:14:49.023807051Z",
    "ID": "sha256:50dcd054e8fe6d4c2e7d34458ff09aa9f15a4bc747a8d6b741174c21340bd4db",
    "Os": "linux",
    "RepoDigests": [
        "registry.hub.docker.com/library/busybox@sha256:2107a35b58593c58ec5f4e8f2c4a70d195321078aebfadfbfb223a2ff4a4ed21"
    ],
    "RepoTags": [
        "registry.hub.docker.com/library/busybox:1.28",
        "registry.hub.docker.com/library/busybox:latest"
    ],
    "RootFS": {
        "Layers": [
            "sha256:c5183829c43c4698634093dc38f9bee26d1b931dedeba71dbee984f42fe1270d"
        ],
        "Type": "layers"
    },
    "Size": 727836
}
```
if user specify a entire image name when create a container, we will store the image name.
```
root@osboxes:test (zr/revert-#997 *) -> pouch run -d registry.hub.docker.com/library/busybox:latest
4bab2bf10eba01f2fe4433bc0771854cdef831e37bf93306254a873bad44cb01
root@osboxes:test (zr/revert-#997 *) -> pouch ps
Name     ID       Status          Created          Image                                            Runtime
4bab2b   4bab2b   Up 14 seconds   14 seconds ago   registry.hub.docker.com/library/busybox:latest   runc
```
but if user just input a image repo name and the image has multi tags, we will random choose one tag to store:
```
root@osboxes:test (zr/revert-#997 *) -> pouch run -d registry.hub.docker.com/library/busybox
65e9f39fa9997c02a6488e3f245f5cbe87cf39afc4f7122edf2f7ec1aabe0626
root@osboxes:test (zr/revert-#997 *) -> pouch ps
Name     ID       Status          Created          Image                                            Runtime
65e9f3   65e9f3   Up 5 minutes    5 minutes ago    registry.hub.docker.com/library/busybox:1.28     runc
```

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


