### PR TITLE
bugfix: distinguish cmd and entrypoint better

### DIFF
--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -171,11 +171,13 @@ func (meta *ContainerMeta) merge(getconfig func() (v1.ImageConfig, error)) error
 		return err
 	}
 
+	// If user specify the Entrypoint, no need to merge image's configuration.
+	// Otherwise use the image's configuration to fill it.
 	if len(meta.Config.Entrypoint) == 0 {
+		if len(meta.Config.Cmd) == 0 {
+			meta.Config.Cmd = config.Cmd
+		}
 		meta.Config.Entrypoint = config.Entrypoint
-	}
-	if len(meta.Config.Cmd) == 0 {
-		meta.Config.Cmd = config.Cmd
 	}
 	if meta.Config.Env == nil {
 		meta.Config.Env = config.Env

--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -424,7 +424,8 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 	createConfig := &apitypes.ContainerCreateConfig{
 		ContainerConfig: apitypes.ContainerConfig{
-			Cmd:        append(config.Command, config.Args...),
+			Entrypoint: config.Command,
+			Cmd:        config.Args,
 			Env:        generateEnvList(config.GetEnvs()),
 			Image:      image,
 			WorkingDir: config.WorkingDir,


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it

In order to be consistent with Docker:

1. User has specified container's entrypoint, don't use the cmd of image's configuration to fill it , even if it is empty.

2. User has not specified container's entrypoing, use the entrypoint of image's configuration to fill it, as well as cmd.  

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


