### PR TITLE
feature: add options when using volume list

### DIFF
--- a/daemon/mgr/volume.go
+++ b/daemon/mgr/volume.go
@@ -21,7 +21,7 @@ type VolumeMgr interface {
 	Remove(ctx context.Context, name string) error
 
 	// List returns all volumes on this host.
-	List(ctx context.Context, labels map[string]string) ([]string, error)
+	List(ctx context.Context, labels map[string]string) ([]*types.Volume, error)
 
 	// Get returns the information of volume that specified name/id.
 	Get(ctx context.Context, name string) (*types.Volume, error)
@@ -100,7 +100,7 @@ func (vm *VolumeManager) Remove(ctx context.Context, name string) error {
 }
 
 // List returns all volumes on this host.
-func (vm *VolumeManager) List(ctx context.Context, labels map[string]string) ([]string, error) {
+func (vm *VolumeManager) List(ctx context.Context, labels map[string]string) ([]*types.Volume, error) {
 	if _, ok := labels["hostname"]; !ok {
 		hostname, err := os.Hostname()
 		if err != nil {
@@ -110,7 +110,7 @@ func (vm *VolumeManager) List(ctx context.Context, labels map[string]string) ([]
 		labels["hostname"] = hostname
 	}
 
-	return vm.core.ListVolumeName(labels)
+	return vm.core.ListVolumes(labels)
 }
 
 // Get returns the information of volume that specified name/id.

--- a/test/cli_volume_test.go
+++ b/test/cli_volume_test.go
@@ -238,3 +238,75 @@ func (suite *PouchVolumeSuite) TestVolumeBindReplaceMode(c *check.C) {
 	}
 	c.Assert(found, check.Equals, true)
 }
+
+// TestVolumeList tests the volume list.
+func (suite *PouchVolumeSuite) TestVolumeList(c *check.C) {
+	pc, _, _, _ := runtime.Caller(0)
+	tmpname := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+	var funcname string
+	for i := range tmpname {
+		funcname = tmpname[i]
+	}
+
+	volumeName := "volume_" + funcname
+	volumeName1 := "volume_" + funcname + "_1"
+	command.PouchRun("volume", "create", "--name", volumeName1, "-o", "size=1g").Assert(c, icmd.Success)
+	defer command.PouchRun("volume", "rm", volumeName1)
+
+	volumeName2 := "volume_" + funcname + "_2"
+	command.PouchRun("volume", "create", "--name", volumeName2, "-o", "size=2g").Assert(c, icmd.Success)
+	defer command.PouchRun("volume", "rm", volumeName2)
+
+	volumeName3 := "volume_" + funcname + "_3"
+	command.PouchRun("volume", "create", "--name", volumeName3, "-o", "size=3g").Assert(c, icmd.Success)
+	defer command.PouchRun("volume", "rm", volumeName3)
+
+	ret := command.PouchRun("volume", "list")
+	ret.Assert(c, icmd.Success)
+
+	for _, line := range strings.Split(ret.Stdout(), "\n") {
+		if strings.Contains(line, volumeName) {
+			if !strings.Contains(line, "local") {
+				c.Errorf("list result have no driver or name or size or mountpoint, line: %s", line)
+				break
+			}
+		}
+	}
+}
+
+// TestVolumeList tests the volume list with options: size and mountpoint.
+func (suite *PouchVolumeSuite) TestVolumeListOptions(c *check.C) {
+	pc, _, _, _ := runtime.Caller(0)
+	tmpname := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+	var funcname string
+	for i := range tmpname {
+		funcname = tmpname[i]
+	}
+
+	volumeName := "volume_" + funcname
+	volumeName1 := "volume_" + funcname + "_1"
+	command.PouchRun("volume", "create", "--name", volumeName1, "-o", "size=1g").Assert(c, icmd.Success)
+	defer command.PouchRun("volume", "rm", volumeName1)
+
+	volumeName2 := "volume_" + funcname + "_2"
+	command.PouchRun("volume", "create", "--name", volumeName2, "-o", "size=2g").Assert(c, icmd.Success)
+	defer command.PouchRun("volume", "rm", volumeName2)
+
+	volumeName3 := "volume_" + funcname + "_3"
+	command.PouchRun("volume", "create", "--name", volumeName3, "-o", "size=3g").Assert(c, icmd.Success)
+	defer command.PouchRun("volume", "rm", volumeName3)
+
+	ret := command.PouchRun("volume", "list", "--size", "--mountpoint")
+	ret.Assert(c, icmd.Success)
+
+	for _, line := range strings.Split(ret.Stdout(), "\n") {
+		if strings.Contains(line, volumeName) {
+			if !strings.Contains(line, "local") ||
+				!strings.Contains(line, "g") ||
+				!strings.Contains(line, "/mnt/local") {
+				c.Errorf("list result have no driver or name or size or mountpoint, line: %s", line)
+				break
+			}
+		}
+	}
+}

--- a/volume/core_util.go
+++ b/volume/core_util.go
@@ -74,6 +74,24 @@ func (c *Core) volumeURL(id ...types.VolumeID) (string, error) {
 	return client.JoinURL(c.BaseURL, types.APIVersion, client.VolumePath, id[0].Name)
 }
 
+func (c *Core) listVolumeURL(labels map[string]string) (string, error) {
+	if c.BaseURL == "" {
+		return "", volerr.ErrDisableControl
+	}
+	url, err := client.JoinURL(c.BaseURL, types.APIVersion, client.VolumePath)
+	if err != nil {
+		return "", err
+	}
+
+	querys := make([]string, 0, len(labels))
+	for k, v := range labels {
+		querys = append(querys, fmt.Sprintf("labels=%s=%s", k, v))
+	}
+
+	url = url + "?" + strings.Join(querys, "&")
+	return url, nil
+}
+
 func (c *Core) listVolumeNameURL(labels map[string]string) (string, error) {
 	if c.BaseURL == "" {
 		return "", volerr.ErrDisableControl

--- a/volume/types/volume.go
+++ b/volume/types/volume.go
@@ -191,6 +191,15 @@ func (v *Volume) Key() string {
 	return v.Name
 }
 
+//CreateTime returns the volume's create time.
+func (v *Volume) CreateTime() string {
+	if v.CreationTimestamp == nil {
+		return ""
+	}
+
+	return v.CreationTimestamp.Format("2006-1-2 15:04:05")
+}
+
 // VolumeID use to define the volume's identity.
 type VolumeID struct {
 	Name      string


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add options when using volume list, add volume driver into default
volume list information. Add list volumes function in volume core module.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #921

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
listing volume format is "DRIVER VOLUME NAME", you can add some options, such as size and mountpoint, list volume with options like this:
```
# pouch volume list --size --mountpoint
DRIVER   VOLUME NAME     SIZE     MOUNT POINT
local    volume1                      ulimit   /mnt/local/volume1
local    test                             1g       /data/volume/test
local    volume-test               10g      /data/volume/volume-test
```

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
