### PR TITLE
bugfix: we should get image ID from containerd

### DIFF
--- a/hack/cri-test/test-cri.sh
+++ b/hack/cri-test/test-cri.sh
@@ -26,7 +26,7 @@ POUCH_SOCK="/var/run/pouchcri.sock"
 CRI_FOCUS=${CRI_FOCUS:-}
 
 # CRI_SKIP skips the test to skip.
-CRI_SKIP=${CRI_SKIP:-"RunAsUserName|seccomp localhost|should error on create with wrong options|listImage should get exactly 2 repoTags"}
+CRI_SKIP=${CRI_SKIP:-"RunAsUserName|seccomp localhost|should error on create with wrong options"}
 # REPORT_DIR is the the directory to store test logs.
 REPORT_DIR=${REPORT_DIR:-"/tmp/test-cri"}
 


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Now we get image ID by calculating ourself, unfortunately it's wrong.

For example `busybox:1-uclibc` and `busybox:1` should have same ID,  however:
```
[root@pouch-test pouch]# pouch images
IMAGE ID       IMAGE NAME                                         SIZE
58af67620523   registry.hub.docker.com/library/busybox:1          710.83 KB
b2e60002262d   registry.hub.docker.com/library/busybox:1-uclibc   709.90 KB
```

So with this PR we get it directly from containerd then:
```
[root@pouch-test pouch]# pouch images
IMAGE ID       IMAGE NAME                                         SIZE
8ac48589692a   registry.hub.docker.com/library/busybox:1          710.83 KB
8ac48589692a   registry.hub.docker.com/library/busybox:1-uclibc   709.90 KB
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


