### PR TITLE
bugfix: specify both cmd and its args when create a container

### DIFF
--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -424,8 +424,7 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 	createConfig := &apitypes.ContainerCreateConfig{
 		ContainerConfig: apitypes.ContainerConfig{
-			// TODO: maybe we should ditinguish cmd and entrypoint more clearly.
-			Cmd:        config.Command,
+			Cmd:        append(config.Command, config.Args...),
 			Env:        generateEnvList(config.GetEnvs()),
 			Image:      image,
 			WorkingDir: config.WorkingDir,


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Actually I forget to specify the args of the cmd executed in the container, so fill it in this PR.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


