### PR TITLE
feature: add a flag of pouchd to specify whether enable CRI

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	// Network config
 	NetworkConfg network.Config
 
+	// Whether enable cri manager.
+	IsCriEnabled bool `json:"enable-cri,omitempty"`
+
 	// CRI config.
 	CriConfig cri.Config
 

--- a/hack/cri-test/test-utils.sh
+++ b/hack/cri-test/test-utils.sh
@@ -49,7 +49,7 @@ test_setup() {
   pouch_pid_command=`pgrep pouchd`
   pouch_pid=${pouch_pid_command}
   if [ ! -n "${pouch_pid}" ]; then
-    keepalive "pouchd ${POUCH_FLAGS}" \
+    keepalive "pouchd --enable-cri ${POUCH_FLAGS}" \
 	  ${RESTART_WAIT_PERIOD} &> ${report_dir}/pouch.log &
     pouch_pid=$!
   fi

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func setupFlags(cmd *cobra.Command) {
 
 	flagSet.StringVar(&cfg.HomeDir, "home-dir", "/var/lib/pouch", "Specify root dir of pouchd")
 	flagSet.StringArrayVarP(&cfg.Listen, "listen", "l", []string{"unix:///var/run/pouchd.sock"}, "Specify listening addresses of Pouchd")
+	flagSet.BoolVar(&cfg.IsCriEnabled, "enable-cri", false, "Specify whether enable the cri part of pouchd which is used to support Kubernetes")
 	flagSet.StringVar(&cfg.CriConfig.Listen, "listen-cri", "/var/run/pouchcri.sock", "Specify listening address of CRI")
 	flagSet.StringVar(&cfg.CriConfig.NetworkPluginBinDir, "cni-bin-dir", "/opt/cni/bin", "The directory for putting cni plugin binaries.")
 	flagSet.StringVar(&cfg.CriConfig.NetworkPluginConfDir, "cni-conf-dir", "/etc/cni/net.d", "The directory for putting cni plugin configuration files.")


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

With this PR, the CRI service of pouch will be off by default.

If we want to enable it, we could start pouchd like:
```
pouchd --enable-cri
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1114 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


