### PR TITLE
refactor: refactor config file resolve

### DIFF
--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIterateConfig(t *testing.T) {
+	assert := assert.New(t)
+	origin := map[string]interface{}{
+		"a": "a",
+		"b": "b",
+		"c": "c",
+		"iter1": map[string]interface{}{
+			"i1": "i1",
+			"i2": "i2",
+		},
+		"iter11": map[string]interface{}{
+			"ii1": map[string]interface{}{
+				"iii1": "iii1",
+				"iii2": "iii2",
+			},
+		},
+	}
+
+	expect := map[string]interface{}{
+		"a":    "a",
+		"b":    "b",
+		"c":    "c",
+		"i1":   "i1",
+		"i2":   "i2",
+		"iii1": "iii1",
+		"iii2": "iii2",
+	}
+
+	config := make(map[string]interface{})
+	iterateConfig(origin, config)
+	assert.Equal(config, expect)
+
+	// test nil map will not cause panic
+	config = make(map[string]interface{})
+	iterateConfig(nil, config)
+	assert.Equal(config, map[string]interface{}{})
+}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	osexec "os/exec"
 	"os/signal"
@@ -269,92 +266,9 @@ func checkLxcfsCfg() error {
 
 // load daemon config file
 func loadDaemonFile(cfg *config.Config, flagSet *pflag.FlagSet) error {
-	configFile := cfg.ConfigFile
-	if configFile == "" {
+	if cfg.ConfigFile == "" {
 		return nil
 	}
 
-	contents, err := ioutil.ReadFile(configFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to read contents from config file %s: %s", configFile, err)
-	}
-
-	var fileFlags map[string]interface{}
-	if err = json.NewDecoder(bytes.NewReader(contents)).Decode(&fileFlags); err != nil {
-		return fmt.Errorf("failed to decode json: %s", err)
-	}
-
-	if len(fileFlags) == 0 {
-		return nil
-	}
-
-	// check if invalid or unknown flag exist in config file
-	if err = getUnknownFlags(flagSet, fileFlags); err != nil {
-		return err
-	}
-
-	// check conflict in command line flags and config file
-	if err = getConflictConfigurations(flagSet, fileFlags); err != nil {
-		return err
-	}
-
-	fileConfig := &config.Config{}
-	if err = json.NewDecoder(bytes.NewReader(contents)).Decode(fileConfig); err != nil {
-		return fmt.Errorf("failed to decode json: %s", err)
-	}
-
-	// merge configurations from command line flags and config file
-	err = mergeConfigurations(fileConfig, cfg)
-	return err
-}
-
-// find unknown flag in config file
-func getUnknownFlags(flagSet *pflag.FlagSet, fileFlags map[string]interface{}) error {
-	var unknownFlags []string
-
-	for k, v := range fileFlags {
-		if m, ok := v.(map[string]interface{}); ok {
-			for k = range m {
-				f := flagSet.Lookup(k)
-				if f == nil {
-					unknownFlags = append(unknownFlags, k)
-				}
-			}
-			continue
-		}
-		f := flagSet.Lookup(k)
-		if f == nil {
-			unknownFlags = append(unknownFlags, k)
-		}
-	}
-
-	if len(unknownFlags) > 0 {
-		return fmt.Errorf("unknown flags: %s", strings.Join(unknownFlags, ", "))
-	}
-
-	return nil
-}
-
-// find conflict in command line flags and config file
-func getConflictConfigurations(flagSet *pflag.FlagSet, fileFlags map[string]interface{}) error {
-	var conflictFlags []string
-	flagSet.Visit(func(f *pflag.Flag) {
-		if v, exist := fileFlags[f.Name]; exist {
-			conflictFlags = append(conflictFlags, fmt.Sprintf("from flag: %s and from config file: %s", f.Value.String(), v))
-		}
-	})
-
-	if len(conflictFlags) > 0 {
-		return fmt.Errorf("found conflict flags in command line and config file: %v", strings.Join(conflictFlags, ", "))
-	}
-
-	return nil
-}
-
-// merge flagSet and config file into cfg
-func mergeConfigurations(src *config.Config, dest *config.Config) error {
-	return utils.Merge(src, dest)
+	return cfg.MergeConfigurations(cfg, flagSet)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -122,7 +122,8 @@ func Merge(src, dest interface{}) error {
 	return doMerge(srcVal, destVal)
 }
 
-// doMerge, begin merge action
+// doMerge, begin merge action, note that we will merge slice type,
+// but we do not validate if slice has duplicate values.
 func doMerge(src, dest reflect.Value) error {
 	if !src.IsValid() || !dest.CanSet() || isEmptyValue(src) {
 		return nil
@@ -142,6 +143,9 @@ func doMerge(src, dest reflect.Value) error {
 				return err
 			}
 		}
+
+	case reflect.Slice:
+		dest.Set(reflect.AppendSlice(dest, src))
 
 	default:
 		dest.Set(src)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -138,6 +138,7 @@ func TestMerge(t *testing.T) {
 		Sc bool
 		Sd map[string]string
 		Se nestS
+		Sf []string
 	}
 
 	getIntAddr := func(i int) *int {
@@ -183,6 +184,11 @@ func TestMerge(t *testing.T) {
 			src:      &simple{},
 			dest:     &simple{Sa: 1, Sb: "hello", Sc: true, Sd: map[string]string{"go": "gogo"}, Se: nestS{Na: 22}},
 			expected: &simple{Sa: 1, Sb: "hello", Sc: true, Sd: map[string]string{"go": "gogo"}, Se: nestS{Na: 22}},
+			ok:       true,
+		}, {
+			src:      &simple{Sa: 1, Sc: true, Sd: map[string]string{"go": "gogo"}, Se: nestS{Na: 11}, Sf: []string{"foo"}},
+			dest:     &simple{Sa: 2, Sb: "world", Sc: false, Sd: map[string]string{"go": "gogo"}, Se: nestS{Na: 22}, Sf: []string{"foo"}},
+			expected: &simple{Sa: 1, Sb: "world", Sc: true, Sd: map[string]string{"go": "gogo"}, Se: nestS{Na: 11}, Sf: []string{"foo", "foo"}},
 			ok:       true,
 		},
 	} {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
move daemon config code from main.go to daemon/config/config.go,
suporrts to resolve config file contains nested object.
for eg, resolve file
```
map[string]interface{}{
		"a": "a",
		"b": "b",
		"c": "c",
		"iter1": map[string]interface{}{
			"i1": "i1",
			"i2": "i2",
		},
		"iter11": map[string]interface{}{
			"ii1": map[string]interface{}{
				"iii1": "iii1",
				"iii2": "iii2",
			},
		},
	}

```
to
```
map[string]interface{}{
		"a":    "a",
		"b":    "b",
		"c":    "c",
		"i1":   "i1",
		"i2":   "i2",
		"iii1": "iii1",
		"iii2": "iii2",
	}

```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


