### PR TITLE
bugfix: fix exec not exit with correct exit code

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -123,6 +123,17 @@ func (e *ExecCommand) runExec(args []string) error {
 	}
 
 	wg.Wait()
+
+	execInfo, err := apiClient.ContainerExecInspect(ctx, createResp.ID)
+	if err != nil {
+		return err
+	}
+
+	code := execInfo.ExitCode
+	if code != 0 {
+		return ExitError{Code: int(code)}
+	}
+
 	return nil
 }
 

--- a/client/container.go
+++ b/client/container.go
@@ -26,29 +26,6 @@ func (client *APIClient) ContainerAttach(ctx context.Context, name string, stdin
 	return client.hijack(ctx, "/containers/"+name+"/attach", q, nil, header)
 }
 
-// ContainerCreateExec creates exec process.
-func (client *APIClient) ContainerCreateExec(ctx context.Context, name string, config *types.ExecCreateConfig) (*types.ExecCreateResp, error) {
-	response, err := client.post(ctx, "/containers/"+name+"/exec", url.Values{}, config, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	body := &types.ExecCreateResp{}
-	decodeBody(body, response.Body)
-	ensureCloseReader(response)
-
-	return body, nil
-}
-
-// ContainerStartExec starts exec process.
-func (client *APIClient) ContainerStartExec(ctx context.Context, execid string, config *types.ExecStartConfig) (net.Conn, *bufio.Reader, error) {
-	header := map[string][]string{
-		"Content-Type": {"text/plain"},
-	}
-
-	return client.hijack(ctx, "/exec/"+execid+"/start", url.Values{}, config, header)
-}
-
 // ContainerUpgrade upgrade a container with new image and args.
 func (client *APIClient) ContainerUpgrade(ctx context.Context, name string, config types.ContainerConfig, hostConfig *types.HostConfig) error {
 	// TODO

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"net/url"
+
+	"github.com/alibaba/pouch/apis/types"
+)
+
+// ContainerCreateExec creates exec process.
+func (client *APIClient) ContainerCreateExec(ctx context.Context, name string, config *types.ExecCreateConfig) (*types.ExecCreateResp, error) {
+	response, err := client.post(ctx, "/containers/"+name+"/exec", url.Values{}, config, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body := &types.ExecCreateResp{}
+	err = decodeBody(body, response.Body)
+	ensureCloseReader(response)
+
+	return body, err
+}
+
+// ContainerStartExec starts exec process.
+func (client *APIClient) ContainerStartExec(ctx context.Context, execid string, config *types.ExecStartConfig) (net.Conn, *bufio.Reader, error) {
+	header := map[string][]string{
+		"Content-Type": {"text/plain"},
+	}
+
+	return client.hijack(ctx, "/exec/"+execid+"/start", url.Values{}, config, header)
+}
+
+// ContainerExecInspect get exec info with a specified exec id.
+func (client *APIClient) ContainerExecInspect(ctx context.Context, execid string) (*types.ContainerExecInspect, error) {
+	resp, err := client.get(ctx, "/exec/"+execid+"/json", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body := &types.ContainerExecInspect{}
+	err = decodeBody(body, resp.Body)
+	ensureCloseReader(resp)
+
+	return body, err
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -28,6 +28,7 @@ type ContainerAPIClient interface {
 	ContainerAttach(ctx context.Context, name string, stdin bool) (net.Conn, *bufio.Reader, error)
 	ContainerCreateExec(ctx context.Context, name string, config *types.ExecCreateConfig) (*types.ExecCreateResp, error)
 	ContainerStartExec(ctx context.Context, execid string, config *types.ExecStartConfig) (net.Conn, *bufio.Reader, error)
+	ContainerExecInspect(ctx context.Context, execid string) (*types.ContainerExecInspect, error)
 	ContainerGet(ctx context.Context, name string) (*types.ContainerJSON, error)
 	ContainerRename(ctx context.Context, id string, name string) error
 	ContainerRestart(ctx context.Context, name string, timeout string) error

--- a/test/cli_exec_test.go
+++ b/test/cli_exec_test.go
@@ -127,3 +127,13 @@ func (suite *PouchExecSuite) TestExecUlimit(c *check.C) {
 	out := command.PouchRun("exec", name, "sh", "-c", "ulimit -p").Stdout()
 	c.Assert(out, check.Equals, "256\n")
 }
+
+// TestExecExitCode test exit code after exec process exit.
+func (suite *PouchExecSuite) TestExecExitCode(c *check.C) {
+	name := "TestExecExitCode"
+	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+
+	command.PouchRun("exec", name, "sh", "-c", "exit 101").Assert(c, icmd.Expected{ExitCode: 101})
+	command.PouchRun("exec", name, "sh", "-c", "exit 0").Assert(c, icmd.Success)
+}


### PR DESCRIPTION
add ContainerExecInspect client api, refactor container
part in client package.
make exec exit with correct exit code.

Fixes: #344.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add ContainerExecInspect client api, refactor container
part in client package.
make exec exit with correct exit code.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


