### PR TITLE
feature: add snapshotter info into container json

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -315,18 +315,17 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 	}
 
 	container := types.ContainerJSON{
-		ID:         meta.ID,
-		Name:       meta.Name,
-		Image:      meta.Config.Image,
-		Created:    meta.Created,
-		State:      meta.State,
-		Config:     meta.Config,
-		HostConfig: meta.HostConfig,
+		ID:          meta.ID,
+		Name:        meta.Name,
+		Image:       meta.Config.Image,
+		Created:     meta.Created,
+		State:       meta.State,
+		Config:      meta.Config,
+		HostConfig:  meta.HostConfig,
+		Snapshotter: meta.Snapshotter,
 		GraphDriver: &types.GraphDriverData{
-			Name: "overlay2",
-			Data: map[string]string{
-				"BaseFS": meta.BaseFS,
-			},
+			Name: meta.Snapshotter.Name,
+			Data: meta.Snapshotter.Data,
 		},
 	}
 

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2808,6 +2808,8 @@ definitions:
         x-nullable: true
       Config:
         $ref: "#/definitions/ContainerConfig"
+      Snapshotter:
+        $ref: "#/definitions/SnapshotterData"
       GraphDriver:
         $ref: "#/definitions/GraphDriverData"
       Mounts:
@@ -2901,6 +2903,20 @@ definitions:
     description: The status of the container. For example, "running" or "exited".
     type: "string"
     enum: ["created", "running", "stopped", "paused", "restarting", "removing", "exited", "dead"]
+
+  SnapshotterData:
+    description: "Information about a container's snapshotter."
+    type: "object"
+    required: [Name, Data]
+    properties:
+      Name:
+        type: "string"
+        x-nullable: false
+      Data:
+        type: "object"
+        x-nullable: false
+        additionalProperties:
+          type: "string"
 
   GraphDriverData:
     description: "Information about a container's graph driver."

--- a/apis/types/container_json.go
+++ b/apis/types/container_json.go
@@ -88,6 +88,9 @@ type ContainerJSON struct {
 	// The size of files that have been created or changed by this container.
 	SizeRw *int64 `json:"SizeRw,omitempty"`
 
+	// snapshotter
+	Snapshotter *SnapshotterData `json:"Snapshotter,omitempty"`
+
 	// The state of the container.
 	State *ContainerState `json:"State,omitempty"`
 }
