### PR TITLE
fix: make json ID be Id to be compatible

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2443,7 +2443,7 @@ definitions:
     description: "An object containing all details of an image at API side"
     type: "object"
     properties:
-      ID:
+      Id:
         description: "ID of an image."
         type: "string"
         x-nullable: false
@@ -2650,7 +2650,7 @@ definitions:
   ExecCreateResp:
     type: "object"
     properties:
-      ID:
+      Id:
         type: "string"
 
   ExecStartConfig:
@@ -2994,7 +2994,7 @@ definitions:
     type: "object"
     description: "contains the response for the remote API: POST /networks/create"
     properties:
-      ID:
+      Id:
         description: "ID is the id of the network."
         type: "string"
       Warning:
@@ -3035,7 +3035,7 @@ definitions:
       Name:
         type: "string"
         description: "Name is the requested name of the network"
-      ID:
+      Id:
         type: "string"
         description: "ID uniquely identifies a network on a single machine"
       Scope:
@@ -3072,7 +3072,7 @@ definitions:
         Name:
           description: "Name is the name of the network."
           type: "string"
-        ID:
+        Id:
           type: "string"
           description: "ID uniquely identifies a network on a single machine"
         Driver:

--- a/apis/types/exec_create_resp.go
+++ b/apis/types/exec_create_resp.go
@@ -17,11 +17,11 @@ import (
 
 type ExecCreateResp struct {
 
-	// ID
-	ID string `json:"ID,omitempty"`
+	// Id
+	ID string `json:"Id,omitempty"`
 }
 
-/* polymorph ExecCreateResp ID false */
+/* polymorph ExecCreateResp Id false */
 
 // Validate validates this exec create resp
 func (m *ExecCreateResp) Validate(formats strfmt.Registry) error {

--- a/apis/types/image_info.go
+++ b/apis/types/image_info.go
@@ -28,7 +28,7 @@ type ImageInfo struct {
 	CreatedAt string `json:"CreatedAt,omitempty"`
 
 	// ID of an image.
-	ID string `json:"ID,omitempty"`
+	ID string `json:"Id,omitempty"`
 
 	// the name of the operating system.
 	Os string `json:"Os,omitempty"`
@@ -52,7 +52,7 @@ type ImageInfo struct {
 
 /* polymorph ImageInfo CreatedAt false */
 
-/* polymorph ImageInfo ID false */
+/* polymorph ImageInfo Id false */
 
 /* polymorph ImageInfo Os false */
 

--- a/apis/types/network_create_resp.go
+++ b/apis/types/network_create_resp.go
@@ -18,13 +18,13 @@ import (
 type NetworkCreateResp struct {
 
 	// ID is the id of the network.
-	ID string `json:"ID,omitempty"`
+	ID string `json:"Id,omitempty"`
 
 	// Warning means the message of create network result.
 	Warning string `json:"Warning,omitempty"`
 }
 
-/* polymorph NetworkCreateResp ID false */
+/* polymorph NetworkCreateResp Id false */
 
 /* polymorph NetworkCreateResp Warning false */
 

--- a/apis/types/network_info.go
+++ b/apis/types/network_info.go
@@ -21,7 +21,7 @@ type NetworkInfo struct {
 	Driver string `json:"Driver,omitempty"`
 
 	// ID uniquely identifies a network on a single machine
-	ID string `json:"ID,omitempty"`
+	ID string `json:"Id,omitempty"`
 
 	// Name is the name of the network.
 	Name string `json:"Name,omitempty"`
@@ -32,7 +32,7 @@ type NetworkInfo struct {
 
 /* polymorph NetworkInfo Driver false */
 
-/* polymorph NetworkInfo ID false */
+/* polymorph NetworkInfo Id false */
 
 /* polymorph NetworkInfo Name false */
 

--- a/apis/types/network_inspect_resp.go
+++ b/apis/types/network_inspect_resp.go
@@ -23,11 +23,11 @@ type NetworkInspectResp struct {
 	// EnableIPv6 represents whether to enable IPv6.
 	EnableIPV6 bool `json:"EnableIPv6,omitempty"`
 
-	// ID uniquely identifies a network on a single machine
-	ID string `json:"ID,omitempty"`
-
 	// IPAM is the network's IP Address Management.
 	IPAM *IPAM `json:"IPAM,omitempty"`
+
+	// ID uniquely identifies a network on a single machine
+	ID string `json:"Id,omitempty"`
 
 	// Internal checks the network is internal network or not.
 	Internal bool `json:"Internal,omitempty"`
@@ -49,9 +49,9 @@ type NetworkInspectResp struct {
 
 /* polymorph NetworkInspectResp EnableIPv6 false */
 
-/* polymorph NetworkInspectResp ID false */
-
 /* polymorph NetworkInspectResp IPAM false */
+
+/* polymorph NetworkInspectResp Id false */
 
 /* polymorph NetworkInspectResp Internal false */
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

We found that in Moby 1.12.6, lots of API communication uses json to wrap data. However, in Moby 1.12.6, almost all field ID is in json format `Id` which is one upper-case and the other is `lower-case`. While in the master code of Pouch, we use `ID` in json format. It will leads to incompatibility there. This PR tries to fix that.



### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix one part of https://github.com/alibaba/pouch/issues/977


### Ⅲ. Describe how you did it
none

### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews
none


