### PR TITLE
bugfix: remove duplicate error msgs

### DIFF
--- a/daemon/mgr/network.go
+++ b/daemon/mgr/network.go
@@ -200,7 +200,6 @@ func (nm *NetworkManager) EndpointCreate(ctx context.Context, endpoint *types.En
 	endpointName := containerID[:8]
 	ep, err := n.CreateEndpoint(endpointName, epOptions...)
 	if err != nil {
-		logrus.Errorf("failed to create endpoint, err: %v", err)
 		return "", err
 	}
 
@@ -209,14 +208,12 @@ func (nm *NetworkManager) EndpointCreate(ctx context.Context, endpoint *types.En
 	if sb == nil {
 		sandboxOptions, err := nm.sandboxOptions(endpoint)
 		if err != nil {
-			logrus.Errorf("failed to build sandbox options, err: %v", err)
-			return "", err
+			return "", fmt.Errorf("failed to build sandbox options: %v", err)
 		}
 
 		sb, err = nm.controller.NewSandbox(containerID, sandboxOptions...)
 		if err != nil {
-			logrus.Errorf("failed to create sandbox, err: %v", err)
-			return "", err
+			return "", fmt.Errorf("failed to create sandbox: %v", err)
 		}
 	}
 	networkConfig.SandboxID = sb.ID()
@@ -228,8 +225,7 @@ func (nm *NetworkManager) EndpointCreate(ctx context.Context, endpoint *types.En
 		return "", err
 	}
 	if err := ep.Join(sb, joinOptions...); err != nil {
-		logrus.Errorf("failed to join sandbox, err: %v", err)
-		return "", err
+		return "", fmt.Errorf("failed to join sandbox: %v", err)
 	}
 
 	// update endpoint settings


### PR DESCRIPTION
Signed-off-by: 程飞 <fay.cheng.cn@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

pouch daemon will print duplicate error messages if fails to create endpoint.
so, i remove duplicate output in func `EndpointCreate`.
```
ERRO[2018-04-03 20:40:33.310004469] failed to create endpoint, err: service endpoint with name 169a941d already exists
ERRO[2018-04-03 20:40:33.310011239] failed to create endpoint: service endpoint with name 169a941d already exists
```
Thanks a lot for your reviews and comments.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


