### PR TITLE
feature: add volumes-from for container

### DIFF
--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -80,6 +80,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringVar(&c.utsMode, "uts", "", "UTS namespace to use")
 
 	flagSet.StringSliceVarP(&c.volume, "volume", "v", nil, "Bind mount volumes to container, format is: [source:]<destination>[:mode], [source] can be volume or host's path, <destination> is container's path, [mode] can be \"ro/rw/dr/rr/z/Z/nocopy/private/rprivate/slave/rslave/shared/rshared\"")
+	flagSet.StringSliceVar(&c.volumesFrom, "volumes-from", nil, "set volumes from other containers, format is <container>[:mode]")
 
 	flagSet.StringVarP(&c.workdir, "workdir", "w", "", "Set the working directory in a container")
 

--- a/cli/container.go
+++ b/cli/container.go
@@ -10,18 +10,19 @@ import (
 )
 
 type container struct {
-	labels     []string
-	name       string
-	tty        bool
-	volume     []string
-	runtime    string
-	env        []string
-	entrypoint string
-	workdir    string
-	user       string
-	groupAdd   []string
-	hostname   string
-	rm         bool
+	labels      []string
+	name        string
+	tty         bool
+	volume      []string
+	volumesFrom []string
+	runtime     string
+	env         []string
+	entrypoint  string
+	workdir     string
+	user        string
+	groupAdd    []string
+	hostname    string
+	rm          bool
 
 	blkioWeight          uint16
 	blkioWeightDevice    WeightDevice
@@ -187,8 +188,9 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 		},
 
 		HostConfig: &types.HostConfig{
-			Binds:   c.volume,
-			Runtime: c.runtime,
+			Binds:       c.volume,
+			VolumesFrom: c.volumesFrom,
+			Runtime:     c.runtime,
 			Resources: types.Resources{
 				// cpu
 				CPUShares:  c.cpushare,

--- a/pkg/opts/mountpoint.go
+++ b/pkg/opts/mountpoint.go
@@ -1,0 +1,104 @@
+package opts
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alibaba/pouch/apis/types"
+)
+
+// CheckBind is used to check the volume bind information.
+func CheckBind(b string) ([]string, error) {
+	if strings.Count(b, ":") > 2 {
+		return nil, fmt.Errorf("unknown volume bind: %s", b)
+	}
+
+	arr := strings.SplitN(b, ":", 3)
+	switch len(arr) {
+	case 1:
+		if arr[0] == "" {
+			return nil, fmt.Errorf("unknown volume bind: %s", b)
+		}
+		if arr[0][:1] != "/" {
+			return nil, fmt.Errorf("invalid bind path: %s", arr[0])
+		}
+	case 2, 3:
+		if arr[1] == "" {
+			return nil, fmt.Errorf("unknown volume bind: %s", b)
+		}
+		if arr[1][:1] != "/" {
+			return nil, fmt.Errorf("invalid bind path: %s", arr[1])
+		}
+	default:
+		return nil, fmt.Errorf("unknown volume bind: %s", b)
+	}
+
+	return arr, nil
+}
+
+// ParseVolumesFrom is used to parse the parameter of VolumesFrom.
+func ParseVolumesFrom(volume string) (string, string, error) {
+	if len(volume) == 0 {
+		return "", "", fmt.Errorf("invalid argument volumes-from")
+	}
+
+	parts := strings.Split(volume, ":")
+	containerID := parts[0]
+	mode := ""
+	if len(parts) > 1 {
+		mode = parts[1]
+	}
+
+	if containerID == "" {
+		return "", "", fmt.Errorf("failed to parse container's id")
+	}
+
+	return containerID, mode, nil
+}
+
+// ParseBindMode is used to parse the bind's mode.
+func ParseBindMode(mp *types.MountPoint, mode string) error {
+	mp.RW = true
+	mp.CopyData = true
+
+	defaultMode := 0
+	rwMode := 0
+	labelMode := 0
+	replaceMode := 0
+	copyMode := 0
+	propagationMode := 0
+
+	for _, m := range strings.Split(mode, ",") {
+		switch m {
+		case "":
+			defaultMode++
+		case "ro":
+			mp.RW = false
+			rwMode++
+		case "rw":
+			mp.RW = true
+			rwMode++
+		case "dr", "rr":
+			// direct replace mode, random replace mode
+			mp.Replace = m
+			replaceMode++
+		case "z", "Z":
+			labelMode++
+		case "nocopy":
+			mp.CopyData = false
+			copyMode++
+		case "private", "rprivate", "slave", "rslave", "shared", "rshared":
+			mp.Propagation = m
+			propagationMode++
+		default:
+			return fmt.Errorf("unknown bind mode: %s", mode)
+		}
+	}
+
+	if defaultMode > 1 || rwMode > 1 || replaceMode > 1 || copyMode > 1 || propagationMode > 1 {
+		return fmt.Errorf("invalid bind mode: %s", mode)
+	}
+
+	mp.Mode = mode
+	return nil
+}

--- a/pkg/opts/mountpoint_test.go
+++ b/pkg/opts/mountpoint_test.go
@@ -1,4 +1,4 @@
-package mgr
+package opts
 
 import (
 	"fmt"
@@ -32,7 +32,7 @@ func TestCheckBind(t *testing.T) {
 	}
 
 	for _, p := range parseds {
-		arr, err := checkBind(p.bind)
+		arr, err := CheckBind(p.bind)
 		if p.err {
 			assert.Equal(err, p.expectErr)
 		} else {
@@ -63,7 +63,7 @@ func TestParseBindMode(t *testing.T) {
 
 	for _, p := range parseds {
 		mp := &types.MountPoint{}
-		err := parseBindMode(mp, p.mode)
+		err := ParseBindMode(mp, p.mode)
 		if p.err {
 			assert.Equal(err, p.expectErr)
 		} else {
@@ -71,6 +71,37 @@ func TestParseBindMode(t *testing.T) {
 			assert.Equal(p.expectMountPoint.Mode, mp.Mode)
 			assert.Equal(p.expectMountPoint.RW, mp.RW)
 			assert.Equal(p.expectMountPoint.CopyData, mp.CopyData)
+		}
+	}
+}
+
+func TestParseVolumesFrom(t *testing.T) {
+	assert := assert.New(t)
+
+	type parsed struct {
+		volumesFrom string
+		expectID    string
+		expectMode  string
+		err         bool
+		expectErr   error
+	}
+
+	parseds := []parsed{
+		{volumesFrom: "123456789", expectID: "123456789", expectMode: "", err: false, expectErr: nil},
+		{volumesFrom: "123456789:nocopy", expectID: "123456789", expectMode: "nocopy", err: false, expectErr: nil},
+		{volumesFrom: "123456789:", expectID: "123456789", expectMode: "", err: false, expectErr: nil},
+		{volumesFrom: "", expectID: "", expectMode: "", err: true, expectErr: fmt.Errorf("invalid argument volumes-from")},
+		{volumesFrom: ":", expectID: "", expectMode: "", err: true, expectErr: fmt.Errorf("failed to parse container's id")},
+	}
+
+	for _, p := range parseds {
+		containerID, mode, err := ParseVolumesFrom(p.volumesFrom)
+		if p.err {
+			assert.Equal(err, p.expectErr)
+		} else {
+			assert.NoError(err, p.expectErr)
+			assert.Equal(p.expectID, containerID)
+			assert.Equal(p.expectMode, mode)
 		}
 	}
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add volumes-from for container, container can use the volumes of another
containers. The format is `<containerID>[:mode]`

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #463

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
1. create old container with volume
```
# pouch volume create -n test-volume
CreatedAt:    2018-4-16 14:46:18
Driver:       local
Labels:       map[]
Mountpoint:   /mnt/local/test-volume
Name:         test-volume
Scope:
Status:       map[sifter:Default]

# pouch run -d --name volumes-from-test -v test-volume:/mnt registry.hub.docker.com/library/busybox:latest top
6203151a7134ae9305cbeddba90c874d76eff9bf345cc30a9e34277d89a4d7d4
```
2. stop old container
```
# pouch stop volumes-from-test
```
3. create new container with old container's volume
```
# pouch run -d --volumes-from 6203151a7134ae9305cbeddba90c874d76eff9bf345cc30a9e34277d89a4d7d4 registry.hub.docker.com/library/busybox:latest top
6821c74073fb6a2262b1c00aa2ceaabc47463e06f4e6e718e8827889afd83492
```

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
