### PR TITLE
[feature] setup profiler and don't bother to enable debug level log

### DIFF
--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -77,7 +77,7 @@ func initRoute(s *Server) http.Handler {
 	r.Path(versionMatcher + "/metrics").Methods(http.MethodGet).Handler(prometheus.Handler())
 	r.Path("/metrics").Methods(http.MethodGet).Handler(prometheus.Handler())
 
-	if s.Config.Debug {
+	if s.Config.Debug || s.Config.EnableProfiler {
 		profilerSetup(r)
 	}
 	return r

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -82,6 +82,9 @@ type Config struct {
 
 	// Labels is the metadata of daemon
 	Labels []string `json:"labels,omitempty"`
+
+	// EnableProfiler indicates whether pouchd setup profiler like pprof and stack dumping etc
+	EnableProfiler bool `json:"enableProfiler"`
 }
 
 // Validate validates the user input config.

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alibaba/pouch/daemon"
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/lxcfs"
+	"github.com/alibaba/pouch/pkg/debug"
 	"github.com/alibaba/pouch/pkg/exec"
 	"github.com/alibaba/pouch/pkg/quota"
 	"github.com/alibaba/pouch/pkg/utils"
@@ -98,6 +99,7 @@ func setupFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.CgroupParent, "cgroup-parent", "default", "Set parent cgroup for all containers")
 	flagSet.StringVar(&cfg.PluginPath, "plugin", "", "Set the path where plugin shared library file put")
 	flagSet.StringSliceVar(&cfg.Labels, "label", []string{}, "Set metadata for Pouch daemon")
+	flagSet.BoolVar(&cfg.EnableProfiler, "enable-profiler", false, "Set if pouchd setup profiler")
 }
 
 // parse flags
@@ -127,10 +129,11 @@ func runDaemon() error {
 	}
 
 	// import debugger tools for pouch when in debug mode.
-	if cfg.Debug {
+	if cfg.Debug || cfg.EnableProfiler {
 		if err := agent.Listen(agent.Options{}); err != nil {
 			logrus.Fatal(err)
 		}
+		debug.SetupDumpStackTrap()
 	}
 
 	// initialize home dir.

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -9,10 +9,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func init() {
-	SetupDumpStackTrap()
-}
-
 // SetupDumpStackTrap setups signal trap to dump stack.
 func SetupDumpStackTrap() {
 	c := make(chan os.Signal, 1)


### PR DESCRIPTION
Signed-off-by: Frank Yang <yyb196@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
In production environment i need to enable profilers like `pprof` `stack dumping` and `gops` always for the emergency cases or odd cases, in these cases i need to attach to the running pouchd to get the `cpu` `memory` or `goroutine stack` snapshot online, and then analyze why the odd things happen,  but in these case we don't want alway print debug level log, which is too much output all the time.

This pr enables users to setup profilers and do not bother to always open debug log output. and if debug log level is specified, it's both enable debug level and setup profilers.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


