### PR TITLE
bugfix: modify subnet mask 24 -> 16

### DIFF
--- a/network/mode/bridge/vars.go
+++ b/network/mode/bridge/vars.go
@@ -8,10 +8,7 @@ const (
 	DefaultBridgeIP = "172.17.0.1"
 
 	// DefaultSubnet defines the default bridge subnet.
-	DefaultSubnet = "172.17.0.1/24"
-
-	// DefaultIPRange defines the default bridge ip range in ipam.
-	DefaultIPRange = "172.17.0.1/24"
+	DefaultSubnet = "172.17.0.1/16"
 
 	// DefaultGateway defines the default bridge gateway.
 	DefaultGateway = "172.17.0.1"


### PR DESCRIPTION
Signed-off-by: 程飞 <fay.cheng.cn@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

the default subnet mask(24) is too long，there can not be more than 254 containers on the same network.
so i change it to 16.

if we create a large number of containers, pouch daemon will print error messages that look like this:

```
ERRO[2018-04-04 16:35:11.197577361] failed to create endpoint, err: no available IPv4 addresses on this network's address pools: bridge 
```

Thanks a lot for your reviews and detailed comments.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it

```
➜  ~ pouch network inspect -f '{{.IPAM.Config}}' bridge
[{map[] 172.17.0.1  172.17.0.1/16}]
```

### Ⅴ. Special notes for reviews


