### PR TITLE
feature: parse volumes from image

### DIFF
--- a/ctrd/utils.go
+++ b/ctrd/utils.go
@@ -105,6 +105,11 @@ func rootFSToAPIType(rootFs *v1.RootFS) types.ImageInfoRootFS {
 // ociImageToPouchImage transfer the image from OCI format to Pouch format.
 func ociImageToPouchImage(ociImage v1.Image) (types.ImageInfo, error) {
 	imageConfig := ociImage.Config
+
+	volumes := make(map[string]interface{})
+	for k, obj := range imageConfig.Volumes {
+		volumes[k] = obj
+	}
 	cfg := &types.ContainerConfig{
 		// TODO: add more fields
 		User:       imageConfig.User,
@@ -114,6 +119,7 @@ func ociImageToPouchImage(ociImage v1.Image) (types.ImageInfo, error) {
 		WorkingDir: imageConfig.WorkingDir,
 		Labels:     imageConfig.Labels,
 		StopSignal: imageConfig.StopSignal,
+		Volumes:    volumes,
 	}
 
 	rootFs := rootFSToAPIType(&ociImage.RootFS)

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1452,6 +1452,39 @@ func (mgr *ContainerManager) parseBinds(ctx context.Context, meta *ContainerMeta
 		}
 	}()
 
+	// parse volumes from image
+	image, err := mgr.ImageMgr.GetImage(ctx, meta.Image)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get image: %s", meta.Image)
+	}
+	for dest := range image.Config.Volumes {
+		name := randomid.Generate()
+		if _, exist := meta.Config.Volumes[name]; exist {
+			continue
+		}
+
+		mp := new(types.MountPoint)
+		mp.Name = name
+		mp.Named = true
+		mp.Destination = dest
+
+		mp.Source, mp.Driver, err = mgr.bindVolume(ctx, mp.Name, meta)
+		if err != nil {
+			logrus.Errorf("failed to bind volume: %s, err: %v", mp.Name, err)
+			return errors.Wrap(err, "failed to bind volume")
+		}
+
+		err = opts.ParseBindMode(mp, "")
+		if err != nil {
+			logrus.Errorf("failed to parse mode, err: %v", err)
+			return err
+		}
+
+		meta.Config.Volumes[mp.Name] = mp.Destination
+		meta.Mounts = append(meta.Mounts, mp)
+	}
+
+	// parse volumes from other containers
 	for _, v := range meta.HostConfig.VolumesFrom {
 		var containerID, mode string
 		containerID, mode, err = opts.ParseVolumesFrom(v)
@@ -1631,12 +1664,27 @@ func (mgr *ContainerManager) setMountPointDiskQuota(ctx context.Context, c *Cont
 
 	for _, mp := range c.Mounts {
 		// skip volume mount or replace mode mount
-		if mp.Name != "" || mp.Replace != "" || mp.Source == "" || mp.Destination == "" {
+		if mp.Replace != "" || mp.Source == "" || mp.Destination == "" {
+			logrus.Debugf("skip volume mount or replace mode mount")
 			continue
+		}
+
+		if mp.Name != "" {
+			v, err := mgr.VolumeMgr.Get(ctx, mp.Name)
+			if err != nil {
+				logrus.Warnf("failed to get volume: %s", mp.Name)
+				continue
+			}
+
+			if v.Size() != "" {
+				logrus.Debugf("skip volume: %s with size", mp.Name)
+				continue
+			}
 		}
 
 		// skip non-directory path.
 		if fd, err := os.Stat(mp.Source); err != nil || !fd.IsDir() {
+			logrus.Debugf("skip non-directory path: %s", mp.Source)
 			continue
 		}
 

--- a/daemon/mgr/volume.go
+++ b/daemon/mgr/volume.go
@@ -3,6 +3,7 @@ package mgr
 import (
 	"context"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/alibaba/pouch/pkg/errtypes"
@@ -80,6 +81,11 @@ func (vm *VolumeManager) Create(ctx context.Context, name, driver string, option
 		}
 
 		id.Options[key] = opt
+	}
+
+	// set default volume mount path
+	if mount, ok := id.Options["mount"]; !ok || mount == "" {
+		id.Options["mount"] = path.Dir(vm.core.VolumeMetaPath)
 	}
 
 	return vm.core.CreateVolume(id)

--- a/storage/volume/core_util.go
+++ b/storage/volume/core_util.go
@@ -195,7 +195,7 @@ func checkVolume(v *types.Volume) error {
 }
 
 func buildVolumeConfig(options map[string]string) (*types.VolumeConfig, error) {
-	size := defaultSize
+	size := ""
 	config := &types.VolumeConfig{
 		FileSystem: defaultFileSystem,
 		MountOpt:   defaultFileSystem,
@@ -206,11 +206,13 @@ func buildVolumeConfig(options map[string]string) (*types.VolumeConfig, error) {
 		size = s
 	}
 
-	sizeInt, err := bytefmt.ToMegabytes(size)
-	if err != nil {
-		return nil, err
+	if size != "" {
+		sizeInt, err := bytefmt.ToMegabytes(size)
+		if err != nil {
+			return nil, err
+		}
+		config.Size = strconv.Itoa(int(sizeInt)) + "M"
 	}
-	config.Size = strconv.Itoa(int(sizeInt)) + "M"
 
 	// Parse filesystem
 	if fs, ok := options[optionFS]; ok {

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -378,13 +378,18 @@ func (suite *PouchRunSuite) TestRunWithLocalVolume(c *check.C) {
 	name := funcname
 
 	command.PouchRun("volume", "create", "--name", funcname).Assert(c, icmd.Success)
+	defer func() {
+		command.PouchRun("volume", "remove", funcname).Assert(c, icmd.Success)
+	}()
+
 	command.PouchRun("run", "--name", name, "-v", funcname+":/tmp", busyboxImage, "touch", "/tmp/test").Assert(c, icmd.Success)
+	defer func() {
+		DelContainerForceMultyTime(c, name)
+	}()
 
-	// check the existence of /mnt/local/function/test
-	icmd.RunCommand("stat", "/mnt/local/"+funcname+"/test").Assert(c, icmd.Success)
+	// check the existence of /var/lib/pouch/volume/function/test
+	icmd.RunCommand("stat", DefaultVolumeMountPath+"/"+funcname+"/test").Assert(c, icmd.Success)
 
-	DelContainerForceMultyTime(c, name)
-	command.PouchRun("volume", "remove", funcname).Assert(c, icmd.Success)
 }
 
 // checkFileContains checks the content of fname contains expt

--- a/test/cli_volume_test.go
+++ b/test/cli_volume_test.go
@@ -15,6 +15,11 @@ import (
 	"github.com/gotestyourself/gotestyourself/icmd"
 )
 
+var (
+	// DefaultVolumeMountPath defines the default volume mount path.
+	DefaultVolumeMountPath = DefaultRootDir + "/volume"
+)
+
 // PouchVolumeSuite is the test suite for volume CLI.
 type PouchVolumeSuite struct{}
 
@@ -46,7 +51,7 @@ func (suite *PouchVolumeSuite) TestVolumeWorks(c *check.C) {
 		ExitCode: 1,
 		Err:      "No such file or directory",
 	}
-	err := icmd.RunCommand("stat", "/mnt/local/"+funcname).Compare(expct)
+	err := icmd.RunCommand("stat", DefaultVolumeMountPath+"/"+funcname).Compare(expct)
 	c.Assert(err, check.IsNil)
 
 }
@@ -232,7 +237,7 @@ func (suite *PouchVolumeSuite) TestVolumeBindReplaceMode(c *check.C) {
 
 	found := false
 	for _, m := range got.Mounts {
-		if m.Replace == "dr" && m.Mode == "dr" && m.Source == "/mnt/local/volume_TestVolumeBindReplaceMode/home" {
+		if m.Replace == "dr" && m.Mode == "dr" && m.Source == DefaultVolumeMountPath+"/volume_TestVolumeBindReplaceMode/home" {
 			found = true
 		}
 	}
@@ -303,7 +308,7 @@ func (suite *PouchVolumeSuite) TestVolumeListOptions(c *check.C) {
 		if strings.Contains(line, volumeName) {
 			if !strings.Contains(line, "local") ||
 				!strings.Contains(line, "g") ||
-				!strings.Contains(line, "/mnt/local") {
+				!strings.Contains(line, DefaultVolumeMountPath) {
 				c.Errorf("list result have no driver or name or size or mountpoint, line: %s", line)
 				break
 			}

--- a/test/util_daemon.go
+++ b/test/util_daemon.go
@@ -12,6 +12,11 @@ import (
 	"github.com/gotestyourself/gotestyourself/icmd"
 )
 
+var (
+	// DefaultRootDir defines the default root dir for pouchd.
+	DefaultRootDir = "/var/lib/pouch"
+)
+
 // StartDefaultDaemonDebug starts a deamon with default configuration and debug on.
 func StartDefaultDaemonDebug(args ...string) (*daemon.Config, error) {
 	cfg := daemon.NewConfig()


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
parse volumes from image, so pouchd will create a volume that is defined
in image automatically.
In addition, if volume has no size, the disk quota will set to volume.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
run a container with image what have volume
```
# pouch run --name test -ti --disk-quota 5g --quota-id -1 registry.hub.docker.com/library/mysql:latest df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay         5.0G   16K  5.0G   1% /
tmpfs            64M     0   64M   0% /dev
shm              64M     0   64M   0% /dev/shm
tmpfs            64M     0   64M   0% /run
/dev/sdb2       5.0G   16K  5.0G   1% /var/lib/mysql
tmpfs           2.0G     0  2.0G   0% /sys/firmware
tmpfs           2.0G     0  2.0G   0% /proc/scsi
```

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
