### PR TITLE
feature: add node ip and sn into daemon labels

### DIFF
--- a/pkg/system/machine.go
+++ b/pkg/system/machine.go
@@ -1,0 +1,36 @@
+package system
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// GetSerialNumber gets serial number or a machine.
+func GetSerialNumber() string {
+	var sn string
+	if b, e := exec.Command("dmidecode", "-s", "system-serial-number").CombinedOutput(); e == nil {
+		scanner := bufio.NewScanner(bytes.NewReader(b))
+		for scanner.Scan() {
+			sn = scanner.Text()
+		}
+	}
+	if len(strings.Fields(sn)) != 0 {
+		sn = strings.Fields(sn)[0]
+	}
+	for i := 0; i < 10; i++ {
+		if _, ex := os.Stat("/usr/alisys/dragoon/libexec/armory/bin/armoryinfo"); ex == nil {
+			if b, e := exec.Command("/usr/alisys/dragoon/libexec/armory/bin/armoryinfo", "sn").CombinedOutput(); e == nil {
+				sn = strings.TrimSpace(string(b))
+			}
+		}
+		if sn != "" {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return sn
+}

--- a/pkg/system/network.go
+++ b/pkg/system/network.go
@@ -1,0 +1,26 @@
+package system
+
+import (
+	"bufio"
+	"bytes"
+	"net"
+	"os/exec"
+)
+
+// GetNodeIP fetches node ip via command hostname.
+// If it fails to get this, return empty string directly.
+func GetNodeIP() string {
+	output, err := exec.Command("hostname", "-i").CombinedOutput()
+	if err != nil {
+		return ""
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		ip := scanner.Text()
+		if net.ParseIP(ip) != nil {
+			return ip
+		}
+	}
+	return ""
+}

--- a/test/api_daemon_update_test.go
+++ b/test/api_daemon_update_test.go
@@ -43,6 +43,18 @@ func (suite *APIDaemonUpdateSuite) TestUpdateDaemon(c *check.C) {
 	err = request.DecodeBody(&info, resp.Body)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(info.Labels, check.DeepEquals, labels)
+	for _, label := range labels {
+		isContained := false
+		for _, infoLabel := range info.Labels {
+			if infoLabel == label {
+				isContained = true
+				break
+			}
+		}
+		if !isContained {
+			c.Fatalf("label %s should be in labels in info API", label)
+		}
+	}
+	//c.Assert(info.Labels, check.DeepEquals, labels)
 	// TODO: add checking image proxy
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This PR adds two default labels in pouchd daemon:

* node_ip: this is node ip which is fetched by `hostname -i`;
* serial number: machine's serial number


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none

### Ⅲ. Describe how you did it



### Ⅳ. Describe how to verify it
```
root@ubuntu:~/go/src/github.com/alibaba/pouch# pouch info
Containers: 8
 Running: 8
 Paused: 0
 Stopped: 0
Images:  0
ID:
Name: ubuntu
Server Version: 0.4.0-dev
Storage Driver: overlayfs
Driver Status: []
Logging Driver:
Cgroup Driver:
runc: <nil>
containerd: <nil>
Security Options: []
Kernel Version: 4.4.0-87-generic
Operating System: "Ubuntu 16.04.3 LTS"
OSType: linux
Architecture:
HTTP Proxy:
HTTPS Proxy:
Registry: https://index.docker.io/v1/
Experimental: false
Debug: false
Labels:
  node_ip=127.0.1.1
  SN=0
CPUs: 1
Total Memory: 1.953 GiB
Pouch Root Dir: /var/lib/pouch
LiveRestoreEnabled: false
Daemon Listen Addresses: [unix:///var/run/pouchd.sock]
```


### Ⅴ. Special notes for reviews
none


