### PR TITLE
bugfix: fix daemon panic when meta snapshotter is nil

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1305,7 +1305,9 @@ func (mgr *ContainerManager) markStoppedAndRelease(c *Container, m *ctrd.Message
 	// delete the containerd container, the merged dir
 	// will also be deleted, so we should unset the
 	// container's MergedDir.
-	c.meta.Snapshotter.Data["MergedDir"] = ""
+	if c.meta.Snapshotter != nil && c.meta.Snapshotter.Data != nil {
+		c.meta.Snapshotter.Data["MergedDir"] = ""
+	}
 
 	// update meta
 	if err := c.Write(mgr.Store); err != nil {


### PR DESCRIPTION
fix #1139 