### PR TITLE
feature: add diskquota support regular expression

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1786,7 +1786,7 @@ definitions:
           type: "string"
       QuotaID:
         type: "string"
-        description: "set disk quota by specified quota id"
+        description: "set disk quota by specified quota id, if id < 0, it means pouchd alloc a unique quota id"
  
   ContainerCreateResp:
     description: "response returned by daemon when container create successfully"

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1784,6 +1784,9 @@ definitions:
         type: "object"
         additionalProperties:
           type: "string"
+      QuotaID:
+        type: "string"
+        description: "set disk quota by specified quota id"
  
   ContainerCreateResp:
     description: "response returned by daemon when container create successfully"

--- a/apis/types/container_config.go
+++ b/apis/types/container_config.go
@@ -79,7 +79,7 @@ type ContainerConfig struct {
 	// Open `stdin`
 	OpenStdin bool `json:"OpenStdin,omitempty"`
 
-	// set disk quota by specified quota id
+	// set disk quota by specified quota id, if id < 0, it means pouchd alloc a unique quota id
 	QuotaID string `json:"QuotaID,omitempty"`
 
 	// Whether to start container in rich container mode. (default false)

--- a/apis/types/container_config.go
+++ b/apis/types/container_config.go
@@ -79,6 +79,9 @@ type ContainerConfig struct {
 	// Open `stdin`
 	OpenStdin bool `json:"OpenStdin,omitempty"`
 
+	// set disk quota by specified quota id
+	QuotaID string `json:"QuotaID,omitempty"`
+
 	// Whether to start container in rich container mode. (default false)
 	Rich bool `json:"Rich,omitempty"`
 
@@ -148,6 +151,8 @@ type ContainerConfig struct {
 /* polymorph ContainerConfig OnBuild false */
 
 /* polymorph ContainerConfig OpenStdin false */
+
+/* polymorph ContainerConfig QuotaID false */
 
 /* polymorph ContainerConfig Rich false */
 

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -92,6 +92,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 
 	// disk quota
 	flagSet.StringSliceVar(&c.diskQuota, "disk-quota", nil, "Set disk quota for container")
+	flagSet.StringVar(&c.quotaID, "quota-id", "", "Specified quota id, if id < 0, it means pouchd alloc a unique quota id")
 
 	// additional runtime spec annotations
 	flagSet.StringSliceVar(&c.specAnnotation, "annotation", nil, "Additional annotation for runtime")

--- a/cli/container.go
+++ b/cli/container.go
@@ -62,6 +62,7 @@ type container struct {
 	capDrop        []string
 	IntelRdtL3Cbm  string
 	diskQuota      []string
+	quotaID        string
 	oomScoreAdj    int64
 	specAnnotation []string
 	cgroupParent   string
@@ -180,6 +181,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 			InitScript:     c.initScript,
 			ExposedPorts:   ports,
 			DiskQuota:      diskQuota,
+			QuotaID:        c.quotaID,
 			SpecAnnotation: specAnnotation,
 		},
 

--- a/daemon/mgr/spec_blkio.go
+++ b/daemon/mgr/spec_blkio.go
@@ -97,7 +97,11 @@ func setupDiskQuota(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper)
 
 	rootFSQuota, ok := meta.Config.DiskQuota["/"]
 	if !ok || rootFSQuota == "" {
-		return nil
+		commonQuota, ok := meta.Config.DiskQuota[".*"]
+		if !ok || commonQuota == "" {
+			return nil
+		}
+		rootFSQuota = commonQuota
 	}
 
 	if s.Hooks == nil {
@@ -114,7 +118,7 @@ func setupDiskQuota(ctx context.Context, meta *ContainerMeta, spec *SpecWrapper)
 
 	quotaPrestart := specs.Hook{
 		Path: target,
-		Args: []string{"set-diskquota", meta.BaseFS, rootFSQuota},
+		Args: []string{"set-diskquota", meta.BaseFS, rootFSQuota, meta.Config.QuotaID},
 	}
 	s.Hooks.Prestart = append(s.Hooks.Prestart, quotaPrestart)
 

--- a/pkg/quota/grpquota.go
+++ b/pkg/quota/grpquota.go
@@ -130,7 +130,7 @@ func (quota *GrpQuota) SetSubtree(dir string, qid uint32) (uint32, error) {
 }
 
 // SetDiskQuota is used to set quota for directory.
-func (quota *GrpQuota) SetDiskQuota(dir string, size string, quotaID int) error {
+func (quota *GrpQuota) SetDiskQuota(dir string, size string, quotaID uint32) error {
 	logrus.Debugf("set disk quota, dir: %s, size: %s, quotaID: %d", dir, size, quotaID)
 	if !UseQuota {
 		return nil
@@ -144,8 +144,8 @@ func (quota *GrpQuota) SetDiskQuota(dir string, size string, quotaID int) error 
 		return fmt.Errorf("mountpoint not found: %s", dir)
 	}
 
-	id, err := quota.SetSubtree(dir, uint32(quotaID))
-	if id == 0 {
+	id, err := quota.SetSubtree(dir, quotaID)
+	if err != nil || id == 0 {
 		return fmt.Errorf("subtree not found: %s %v", dir, err)
 	}
 

--- a/pkg/quota/prjquota.go
+++ b/pkg/quota/prjquota.go
@@ -100,7 +100,7 @@ func (quota *PrjQuota) SetSubtree(dir string, qid uint32) (uint32, error) {
 }
 
 // SetDiskQuota is used to set quota for directory.
-func (quota *PrjQuota) SetDiskQuota(dir string, size string, quotaID int) error {
+func (quota *PrjQuota) SetDiskQuota(dir string, size string, quotaID uint32) error {
 	logrus.Debugf("set disk quota, dir: %s, size: %s, quotaID: %d", dir, size, quotaID)
 	if !UseQuota {
 		return nil
@@ -114,8 +114,8 @@ func (quota *PrjQuota) SetDiskQuota(dir string, size string, quotaID int) error 
 		return fmt.Errorf("mountpoint not found: %s", dir)
 	}
 
-	id, err := quota.SetSubtree(dir, uint32(quotaID))
-	if id == 0 {
+	id, err := quota.SetSubtree(dir, quotaID)
+	if err != nil || id == 0 {
 		return fmt.Errorf("subtree not found: %s %v", dir, err)
 	}
 

--- a/pkg/quota/quota.go
+++ b/pkg/quota/quota.go
@@ -24,7 +24,7 @@ var (
 type BaseQuota interface {
 	StartQuotaDriver(dir string) (string, error)
 	SetSubtree(dir string, qid uint32) (uint32, error)
-	SetDiskQuota(dir string, size string, quotaID int) error
+	SetDiskQuota(dir string, size string, quotaID uint32) error
 	CheckMountpoint(devID uint64) (string, bool, string)
 	GetFileAttr(dir string) uint32
 	SetFileAttr(dir string, id uint32) error
@@ -92,7 +92,7 @@ func SetSubtree(dir string, qid uint32) (uint32, error) {
 }
 
 // SetDiskQuota is used to set quota for directory.
-func SetDiskQuota(dir string, size string, quotaID int) error {
+func SetDiskQuota(dir string, size string, quotaID uint32) error {
 	return Gquota.SetDiskQuota(dir, size, quotaID)
 }
 

--- a/pkg/quota/quota.go
+++ b/pkg/quota/quota.go
@@ -120,3 +120,22 @@ func SetFileAttrNoOutput(dir string, id uint32) {
 func GetNextQuatoID() (uint32, error) {
 	return Gquota.GetNextQuatoID()
 }
+
+//GetDefaultQuota returns the default quota size.
+func GetDefaultQuota(quotas map[string]string) string {
+	if quotas == nil {
+		return ""
+	}
+
+	quota, ok := quotas["/"]
+	if ok && quota != "" {
+		return quota
+	}
+
+	quota, ok = quotas[".*"]
+	if ok && quota != "" {
+		return quota
+	}
+
+	return ""
+}

--- a/pkg/quota/set_diskquota.go
+++ b/pkg/quota/set_diskquota.go
@@ -45,7 +45,10 @@ func processSetQuotaReexec() {
 
 	basefs := os.Args[1]
 	size := os.Args[2]
-	id, _ := strconv.Atoi(os.Args[3])
+	id, err := strconv.Atoi(os.Args[3])
+	if err != nil {
+		return
+	}
 	qid = uint32(id)
 
 	logrus.Infof("set diskquota: %v", os.Args)

--- a/pkg/quota/set_diskquota.go
+++ b/pkg/quota/set_diskquota.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/pkg/reexec"
@@ -37,13 +38,15 @@ func processSetQuotaReexec() {
 		}
 	}()
 
-	if len(os.Args) != 3 {
-		err = fmt.Errorf("invalid arguments: %v, it should be: %s: <path> <size>", os.Args, os.Args[0])
+	if len(os.Args) != 4 {
+		err = fmt.Errorf("invalid arguments: %v, it should be: %s: <path> <size> <quota id>", os.Args, os.Args[0])
 		return
 	}
 
 	basefs := os.Args[1]
 	size := os.Args[2]
+	id, _ := strconv.Atoi(os.Args[3])
+	qid = uint32(id)
 
 	logrus.Infof("set diskquota: %v", os.Args)
 
@@ -60,18 +63,19 @@ func processSetQuotaReexec() {
 			return
 		}
 
-		qid, err = SetSubtree(dir, qid)
+		qid, err = SetSubtree(dir, uint32(qid))
 		if err != nil {
 			logrus.Errorf("failed to set subtree: %v", err)
 			return
 		}
 
-		err = SetDiskQuota(dir, size, int(qid))
+		err = SetDiskQuota(dir, size, qid)
 		if err != nil {
 			logrus.Errorf("failed to set disk quota: %v", err)
+			return
 		}
 
-		setQuotaForDir(dir, qid)
+		setQuotaForDir(dir, uint32(qid))
 	}
 
 	return

--- a/pkg/quota/type.go
+++ b/pkg/quota/type.go
@@ -1,0 +1,10 @@
+package quota
+
+import "regexp"
+
+// RegExp defines the regular expression of disk quota.
+type RegExp struct {
+	Pattern *regexp.Regexp
+	Path    string
+	Size    string
+}

--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -337,7 +337,7 @@ func (suite *PouchNetworkSuite) TestNetworkPortMapping(c *check.C) {
 		"-p", "9999:80",
 		image).Assert(c, icmd.Success)
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(10 * time.Second)
 	err := icmd.RunCommand("curl", "localhost:9999").Compare(expct)
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add diskquota support regular expression.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how you did it
We can use ```pouch run --disk-quota="key=value"``` to set quota for container. This pr can make it support to use regular expression key, such as: --disk-quota=".*=1g", it means all the quota of mount points are '1g', the priority of key '.*' is the lowest. If it has no 'key', just have  'value', such as: ```--disk-quota=1g```, it means the quota of rootfs is 1g. If the mountpoint is a volume, the quota of volume is base on volume's size, the disk-quota is not take effect on a volume.

### Ⅳ. Describe how to verify it
The example is test case: ```TestRunWithDiskQuotaRegular```

create a volume with size limit: 256m 
```
# pouch volume create -n diskquota-volume -o size=256m -o mount=/data/volume
Name:         diskquota-volume
Scope:
Status:       map[mount:/data/volume sifter:Default size:256m]
CreatedAt:    2018-4-8 14:18:35
Driver:       local
Labels:       map[]
Mountpoint:   /data/volume/diskquota-volume
```
create a container with diskquota
```
# pouch run --name diskquota-test -ti --disk-quota="1024m" --disk-quota=".*=512m" --disk-quota="/mnt/mount1=768m" -v /data/mount1:/mnt/mount1 -v /data/mount2:/mnt/mount2 -v diskquota-volume:/mnt/diskquota-volume registry.docker-cn.com/library/busybox:latest df
Filesystem           1K-blocks      Used Available Use% Mounted on
overlay                1048576        40   1048536   0% /
tmpfs                    65536         0     65536   0% /dev
shm                      65536         0     65536   0% /dev/shm
tmpfs                    65536         0     65536   0% /run
/dev/sdb2               786432         4    786428   0% /mnt/mount1
/dev/sdb2               524288         4    524284   0% /mnt/mount2
/dev/sdb2               262144         4    262140   0% /mnt/diskquota-volume
tmpfs                    65536         0     65536   0% /proc/kcore
tmpfs                    65536         0     65536   0% /proc/timer_list
tmpfs                    65536         0     65536   0% /proc/sched_debug
tmpfs                  2008224         0   2008224   0% /sys/firmware
tmpfs                  2008224         0   2008224   0% /proc/scsi
```
### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
