### PR TITLE
bugfix: make container exit with real exit code

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -140,3 +140,14 @@ func (c *Cli) Print(obj interface{}) {
 
 	display.Flush()
 }
+
+// ExitError defines exit error produce by cli commands.
+type ExitError struct {
+	Code   int
+	Status string
+}
+
+// Error inplements error interface.
+func (e ExitError) Error() string {
+	return fmt.Sprintf("Exit Code: %d, Status: %s", e.Code, e.Status)
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -47,6 +47,20 @@ func main() {
 	cli.AddCommand(base, &GenDocCommand{})
 
 	if err := cli.Run(); err != nil {
+		// deal with ExitError, which should be recognize as error, and should
+		// not be exit with status 0.
+		if exitErr, ok := err.(ExitError); ok {
+			if exitErr.Status != "" {
+				fmt.Fprintln(os.Stderr, exitErr.Status)
+			}
+			if exitErr.Code == 0 {
+				// when get error with ExitError, code should not be 0.
+				exitErr.Code = 1
+			}
+			os.Exit(exitErr.Code)
+		}
+
+		// not ExitError, print error to os.Stderr, exit code 1.
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/cli/run.go
+++ b/cli/run.go
@@ -108,6 +108,7 @@ func (rc *RunCommand) runRun(args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to attach container: %v", err)
 		}
+		defer conn.Close()
 
 		go func() {
 			io.Copy(os.Stdout, br)
@@ -115,7 +116,6 @@ func (rc *RunCommand) runRun(args []string) error {
 		}()
 		go func() {
 			io.Copy(conn, os.Stdin)
-			wait <- struct{}{}
 		}()
 	}
 
@@ -130,6 +130,17 @@ func (rc *RunCommand) runRun(args []string) error {
 	} else {
 		fmt.Fprintf(os.Stdout, "%s\n", result.ID)
 	}
+
+	info, err := apiClient.ContainerGet(ctx, containerName)
+	if err != nil {
+
+	}
+
+	code := info.State.ExitCode
+	if code != 0 {
+		return ExitError{Code: int(code)}
+	}
+
 	return nil
 }
 

--- a/cli/start.go
+++ b/cli/start.go
@@ -72,6 +72,7 @@ func (s *StartCommand) runStart(args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to attach container: %v", err)
 		}
+		defer conn.Close()
 
 		wait = make(chan struct{})
 		go func() {
@@ -80,7 +81,6 @@ func (s *StartCommand) runStart(args []string) error {
 		}()
 		go func() {
 			io.Copy(conn, os.Stdin)
-			close(wait)
 		}()
 	}
 
@@ -93,6 +93,17 @@ func (s *StartCommand) runStart(args []string) error {
 	if s.attach || s.stdin {
 		<-wait
 	}
+
+	info, err := apiClient.ContainerGet(ctx, container)
+	if err != nil {
+
+	}
+
+	code := info.State.ExitCode
+	if code != 0 {
+		return ExitError{Code: int(code)}
+	}
+
 	return nil
 }
 

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -626,6 +626,7 @@ func (mgr *ContainerManager) createContainerdContainer(ctx context.Context, c *C
 			return errors.Wrapf(err, "failed to get PID of container: %s", c.ID())
 		}
 		c.meta.State.Pid = int64(pid)
+		c.meta.State.ExitCode = 0
 	} else {
 		c.meta.State.FinishedAt = time.Now().UTC().Format(utils.TimeLayout)
 		c.meta.State.Error = err.Error()

--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -139,7 +139,7 @@ func (suite *PouchNetworkSuite) TestNetworkBridgeWorks(c *check.C) {
 			ExitCode: 1,
 			Err:      "has active endpoints",
 		}
-		command.PouchRun("run", "--name", funcname, "--net", funcname, busyboxImage, "top").Assert(c, icmd.Success)
+		command.PouchRun("run", "-d", "--name", funcname, "--net", funcname, busyboxImage, "top").Assert(c, icmd.Success)
 
 		err := command.PouchRun("network", "remove", funcname).Compare(expct)
 		c.Assert(err, check.IsNil)
@@ -181,7 +181,7 @@ func (suite *PouchNetworkSuite) TestNetworkBridgeWorks(c *check.C) {
 	}
 	{
 		// running container is stopped, then the veth device should also been removed
-		command.PouchRun("run", "--name", funcname, "--net", funcname, busyboxImage, "top").Assert(c, icmd.Success)
+		command.PouchRun("run", "-d", "--name", funcname, "--net", funcname, busyboxImage, "top").Assert(c, icmd.Success)
 		command.PouchRun("stop", funcname).Assert(c, icmd.Success)
 
 		// get the ID of bridge to construct the bridge name.

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -185,7 +185,7 @@ func (suite *PouchRunSuite) TestRunInWrongWay(c *check.C) {
 func (suite *PouchRunSuite) TestRunEnableLxcfs(c *check.C) {
 	name := "test-run-lxcfs"
 
-	command.PouchRun("run", "--name", name, "-m", "512M", "--enableLxcfs=true",
+	command.PouchRun("run", "-d", "--name", name, "-m", "512M", "--enableLxcfs=true",
 		busyboxImage, "sleep", "10000").Assert(c, icmd.Success)
 
 	res := command.PouchRun("exec", name, "head", "-n", "5", "/proc/meminfo")
@@ -237,7 +237,7 @@ func (suite *PouchRunSuite) TestRunRestartPolicyNone(c *check.C) {
 func (suite *PouchRunSuite) TestRunWithIPCMode(c *check.C) {
 	name := "test-run-with-ipc-mode"
 
-	res := command.PouchRun("run", "--name", name, "--ipc", "host", busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, "--ipc", "host", busyboxImage)
 	res.Assert(c, icmd.Success)
 	DelContainerForceMultyTime(c, name)
 }
@@ -247,7 +247,7 @@ func (suite *PouchRunSuite) TestRunWithIPCMode(c *check.C) {
 func (suite *PouchRunSuite) TestRunWithPIDMode(c *check.C) {
 	name := "test-run-with-pid-mode"
 
-	res := command.PouchRun("run", "--name", name, "--pid", "host", busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, "--pid", "host", busyboxImage)
 	res.Assert(c, icmd.Success)
 	DelContainerForceMultyTime(c, name)
 }
@@ -256,7 +256,7 @@ func (suite *PouchRunSuite) TestRunWithPIDMode(c *check.C) {
 func (suite *PouchRunSuite) TestRunWithUTSMode(c *check.C) {
 	name := "test-run-with-uts-mode"
 
-	res := command.PouchRun("run", "--name", name, "--uts", "host", busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, "--uts", "host", busyboxImage)
 	res.Assert(c, icmd.Success)
 	DelContainerForceMultyTime(c, name)
 }
@@ -266,7 +266,7 @@ func (suite *PouchRunSuite) TestRunWithSysctls(c *check.C) {
 	sysctl := "net.ipv4.ip_forward=1"
 	name := "run-sysctl"
 
-	res := command.PouchRun("run", "--name", name, "--sysctl", sysctl, busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, "--sysctl", sysctl, busyboxImage)
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("exec", name, "cat", "/proc/sys/net/ipv4/ip_forward").Stdout()
@@ -281,7 +281,7 @@ func (suite *PouchRunSuite) TestRunWithUser(c *check.C) {
 	user := "1001"
 	name := "run-user"
 
-	res := command.PouchRun("run", "--name", name, "--user", user, busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, "--user", user, busyboxImage)
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("exec", name, "id", "-u").Stdout()
@@ -304,7 +304,7 @@ func (suite *PouchRunSuite) TestRunWithAppArmor(c *check.C) {
 	appArmor := "apparmor=unconfined"
 	name := "run-apparmor"
 
-	res := command.PouchRun("run", "--name", name, "--security-opt", appArmor, busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, "--security-opt", appArmor, busyboxImage)
 	res.Assert(c, icmd.Success)
 
 	// TODO: do the test more strictly with effective AppArmor profile.
@@ -317,7 +317,7 @@ func (suite *PouchRunSuite) TestRunWithSeccomp(c *check.C) {
 	seccomp := "seccomp=unconfined"
 	name := "run-seccomp"
 
-	res := command.PouchRun("run", "--name", name, "--security-opt", seccomp, busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, "--security-opt", seccomp, busyboxImage)
 	res.Assert(c, icmd.Success)
 
 	// TODO: do the test more strictly with effective seccomp profile.
@@ -359,7 +359,7 @@ func (suite *PouchRunSuite) TestRunWithPrivilege(c *check.C) {
 func (suite *PouchRunSuite) TestRunWithBlkioWeight(c *check.C) {
 	name := "test-run-with-blkio-weight"
 
-	res := command.PouchRun("run", "--name", name, "--blkio-weight", "500", busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, "--blkio-weight", "500", busyboxImage)
 	res.Assert(c, icmd.Success)
 	DelContainerForceMultyTime(c, name)
 }
@@ -817,7 +817,7 @@ func (suite *PouchRunSuite) TestRunWithDiskQuota(c *check.C) {
 // TestRunWithAnnotation is to verify the valid running container with annotation, and verify SpecAnnotation filed has been in inspect output.
 func (suite *PouchRunSuite) TestRunWithAnnotation(c *check.C) {
 	cname := "TestRunWithAnnotation"
-	command.PouchRun("run", "-d", "--annotation", "a=b", "--annotation", "foo=bar", "--name", cname, busyboxImage).Stdout()
+	command.PouchRun("run", "-d", "--annotation", "a=b", "--annotation", "foo=bar", "--name", cname, busyboxImage).Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", cname).Stdout()
 	result := []types.ContainerJSON{}
@@ -834,4 +834,20 @@ func (suite *PouchRunSuite) TestRunWithAnnotation(c *check.C) {
 
 	c.Assert(util.PartialEqual(annotationStr, "a=b"), check.IsNil)
 	c.Assert(util.PartialEqual(annotationStr, "foo=bar"), check.IsNil)
+}
+
+// TestRunWithExitCode is to verify the valid running container with exit code != 0.
+func (suite *PouchRunSuite) TestRunWithExitCode(c *check.C) {
+	cname := "TestRunWithExitCode"
+	ret := command.PouchRun("run", "--name", cname, busyboxImage, "sh", "-c", "exit 101")
+	// test process exit code $? == 101
+	ret.Assert(c, icmd.Expected{ExitCode: 101})
+
+	// test container ExitCode == 101
+	output := command.PouchRun("inspect", cname).Stdout()
+	result := []types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result[0].State.ExitCode, check.Equals, int64(101))
 }

--- a/test/z_cli_daemon_test.go
+++ b/test/z_cli_daemon_test.go
@@ -48,7 +48,7 @@ func (suite *PouchDaemonSuite) TestDaemonCgroupParent(c *check.C) {
 		}
 	}
 	{
-		result := command.PouchRun("--host", daemon.Listen, "run", "--name", cname, busyboxImage)
+		result := command.PouchRun("--host", daemon.Listen, "run", "-d", "--name", cname, busyboxImage)
 		if result.ExitCode != 0 {
 			dcfg.DumpLog()
 			c.Fatalf("run container failed, err:%v", result)


### PR DESCRIPTION
Fixes: #1075

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

1. make container exit with real exit code
2. fix stop wait after stdin close
3. fix some test case hang, such as this will hang forever, miss detach flag.
```
-       command.PouchRun("run", "--name", name, "-m", "512M", "--enableLxcfs=true",
+       command.PouchRun("run", "-d", "--name", name, "-m", "512M", "--enableLxcfs=true",
```
4. fix container exit code not equal 0 after container start

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


