### PR TITLE
golint: not found has exit code 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ check: pre fmt lint vet validate-swagger
 .PHONY: fmt
 fmt: ## run go fmt
 	@echo $@
+	@which gofmt
 	@test -z "$$(gofmt -s -l . 2>/dev/null | grep -Fv 'vendor/' | grep -Fv 'extra/' | grep -v ".pb.go$$" | tee /dev/stderr)" || \
 		(echo "please format Go code with 'gofmt -s -w'" && false)
 	@test -z "$$(find . -path ./vendor -prune -o ! -path ./extra -prune -o ! -name timestamp.proto ! -name duration.proto -name '*.proto' -type f -exec grep -Hn -e "^ " {} \; | tee /dev/stderr)" || \
@@ -50,6 +51,7 @@ fmt: ## run go fmt
 .PHONY: lint
 lint: ## run go lint
 	@echo $@
+	@which golint
 	@test -z "$$(golint ./... | grep -Fv 'vendor/' | grep -Fv 'extra' | grep -v ".pb.go:" | tee /dev/stderr)"
 
 .PHONY: vet


### PR DESCRIPTION
Signed-off-by: Yuan Sun <yile.sy@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
golint: not found has exit code 0

fixes https://github.com/alibaba/pouch/issues/1042

### Ⅲ. Describe how you did it
Remove the code leading to the failure.

```
bash-3.2$ golint ./... | grep -Fv 'vendor/' | grep -Fv 'extra' | grep -v ".pb.go:" | tee /dev/stderr
bash: golint: command not found
bash-3.2$ echo $?
0
bash-3.2$ golint ./... | grep -Fv 'vendor/' | grep -Fv 'extra' | grep -v ".pb.go:"
bash: golint: command not found
bash-3.2$ echo $?
1
```

### Ⅳ. Describe how to verify it
remove golint file if it exists in your PATH
execute make lint


### Ⅴ. Special notes for reviews
NA

