### PR TITLE
feature: inspect network by ID

### DIFF
--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -33,13 +33,24 @@ func (suite *PouchNetworkSuite) SetUpSuite(c *check.C) {
 // TestNetworkInspectFormat tests the inspect format of network works.
 func (suite *PouchNetworkSuite) TestNetworkInspectFormat(c *check.C) {
 	output := command.PouchRun("network", "inspect", "bridge").Stdout()
-	result := &types.ContainerJSON{}
+	result := &types.NetworkInspectResp{}
 	if err := json.Unmarshal([]byte(output), result); err != nil {
 		c.Errorf("failed to decode inspect output: %v", err)
 	}
 
 	// inspect network name
 	output = command.PouchRun("network", "inspect", "-f", "{{.Name}}", "bridge").Stdout()
+	c.Assert(output, check.Equals, "bridge\n")
+
+	output = command.PouchRun("network", "inspect", "bridge").Stdout()
+	network := &types.NetworkInspectResp{}
+	if err := json.Unmarshal([]byte(output), network); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	networkID := network.ID
+
+	// inspect network name by ID
+	output = command.PouchRun("network", "inspect", "-f", "{{.Name}}", networkID).Stdout()
 	c.Assert(output, check.Equals, "bridge\n")
 }
 


### PR DESCRIPTION
Signed-off-by: 程飞 <fay.cheng.cn@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add network inspection with network ID

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it

```
> pouch network inspect ab65cbdb889a6b02
{
    "Driver": "bridge",
    "ID": "ab65cbdb889a6b0218aa075a0d56b6bd1d81ffd5dcc179ba9489f749c829ffa3",
    "IPAM": {
        "Config": [
            {
                "Gateway": "172.19.0.1",
                "Subnet": "172.19.0.0/16"
            }
        ],
        "Driver": "default"
    },
    "Name": "bridge-0"
}
```

### Ⅴ. Special notes for reviews


