### PR TITLE
bugfix: fix use old image's cmd when upgrade container

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -370,10 +370,10 @@ func (c *Client) createContainer(ctx context.Context, ref, id string, container 
 	}
 
 	// check snapshot exist or not.
-	if _, err := c.GetSnapshot(ctx, id); err != nil {
-		return errors.Wrapf(err, "failed to create container %s", id)
+	if _, err := c.GetSnapshot(ctx, container.SnapshotKey); err != nil {
+		return errors.Wrapf(err, "failed to create container, id: %s", id)
 	}
-	options = append(options, containerd.WithSnapshot(id))
+	options = append(options, containerd.WithSnapshot(container.SnapshotKey))
 
 	nc, err := wrapperCli.client.NewContainer(ctx, id, options...)
 	if err != nil {

--- a/ctrd/container_types.go
+++ b/ctrd/container_types.go
@@ -8,11 +8,12 @@ import (
 
 // Container wraps container's info.
 type Container struct {
-	ID      string
-	Image   string
-	Runtime string
-	IO      *containerio.IO
-	Spec    *specs.Spec
+	ID          string
+	Image       string
+	Runtime     string
+	SnapshotKey string
+	IO          *containerio.IO
+	Spec        *specs.Spec
 }
 
 // Process wraps exec process's info.

--- a/test/cli_upgrade_test.go
+++ b/test/cli_upgrade_test.go
@@ -29,7 +29,7 @@ func (suite *PouchUpgradeSuite) SetUpSuite(c *check.C) {
 	environment.PruneAllContainers(apiClient)
 
 	PullImage(c, busyboxImage)
-	command.PouchRun("pull", busyboxImage125).Assert(c, icmd.Success)
+	PullImage(c, busyboxImage125)
 }
 
 // TearDownTest does cleanup work in the end of each test.
@@ -163,4 +163,21 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeContainerLabels(c *check.C) {
 	if !reflect.DeepEqual(result[0].Config.Labels, labels) {
 		c.Errorf("unexpected output: %s, expected: %s", result[0].Config.Labels, labels)
 	}
+}
+
+// TestPouchUpgradeWithDifferentImage is to verify pouch upgrade command.
+func (suite *PouchUpgradeSuite) TestPouchUpgradeWithDifferentImage(c *check.C) {
+	name := "TestPouchUpgradeWithDifferentImage"
+
+	command.PouchRun("run", "-d", "--name", name, busyboxImage).Assert(c, icmd.Success)
+
+	res := command.PouchRun("upgrade", "--name", name, helloworldImage)
+	c.Assert(res.Error, check.IsNil)
+
+	if out := res.Combined(); !strings.Contains(out, name) {
+		c.Fatalf("unexpected output: %s, expected: %s", out, name)
+	}
+
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
+
 }


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
fix create new container using old image's cmd params when upgrade a container

### Ⅱ. Does this pull request fix one issue?
fixes https://github.com/alibaba/pouch/issues/1077


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
1. create a new container:
```
root@osboxes:test (zr/fix-upgrade) -> pouch run --name test -d registry.hub.docker.com/library/busybox:latest
517711dd75bb33a2ec12d6f6355ca6cd7d83fcf13140484285c9d03135b7cfad
```

2.  `upgrade` container with `hello-world` image:
```
root@osboxes:test (zr/fix-upgrade) -> pouch upgrade --name test registry.hub.docker.com/library/hello-world:latest
test
```

3. check container status:
```
root@osboxes:test (zr/fix-upgrade) -> pouch ps -a
Name   ID       Status   Created          Image                                                Runtime
test   517711   exited   49 seconds ago   registry.hub.docker.com/library/hello-world:latest   runc
```

4. now we `upgrade` the container with `busybox` image again:
```
root@osboxes:test (zr/fix-upgrade) -> pouch upgrade --name test registry.hub.docker.com/library/busybox:1.28
test
```

5. check container status again: still `exited`,  because the container's status is `exited` before `upgrade`
```
root@osboxes:test (zr/fix-upgrade) -> pouch ps -a
Name   ID       Status   Created        Image                                          Runtime
test   517711   exited   1 minute ago   registry.hub.docker.com/library/busybox:1.28   runc
```

6. now we start the container:
```
root@osboxes:test (zr/fix-upgrade) -> pouch start test
root@osboxes:test (zr/fix-upgrade) -> pouch ps
Name   ID       Status         Created        Image                                          Runtime
test   517711   Up 2 seconds   1 minute ago   registry.hub.docker.com/library/busybox:1.28   runc
```


### Ⅴ. Special notes for reviews


