### PR TITLE
feature: add circleci parrallism testing to split unit-test and code-check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
-  build:
+  markdown-lint-docs:
     docker:
       # specify the version
       - image: allencloud/mdl:v0.4
@@ -24,18 +24,41 @@ jobs:
       # specify any bash command here prefixed with `run: `
       - run:
           name: use markdownlint v0.4.0 to lint markdown file (https://github.com/markdownlint/markdownlint)
-          command: find  ./ -name  "*.md" | grep -v vendor | grep -v extra | grep -v commandline | grep -v .github | grep -v swagger | grep -v api | xargs mdl -r ~MD013,~MD024,~MD029,~MD033,~MD036
-      - run:
-          name: run unit test with coverage
           command: |
-              cd /tmp/pouchbuild/src/github.com/alibaba/pouch
-              go test -i
-              for d in `go list ./... | grep -v 'github.com/alibaba/pouch/test' | grep -v 'github.com/alibaba/pouch/extra' | grep -v 'github.com/alibaba/pouch/vendor' `
-              do
-                  go test -coverprofile=profile.out -covermode=atomic $d
-                  if [ -f profile.out ] ; then
-                      cat profile.out >> coverage.txt
-                      rm profile.out >/dev/null 2>&1
-                  fi
-              done
+            find  ./ -name  "*.md" | grep -v vendor | grep -v extra |  grep -v commandline |  grep -v .github |  grep -v swagger |  grep -v api |  xargs mdl -r ~MD013,~MD024,~MD029,~MD033,~MD036
 
+  code-check:
+    docker: 
+      - image: golang:1.9.1
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    steps:
+      - checkout
+      - run: 
+          name: install golint
+          command: go get github.com/golang/lint/golint
+      - run: 
+          name: install swagger-0.12.0
+          command: |
+            wget --quiet -O /bin/swagger https://github.com/go-swagger/go-swagger/releases/download/0.12.0/swagger_linux_amd64
+            chmod +x /bin/swagger
+      - run: 
+          name: use check target in Makefile to check code
+          command: make check
+  
+  unit-test:
+    docker:
+      - image: golang:1.9.1
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    steps:
+      - checkout
+      - run:
+          name: unit test
+          command: make unit-test
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - markdown-lint-docs
+      - code-check
+      - unit-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,3 +25,17 @@ jobs:
       - run:
           name: use markdownlint v0.4.0 to lint markdown file (https://github.com/markdownlint/markdownlint)
           command: find  ./ -name  "*.md" | grep -v vendor | grep -v extra | grep -v commandline | grep -v .github | grep -v swagger | grep -v api | xargs mdl -r ~MD013,~MD024,~MD029,~MD033,~MD036
+      - run:
+          name: run unit test with coverage
+          command: |
+              cd /tmp/pouchbuild/src/github.com/alibaba/pouch
+              go test -i
+              for d in `go list ./... | grep -v 'github.com/alibaba/pouch/test' | grep -v 'github.com/alibaba/pouch/extra' | grep -v 'github.com/alibaba/pouch/vendor' `
+              do
+                  go test -coverprofile=profile.out -covermode=atomic $d
+                  if [ -f profile.out ] ; then
+                      cat profile.out >> coverage.txt
+                      rm profile.out >/dev/null 2>&1
+                  fi
+              done
+

--- a/Makefile
+++ b/Makefile
@@ -95,12 +95,12 @@ uninstall:
 # Ref https://unix.stackexchange.com/questions/83191/how-to-make-sudo-preserve-path
 .PHONY: integration-test
 integration-test:
-	@bash -c "env PATH=$(PATH) hack/make.sh check build integration-test"
+	@bash -c "env PATH=$(PATH) hack/make.sh pre build integration-test"
 
 .PHONY: cri-test
 cri-test:
-	@bash -c "env PATH=$(PATH) hack/make.sh check build cri-test"
+	@bash -c "env PATH=$(PATH) hack/make.sh pre build cri-test"
 
 .PHONY: test
 test:
-	@bash -c "env PATH=$(PATH) hack/make.sh check build unit-test integration-test cri-test"
+	@bash -c "env PATH=$(PATH) hack/make.sh build integration-test cri-test"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This pr move unit-test and check-code to circleCI, while others( integration test and cri test) still use travisCI.

This PR is based on @ZouRui89 's pr https://github.com/alibaba/pouch/pull/1039.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1008 


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