@@ -138,6 +141,8 @@ type ContainerJSON struct {
 
 /* polymorph ContainerJSON SizeRw false */
 
+/* polymorph ContainerJSON Snapshotter false */
+
 /* polymorph ContainerJSON State false */
 
 // Validate validates this container JSON
@@ -165,6 +170,11 @@ func (m *ContainerJSON) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateNetworkSettings(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateSnapshotter(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -247,6 +257,25 @@ func (m *ContainerJSON) validateNetworkSettings(formats strfmt.Registry) error {
 		if err := m.NetworkSettings.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("NetworkSettings")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *ContainerJSON) validateSnapshotter(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Snapshotter) { // not required
+		return nil
+	}
+
+	if m.Snapshotter != nil {
+
+		if err := m.Snapshotter.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("Snapshotter")
 			}
 			return err
 		}

--- a/apis/types/snapshotter_data.go
+++ b/apis/types/snapshotter_data.go
@@ -13,10 +13,10 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// GraphDriverData Information about a container's snapshotter.
-// swagger:model GraphDriverData
+// SnapshotterData Information about a container's snapshotter.
+// swagger:model SnapshotterData
 
-type GraphDriverData struct {
+type SnapshotterData struct {
 
 	// data
 	// Required: true
@@ -27,12 +27,12 @@ type GraphDriverData struct {
 	Name string `json:"Name"`
 }
 
-/* polymorph GraphDriverData Data false */
+/* polymorph SnapshotterData Data false */
 
-/* polymorph GraphDriverData Name false */
+/* polymorph SnapshotterData Name false */
 
-// Validate validates this graph driver data
-func (m *GraphDriverData) Validate(formats strfmt.Registry) error {
+// Validate validates this snapshotter data
+func (m *SnapshotterData) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateData(formats); err != nil {
@@ -51,7 +51,7 @@ func (m *GraphDriverData) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *GraphDriverData) validateData(formats strfmt.Registry) error {
+func (m *SnapshotterData) validateData(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Data) { // not required
 		return nil
@@ -60,7 +60,7 @@ func (m *GraphDriverData) validateData(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *GraphDriverData) validateName(formats strfmt.Registry) error {
+func (m *SnapshotterData) validateName(formats strfmt.Registry) error {
 
 	if err := validate.RequiredString("Name", "body", string(m.Name)); err != nil {
 		return err
@@ -70,7 +70,7 @@ func (m *GraphDriverData) validateName(formats strfmt.Registry) error {
 }
 
 // MarshalBinary interface implementation
-func (m *GraphDriverData) MarshalBinary() ([]byte, error) {
+func (m *SnapshotterData) MarshalBinary() ([]byte, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -78,8 +78,8 @@ func (m *GraphDriverData) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary interface implementation
-func (m *GraphDriverData) UnmarshalBinary(b []byte) error {
-	var res GraphDriverData
+func (m *SnapshotterData) UnmarshalBinary(b []byte) error {
+	var res SnapshotterData
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/ctrd/interface.go
+++ b/ctrd/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alibaba/pouch/pkg/jsonstream"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -73,4 +74,7 @@ type SnapshotAPIClient interface {
 	GetSnapshot(ctx context.Context, id string) (snapshots.Info, error)
 	// RemoveSnapshot removes the snapshot by id.
 	RemoveSnapshot(ctx context.Context, id string) error
+	// GetMounts returns the mounts for the active snapshot transaction identified
+	// by key.
+	GetMounts(ctx context.Context, id string) ([]mount.Mount, error)
 }

--- a/ctrd/snapshot.go
+++ b/ctrd/snapshot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd/leases"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/opencontainers/image-spec/identity"
@@ -61,4 +62,18 @@ func (c *Client) RemoveSnapshot(ctx context.Context, id string) error {
 	defer service.Close()
 
 	return service.Remove(ctx, id)
+}
+
+// GetMounts returns the mounts for the active snapshot transaction identified
+// by key.
+func (c *Client) GetMounts(ctx context.Context, id string) ([]mount.Mount, error) {
+	wrapperCli, err := c.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get a containerd grpc client: %v", err)
+	}
+
+	service := wrapperCli.client.SnapshotService(defaultSnapshotterName)
+	defer service.Close()
+
+	return service.Mounts(ctx, id)
 }

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -104,6 +104,11 @@ type ContainerMeta struct {
 	// exec ids
 	ExecIds string `json:"ExecIDs,omitempty"`
 
+	// Snapshotter, GraphDriver is same, keep both
+	// just for compatibility
+	// snapshotter informations of container
+	Snapshotter *types.SnapshotterData `json:"Snapshotter,omitempty"`
+
 	// graph driver
 	GraphDriver *types.GraphDriverData `json:"GraphDriver,omitempty"`
 


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
add snapshotter info into container json

since graphdriver has been replace by snapshotter, so i also rename the GraphDriver to Snapshotter in pouch

### Ⅱ. Does this pull request fix one issue?

fixes #1011 

```
root@osboxes:wanziren -> pouch inspect -f "{{.GraphDriver.Data.UpperDir}}" test
/var/lib/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/1809/fs
```

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
now we has snapshotter info in container json
```
        "Snapshotter": {
            "Data": {
                "MergedDir": "/var/lib/pouch/containerd/state/io.containerd.runtime.v1.linux/default/6933c23039432c5a1b1f88c6d94c39fe8fd88943121ac7af419b2c42a2e440fe/rootfs",
                "UpperDir": "/var/lib/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/1809/fs"
            },
            "Name": "overlayfs"
        },
```

```
root@osboxes:wanziren -> pouch inspect test
[
    {
        "Args": null,
        "Config": {
            "Cmd": [
                "sh"
            ],
            "Entrypoint": null,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Image": "registry.hub.docker.com/library/busybox:latest",
            "OnBuild": null,
            "Shell": null
        },
        "Created": "2018-04-15T17:01:17.359541477Z",
        "GraphDriver": {
            "Data": {
                "MergedDir": "/var/lib/pouch/containerd/state/io.containerd.runtime.v1.linux/default/6933c23039432c5a1b1f88c6d94c39fe8fd88943121ac7af419b2c42a2e440fe/rootfs",
                "UpperDir": "/var/lib/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/1809/fs"
            },
            "Name": "overlayfs"
        },
        "HostConfig": {
            "NetworkMode": "bridge",
            "OomScoreAdj": -500,
            "RestartPolicy": {
                "Name": "no"
            },
            "Runtime": "runc",
            "BlkioDeviceReadBps": null,
            "BlkioDeviceReadIOps": null,
            "BlkioDeviceWriteBps": null,
            "BlkioDeviceWriteIOps": null,
            "BlkioWeightDevice": null,
            "CgroupParent": "default",
            "DeviceCgroupRules": null,
            "Devices": [],
            "MemoryExtra": 0,
            "MemorySwappiness": -1,
            "MemoryWmarkRatio": 0,
            "OomKillDisable": false,
            "Ulimits": null
        },
        "Id": "6933c23039432c5a1b1f88c6d94c39fe8fd88943121ac7af419b2c42a2e440fe",
        "Image": "registry.hub.docker.com/library/busybox:latest",
        "Mounts": [],
        "Name": "test",
        "NetworkSettings": {
            "Networks": {
                "bridge": {
                    "Aliases": null,
                    "EndpointID": "58889c2650a2051fc2ad76d44d1e0fe54044bf043a38f4b74104c4f5c14cde1f",
                    "Gateway": "172.17.0.1",
                    "IPAddress": "172.17.0.2",
                    "IPPrefixLen": 24,
                    "Links": null,
                    "MacAddress": "02:42:ac:11:00:02",
                    "NetworkID": "3f31a4ebae28cb6ec7dbe6950ae736929ee9dac611a49a7d369b8b8bcdfb5e6c"
                }
            },
            "SecondaryIPAddresses": null,
            "SecondaryIPv6Addresses": null
        },
        "Snapshotter": {
            "Data": {
                "MergedDir": "/var/lib/pouch/containerd/state/io.containerd.runtime.v1.linux/default/6933c23039432c5a1b1f88c6d94c39fe8fd88943121ac7af419b2c42a2e440fe/rootfs",
                "UpperDir": "/var/lib/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/1809/fs"
            },
            "Name": "overlayfs"
        },
        "State": {
            "Pid": 10364,
            "StartedAt": "2018-04-15T17:01:17.71750248Z",
            "Status": "running"
        }
    }
]
```

### Ⅴ. Special notes for reviews


