### PR TITLE
bugfix: restful api url should support both with or without version info

### DIFF
--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -74,6 +74,7 @@ func initRoute(s *Server) http.Handler {
 
 	// metrics
 	r.Path(versionMatcher + "/metrics").Methods(http.MethodGet).Handler(prometheus.Handler())
+	r.Path("/metrics").Methods(http.MethodGet).Handler(prometheus.Handler())
 
 	if s.Config.Debug {
 		profilerSetup(r)
@@ -83,6 +84,7 @@ func initRoute(s *Server) http.Handler {
 
 func addRoute(r *mux.Router, mothod string, path string, f func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error) {
 	r.Path(versionMatcher + path).Methods(mothod).Handler(filter(f))
+	r.Path(path).Methods(mothod).Handler(filter(f))
 }
 
 func profilerSetup(mainRouter *mux.Router) {

--- a/test/api_version_parameter_test.go
+++ b/test/api_version_parameter_test.go
@@ -25,6 +25,7 @@ func (suite *APIVersionSuite) SetUpTest(c *check.C) {
 }
 
 // TestNoVersionParamsInURL test api url not contains version info.
+// Pouch api url support with or without version info.
 func (suite *APIVersionSuite) TestNoVersionParamsInURL(c *check.C) {
 	cname := "TestCreateURLNoVersionInfo"
 
@@ -55,5 +56,5 @@ func (suite *APIVersionSuite) TestNoVersionParamsInURL(c *check.C) {
 	resp, err := apiClient.HTTPCli.Do(req)
 	c.Assert(err, check.IsNil)
 
-	CheckRespStatus(c, resp, 404)
+	CheckRespStatus(c, resp, 201)
 }


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
i check the moby api, it also support with or without version info in restful api url

Now we support both without version info in restful api url:
```
wanziren@osboxes:pouch (zr/fix-api-version) -> sudo curl /var/run/pouchd.sock http://0.0.0.0:8080/info
curl: (3) <url> malformed
{"Containers":200,"ContainersRunning":200,"Debug":true,"DefaultRegistry":"registry.hub.docker.com","DefaultRuntime":"runc","DriverStatus":null,"IndexServerAddress":"https://index.docker.io/v1/","KernelVersion":"3.10.0-693.17.1.el7.x86_64","Labels":[],"ListenAddresses":["tcp://0.0.0.0:8080","unix:///var/run/pouchd.sock"],"OSType":"linux","PouchRootDir":"/var/lib/pouch","SecurityOptions":null,"ServerVersion":"0.4.0-dev"}
```

and with version info in restful api url:
```
wanziren@osboxes:pouch (zr/fix-api-version) -> sudo curl /var/run/pouchd.sock http://0.0.0.0:8080/v1.24/info
curl: (3) <url> malformed
{"Containers":200,"ContainersRunning":200,"Debug":true,"DefaultRegistry":"registry.hub.docker.com","DefaultRuntime":"runc","DriverStatus":null,"IndexServerAddress":"https://index.docker.io/v1/","KernelVersion":"3.10.0-693.17.1.el7.x86_64","Labels":[],"ListenAddresses":["tcp://0.0.0.0:8080","unix:///var/run/pouchd.sock"],"OSType":"linux","PouchRootDir":"/var/lib/pouch","SecurityOptions":null,"ServerVersion":"0.4.0-dev"}
```


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


