### PR TITLE
feature: add image proxy info in 'pouch info'

### DIFF
--- a/cli/info.go
+++ b/cli/info.go
@@ -55,9 +55,9 @@ func (v *InfoCommand) runInfo() error {
 
 func prettyPrintInfo(cli *Cli, info *types.SystemInfo) error {
 	fmt.Fprintln(os.Stdout, "Containers:", info.Containers)
-	fmt.Fprintln(os.Stdout, "Running:", info.ContainersRunning)
-	fmt.Fprintln(os.Stdout, "Paused:", info.ContainersPaused)
-	fmt.Fprintln(os.Stdout, "Stopped:", info.ContainersStopped)
+	fmt.Fprintln(os.Stdout, " Running:", info.ContainersRunning)
+	fmt.Fprintln(os.Stdout, " Paused:", info.ContainersPaused)
+	fmt.Fprintln(os.Stdout, " Stopped:", info.ContainersStopped)
 	fmt.Fprintln(os.Stdout, "Images: ", info.Images)
 	fmt.Fprintln(os.Stdout, "ID:", info.ID)
 	fmt.Fprintln(os.Stdout, "Name:", info.Name)
@@ -129,9 +129,9 @@ func prettyPrintInfo(cli *Cli, info *types.SystemInfo) error {
 func infoExample() string {
 	return `$ pouch info
 Containers: 1
-Running: 1
-Paused: 0
-Stopped: 0
+ Running: 1
+ Paused: 0
+ Stopped: 0
 Images:  0
 ID:
 Name:
@@ -147,7 +147,7 @@ Kernel Version: 3.10.0-693.17.1.el7.x86_64
 Operating System:
 OSType: linux
 Architecture:
-HTTP Proxy:
+HTTP Proxy: http://127.0.0.1:5678
 HTTPS Proxy:
 Registry: https://index.docker.io/v1/
 Experimental: false

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -86,7 +86,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		// Driver: ,
 		// DriverStatus: ,
 		// ExperimentalBuild: ,
-		// HTTPProxy: ,
+		HTTPProxy: mgr.config.ImageProxy,
 		// HTTPSProxy: ,
 		// ID: ,
 		// Images: ,


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This pr enhance the output of 'pouch info' by adding the info of http proxy(image proxy).

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes one part of #1096 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
start pouch like 
```pouchd --image-proxy=http://127.0.0.1:5678```

then
```
$ pouch info
Containers: 1
 Running: 1
 Paused: 0
 Stopped: 0
Images:  0
ID:
Name:
Server Version: 0.3-dev
Storage Driver:
Driver Status: []
Logging Driver:
Cgroup Driver:
runc: <nil>
containerd: <nil>
Security Options: []
Kernel Version: 3.10.0-693.17.1.el7.x86_64
Operating System:
OSType: linux
Architecture:
HTTP Proxy: http://127.0.0.1:5678
HTTPS Proxy:
Registry: https://index.docker.io/v1/
Experimental: false
Debug: true
Labels: []
CPUs: 0
Total Memory: 0
Pouch Root Dir: /var/lib/pouch
LiveRestoreEnabled: false
Daemon Listen Addresses: [unix:///var/run/pouchd.sock]
```
### Ⅴ. Special notes for reviews


