### PR TITLE
bugfix: change container create output

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -68,12 +68,12 @@ func (cc *CreateCommand) runCreate(args []string) error {
 	if len(result.Warnings) != 0 {
 		fmt.Printf("WARNING: %s \n", strings.Join(result.Warnings, "\n"))
 	}
-	fmt.Printf("container ID: %s, name: %s \n", result.ID, result.Name)
+	fmt.Printf(result.ID)
 	return nil
 }
 
 // createExample shows examples in create command, and is used in auto-generated cli docs.
 func createExample() string {
 	return `$ pouch create --name foo busybox:latest
-container ID: e1d541722d68dc5d133cca9e7bd8fd9338603e1763096c8e853522b60d11f7b9, name: foo`
+e1d541722d68dc5d133cca9e7bd8fd9338603e1763096c8e853522b60d11f7b9`
 }

--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
+	"github.com/stretchr/testify/assert"
 )
 
 // PouchCreateSuite is the test suite for create CLI.
@@ -39,9 +40,6 @@ func (suite *PouchCreateSuite) TestCreateName(c *check.C) {
 	res := command.PouchRun("create", "--name", name, busyboxImage)
 
 	res.Assert(c, icmd.Success)
-	if out := res.Combined(); !strings.Contains(out, name) {
-		c.Fatalf("unexpected output %s expected %s\n", out, name)
-	}
 
 	defer DelContainerForceMultyTime(c, name)
 }
@@ -57,9 +55,7 @@ func (suite *PouchCreateSuite) TestCreateNameByImageID(c *check.C) {
 	res = command.PouchRun("create", "--name", name, imageID)
 
 	res.Assert(c, icmd.Success)
-	if out := res.Combined(); !strings.Contains(out, name) {
-		c.Fatalf("unexpected output %s expected %s\n", out, name)
-	}
+	assert.Equal(c, len(res.Combined()), 64)
 
 	DelContainerForceMultyTime(c, name)
 }


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
change the output of container create
old way:
```
#pouch create --cpuset-cpus=0-1 --memory=4m --memory-swap 4m busybox top
container ID: c7f1fc453f6efbbd400e7d587d1277cc00a52efc893ee9c15cd2759cf71e049d, name: c7f1fc
now:
#pouch create --cpuset-cpus=0-1 --memory=4m --memory-swap 4m busybox top
c7f1fc453f6efbbd400e7d587d1277cc00a52efc893ee9c15cd2759cf71e049d
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


