### PR TITLE
bugfix: do not append latest to image name having a tag already

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -30,6 +30,10 @@ func (s *Server) pullImage(ctx context.Context, rw http.ResponseWriter, req *htt
 
 	if tag == "" {
 		tag = "latest"
+		if index := strings.LastIndex(image, ":"); index > 0 {
+			tag = image[index+1:]
+			image = image[:index]
+		}
 	}
 	// record the time spent during image pull procedure.
 	defer func(start time.Time) {

--- a/apis/server/image_bridge_test.go
+++ b/apis/server/image_bridge_test.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/daemon/mgr"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockImgePull struct {
+	mgr.ImageMgr
+	handler func(ctx context.Context, imageRef string, authConfig *types.AuthConfig, out io.Writer) error
+}
+
+func (m *mockImgePull) PullImage(ctx context.Context, imageRef string, authConfig *types.AuthConfig, out io.Writer) error {
+	return m.handler(ctx, imageRef, authConfig, out)
+}
+
+func Test_pullImage_without_tag(t *testing.T) {
+	var s Server
+
+	s.ImageMgr = &mockImgePull{
+		ImageMgr: &mgr.ImageManager{},
+		handler: func(ctx context.Context, imageRef string, authConfig *types.AuthConfig, out io.Writer) error {
+			assert.Equal(t, "reg.abc.com/base/os:7.2", imageRef)
+			return nil
+		},
+	}
+	req := &http.Request{
+		Form:   map[string][]string{"fromImage": {"reg.abc.com/base/os:7.2"}},
+		Header: map[string][]string{},
+	}
+	s.pullImage(context.Background(), nil, req)
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
when using swarm to pull an image, it post a request with a param named fromImage, which already include a tag, then we shouldn't append a 'latest' to it.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it
fixes #1109 

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


