### PR TITLE
bugfix: remove ip mask in Networks.IPAddress

### DIFF
--- a/daemon/mgr/network.go
+++ b/daemon/mgr/network.go
@@ -310,7 +310,7 @@ func (nm *NetworkManager) EndpointCreate(ctx context.Context, endpoint *types.En
 		if iface.Address() != nil {
 			mask, _ := iface.Address().Mask.Size()
 			endpointConfig.IPPrefixLen = int64(mask)
-			endpointConfig.IPAddress = iface.Address().String()
+			endpointConfig.IPAddress = iface.Address().IP.String()
 		}
 
 		if iface.MacAddress() != nil {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Removing ip mask in Networks.IPAddress when inspecting a container.
Wrong format: "IPAddress": "172.17.0.2/24", change to ""IPAddress":
"172.17.0.2"

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1079

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>

