### PR TITLE
feature: upgrade containerd version to v1.0.3

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -154,7 +154,7 @@ As a developer, you may need to build and test Pouch binaries via source code. T
 
 * Linux Kernel 3.10+
 * Go 1.9.0+
-* containerd: 1.0.0
+* containerd: 1.0.3
 * runc: 1.0.0-rc4
 * runv: 1.0.0 (option)
 
@@ -170,8 +170,8 @@ Here are the shell scripts to install `containerd` and `runc`:
 
 ``` shell
 # install containerd
-$ wget https://github.com/containerd/containerd/releases/download/v1.0.0/containerd-1.0.0.linux-amd64.tar.gz
-$ tar -xzvf containerd-1.0.0.linux-amd64.tar.gz -C /usr/local
+$ wget https://github.com/containerd/containerd/releases/download/v1.0.3/containerd-1.0.3.linux-amd64.tar.gz
+$ tar -xzvf containerd-1.0.3.linux-amd64.tar.gz -C /usr/local
 $
 # install runc
 $ wget https://github.com/opencontainers/runc/releases/download/v1.0.0-rc4/runc.amd64 -P /usr/local/bin
@@ -207,7 +207,7 @@ With all needed binaries installed, you could start pouchd via:
 
 ``` shell
 $ pouchd
-INFO[0000] starting containerd                           module=containerd revision=a543c937eb0a05e1636714ee2be70819d745b960 version=v1.0.0-beta.2
+INFO[0000] starting containerd                           module=containerd revision=773c489c9c1b21a6d78b5c538cd395416ec50f88 version=v1.0.3
 INFO[0000] setting subreaper...                          module=containerd
 INFO[0000] loading plugin "io.containerd.content.v1.content"...  module=containerd type=io.containerd.content.v1
 INFO[0000] loading plugin "io.containerd.snapshotter.v1.btrfs"...  module=containerd type=io.containerd.snapshotter.v1

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -21,8 +21,8 @@ function install_pouch ()
 {
 	# install containerd
 	echo "Download and install containerd."
-	wget --quiet https://github.com/containerd/containerd/releases/download/v1.0.0/containerd-1.0.0.linux-amd64.tar.gz -P $TMP
-	tar xf $TMP/containerd-1.0.0.linux-amd64.tar.gz -C $TMP && cp -f $TMP/bin/* /usr/local/bin/
+	wget --quiet https://github.com/containerd/containerd/releases/download/v1.0.3/containerd-1.0.3.linux-amd64.tar.gz -P $TMP
+	tar xf $TMP/containerd-1.0.3.linux-amd64.tar.gz -C $TMP && cp -f $TMP/bin/* /usr/local/bin/
 
 	# install runc
 	echo "Download and install runc."

--- a/hack/package/deb/Makefile
+++ b/hack/package/deb/Makefile
@@ -52,8 +52,8 @@ install: build
 	# install containerd
 	echo "Download and install containerd."
 	[ -d $(TMP) ] || mkdir -p /tmp/tmp.pouch
-	wget --quiet https://github.com/containerd/containerd/releases/download/v1.0.0/containerd-1.0.0.linux-amd64.tar.gz -P $(TMP)
-	tar xf $(TMP)/containerd-1.0.0.linux-amd64.tar.gz -C $(TMP) && cp -f $(TMP)/bin/* debian/pouch/usr/bin/
+	wget --quiet https://github.com/containerd/containerd/releases/download/v1.0.3/containerd-1.0.3.linux-amd64.tar.gz -P $(TMP)
+	tar xf $(TMP)/containerd-1.0.3.linux-amd64.tar.gz -C $(TMP) && cp -f $(TMP)/bin/* debian/pouch/usr/bin/
 
 	# install runc
 	echo "Download and install runc."

--- a/hack/package/rpm/build.sh
+++ b/hack/package/rpm/build.sh
@@ -48,8 +48,8 @@ function build_pouch()
 {
     # install containerd
     echo "Downloading containerd."
-    wget --quiet https://github.com/containerd/containerd/releases/download/v1.0.0/containerd-1.0.0.linux-amd64.tar.gz -P $TMP
-    tar xf $TMP/containerd-1.0.0.linux-amd64.tar.gz -C $TMP && cp -f $TMP/bin/* $BINDIR/
+    wget --quiet https://github.com/containerd/containerd/releases/download/v1.0.3/containerd-1.0.3.linux-amd64.tar.gz -P $TMP
+    tar xf $TMP/containerd-1.0.3.linux-amd64.tar.gz -C $TMP && cp -f $TMP/bin/* $BINDIR/
 
     # install runc
     echo "Downloading runc."

--- a/vendor/github.com/containerd/containerd/Makefile
+++ b/vendor/github.com/containerd/containerd/Makefile
@@ -56,7 +56,7 @@ include Makefile.$(target_os)
 TESTFLAGS ?= -v $(TESTFLAGS_RACE)
 TESTFLAGS_PARALLEL ?= 8
 
-.PHONY: clean all AUTHORS fmt vet lint dco build binaries test integration setup generate protos checkprotos coverage ci check help install uninstall vendor release
+.PHONY: clean all AUTHORS fmt vet lint dco build binaries test integration generate protos checkprotos coverage ci check help install uninstall vendor release
 .DEFAULT: default
 
 all: binaries
@@ -70,20 +70,13 @@ ci: check binaries checkprotos coverage coverage-integration ## to be used by th
 AUTHORS: .mailmap .git/HEAD
 	git log --format='%aN <%aE>' | sort -fu > $@
 
-setup: ## install dependencies
-	@echo "$(WHALE) $@"
-	# TODO(stevvooe): Install these from the vendor directory
-	@go get -u github.com/alecthomas/gometalinter
-	@gometalinter --install
-	@go get -u github.com/stevvooe/protobuild
-
 generate: protos
 	@echo "$(WHALE) $@"
 	@PATH=${ROOTDIR}/bin:${PATH} go generate -x ${PACKAGES}
 
 protos: bin/protoc-gen-gogoctrd ## generate protobuf
 	@echo "$(WHALE) $@"
-	@PATH=${ROOTDIR}/bin:${PATH} protobuild ${PACKAGES}
+	@PATH=${ROOTDIR}/bin:${PATH} protobuild --quiet ${PACKAGES}
 
 check-protos: protos ## check if protobufs needs to be generated again
 	@echo "$(WHALE) $@"
@@ -114,7 +107,7 @@ endif
 
 build: ## build the go packages
 	@echo "$(WHALE) $@"
-	@go build -v ${EXTRA_FLAGS} ${GO_LDFLAGS} ${GO_GCFLAGS} ${PACKAGES}
+	@go build ${EXTRA_FLAGS} ${GO_LDFLAGS} ${GO_GCFLAGS} ${PACKAGES}
 
 test: ## run tests, except integration tests and tests that require root
 	@echo "$(WHALE) $@"
@@ -170,8 +163,8 @@ uninstall:
 coverage: ## generate coverprofiles from the unit tests, except tests that require root
 	@echo "$(WHALE) $@"
 	@rm -f coverage.txt
-	@go test -i ${TESTFLAGS} $(filter-out ${INTEGRATION_PACKAGE},${PACKAGES})
-	( for pkg in $(filter-out ${INTEGRATION_PACKAGE},${PACKAGES}); do \
+	@go test -i ${TESTFLAGS} $(filter-out ${INTEGRATION_PACKAGE},${PACKAGES}) 2> /dev/null
+	@( for pkg in $(filter-out ${INTEGRATION_PACKAGE},${PACKAGES}); do \
 		go test ${TESTFLAGS} \
 			-cover \
 			-coverprofile=profile.out \
@@ -184,8 +177,8 @@ coverage: ## generate coverprofiles from the unit tests, except tests that requi
 
 root-coverage: ## generate coverage profiles for unit tests that require root
 	@echo "$(WHALE) $@"
-	@go test -i ${TESTFLAGS} $(filter-out ${INTEGRATION_PACKAGE},${TEST_REQUIRES_ROOT_PACKAGES})
-	( for pkg in $(filter-out ${INTEGRATION_PACKAGE},${TEST_REQUIRES_ROOT_PACKAGES}); do \
+	@go test -i ${TESTFLAGS} $(filter-out ${INTEGRATION_PACKAGE},${TEST_REQUIRES_ROOT_PACKAGES}) 2> /dev/null
+	@( for pkg in $(filter-out ${INTEGRATION_PACKAGE},${TEST_REQUIRES_ROOT_PACKAGES}); do \
 		go test ${TESTFLAGS} \
 			-cover \
 			-coverprofile=profile.out \

--- a/vendor/github.com/containerd/containerd/RUNC.md
+++ b/vendor/github.com/containerd/containerd/RUNC.md
@@ -2,7 +2,7 @@ containerd is built with OCI support and with support for advanced features prov
 
 We depend on a specific `runc` version when dealing with advanced features.  You should have a specific runc build for development.  The current supported runc commit is:
 
-RUNC_COMMIT = 74a17296470088de3805e138d3d87c62e613dfc4
+RUNC_COMMIT = 9f9c96235cc97674e935002fc3d78361b696a69e
 
 For more information on how to clone and build runc see the runc Building [documentation](https://github.com/opencontainers/runc#building).
 

--- a/vendor/github.com/containerd/containerd/cio/io.go
+++ b/vendor/github.com/containerd/containerd/cio/io.go
@@ -8,7 +8,14 @@ import (
 	"sync"
 )
 
-// Config holds the io configurations.
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		buffer := make([]byte, 32<<10)
+		return &buffer
+	},
+}
+
+// Config holds the IO configurations.
 type Config struct {
 	// Terminal is true if one has been allocated
 	Terminal bool

--- a/vendor/github.com/containerd/containerd/cio/io_windows.go
+++ b/vendor/github.com/containerd/containerd/cio/io_windows.go
@@ -46,7 +46,11 @@ func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
 				log.L.WithError(err).Errorf("failed to accept stdin connection on %s", fifos.In)
 				return
 			}
-			io.Copy(c, ioset.in)
+
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(c, ioset.in, *p)
 			c.Close()
 			l.Close()
 		}()
@@ -72,7 +76,10 @@ func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
 				log.L.WithError(err).Errorf("failed to accept stdout connection on %s", fifos.Out)
 				return
 			}
-			io.Copy(ioset.out, c)
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(ioset.out, c, *p)
 			c.Close()
 			l.Close()
 		}()
@@ -98,7 +105,10 @@ func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
 				log.L.WithError(err).Errorf("failed to accept stderr connection on %s", fifos.Err)
 				return
 			}
-			io.Copy(ioset.err, c)
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(ioset.err, c, *p)
 			c.Close()
 			l.Close()
 		}()

--- a/vendor/github.com/containerd/containerd/content/helpers.go
+++ b/vendor/github.com/containerd/containerd/content/helpers.go
@@ -3,6 +3,7 @@ package content
 import (
 	"context"
 	"io"
+	"io/ioutil"
 	"sync"
 
 	"github.com/containerd/containerd/errdefs"
@@ -76,14 +77,7 @@ func Copy(ctx context.Context, cw Writer, r io.Reader, size int64, expected dige
 	if ws.Offset > 0 {
 		r, err = seekReader(r, ws.Offset, size)
 		if err != nil {
-			if !isUnseekable(err) {
-				return errors.Wrapf(err, "unabled to resume write to %v", ws.Ref)
-			}
-
-			// reader is unseekable, try to move the writer back to the start.
-			if err := cw.Truncate(0); err != nil {
-				return errors.Wrapf(err, "content writer truncate failed")
-			}
+			return errors.Wrapf(err, "unable to resume write to %v", ws.Ref)
 		}
 	}
 
@@ -103,14 +97,9 @@ func Copy(ctx context.Context, cw Writer, r io.Reader, size int64, expected dige
 	return nil
 }
 
-var errUnseekable = errors.New("seek not supported")
-
-func isUnseekable(err error) bool {
-	return errors.Cause(err) == errUnseekable
-}
-
 // seekReader attempts to seek the reader to the given offset, either by
-// resolving `io.Seeker` or by detecting `io.ReaderAt`.
+// resolving `io.Seeker`, by detecting `io.ReaderAt`, or discarding
+// up to the given offset.
 func seekReader(r io.Reader, offset, size int64) (io.Reader, error) {
 	// attempt to resolve r as a seeker and setup the offset.
 	seeker, ok := r.(io.Seeker)
@@ -134,5 +123,17 @@ func seekReader(r io.Reader, offset, size int64) (io.Reader, error) {
 		return sr, nil
 	}
 
-	return r, errors.Wrapf(errUnseekable, "seek to offset %v failed", offset)
+	// well then, let's just discard up to the offset
+	buf := bufPool.Get().(*[]byte)
+	defer bufPool.Put(buf)
+
+	n, err := io.CopyBuffer(ioutil.Discard, io.LimitReader(r, offset), *buf)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to discard to offset")
+	}
+	if n != offset {
+		return nil, errors.Errorf("unable to discard to offset")
+	}
+
+	return r, nil
 }

--- a/vendor/github.com/containerd/containerd/contrib/seccomp/seccomp_default.go
+++ b/vendor/github.com/containerd/containerd/contrib/seccomp/seccomp_default.go
@@ -428,25 +428,8 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		})
 	}
 
-	// make a map of enabled capabilities
-	caps := make(map[string]bool)
+	admin := false
 	for _, c := range sp.Process.Capabilities.Bounding {
-		caps[c] = true
-	}
-	for _, c := range sp.Process.Capabilities.Effective {
-		caps[c] = true
-	}
-	for _, c := range sp.Process.Capabilities.Inheritable {
-		caps[c] = true
-	}
-	for _, c := range sp.Process.Capabilities.Permitted {
-		caps[c] = true
-	}
-	for _, c := range sp.Process.Capabilities.Ambient {
-		caps[c] = true
-	}
-
-	for c := range caps {
 		switch c {
 		case "CAP_DAC_READ_SEARCH":
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
@@ -455,6 +438,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				Args:   []specs.LinuxSeccompArg{},
 			})
 		case "CAP_SYS_ADMIN":
+			admin = true
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 				Names: []string{
 					"bpf",
@@ -542,7 +526,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		}
 	}
 
-	if !caps["CAP_SYS_ADMIN"] {
+	if !admin {
 		switch runtime.GOARCH {
 		case "s390", "s390x":
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{

--- a/vendor/github.com/containerd/containerd/dialer/dialer.go
+++ b/vendor/github.com/containerd/containerd/dialer/dialer.go
@@ -42,7 +42,7 @@ func Dialer(address string, timeout time.Duration) (net.Conn, error) {
 		close(stopC)
 		go func() {
 			dr := <-synC
-			if dr != nil {
+			if dr != nil && dr.c != nil {
 				dr.c.Close()
 			}
 		}()

--- a/vendor/github.com/containerd/containerd/fs/diff.go
+++ b/vendor/github.com/containerd/containerd/fs/diff.go
@@ -222,10 +222,8 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 		c1 = make(chan *currentPath)
 		c2 = make(chan *currentPath)
 
-		f1, f2         *currentPath
-		rmdir          string
-		lastEmittedDir = string(filepath.Separator)
-		parents        []os.FileInfo
+		f1, f2 *currentPath
+		rmdir  string
 	)
 	g.Go(func() error {
 		defer close(c1)
@@ -260,10 +258,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				continue
 			}
 
-			var (
-				f    os.FileInfo
-				emit = true
-			)
+			var f os.FileInfo
 			k, p := pathChange(f1, f2)
 			switch k {
 			case ChangeKindAdd:
@@ -278,7 +273,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				if rmdir != "" && strings.HasPrefix(f1.path, rmdir) {
 					f1 = nil
 					continue
-				} else if rmdir == "" && f1.f.IsDir() {
+				} else if f1.f.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""
@@ -299,83 +294,17 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				f2 = nil
 				if same {
 					if !isLinked(f) {
-						emit = false
+						continue
 					}
 					k = ChangeKindUnmodified
 				}
 			}
-			if emit {
-				emittedDir, emitParents := commonParents(lastEmittedDir, p, parents)
-				for _, pf := range emitParents {
-					p := filepath.Join(emittedDir, pf.Name())
-					if err := changeFn(ChangeKindUnmodified, p, pf, nil); err != nil {
-						return err
-					}
-					emittedDir = p
-				}
-
-				if err := changeFn(k, p, f, nil); err != nil {
-					return err
-				}
-
-				if f != nil && f.IsDir() {
-					lastEmittedDir = p
-				} else {
-					lastEmittedDir = emittedDir
-				}
-
-				parents = parents[:0]
-			} else if f.IsDir() {
-				lastEmittedDir, parents = commonParents(lastEmittedDir, p, parents)
-				parents = append(parents, f)
+			if err := changeFn(k, p, f, nil); err != nil {
+				return err
 			}
 		}
 		return nil
 	})
 
 	return g.Wait()
-}
-
-func commonParents(base, updated string, dirs []os.FileInfo) (string, []os.FileInfo) {
-	if basePrefix := makePrefix(base); strings.HasPrefix(updated, basePrefix) {
-		var (
-			parents []os.FileInfo
-			last    = base
-		)
-		for _, d := range dirs {
-			next := filepath.Join(last, d.Name())
-			if strings.HasPrefix(updated, makePrefix(last)) {
-				parents = append(parents, d)
-				last = next
-			} else {
-				break
-			}
-		}
-		return base, parents
-	}
-
-	baseS := strings.Split(base, string(filepath.Separator))
-	updatedS := strings.Split(updated, string(filepath.Separator))
-	commonS := []string{string(filepath.Separator)}
-
-	min := len(baseS)
-	if len(updatedS) < min {
-		min = len(updatedS)
-	}
-	for i := 0; i < min; i++ {
-		if baseS[i] == updatedS[i] {
-			commonS = append(commonS, baseS[i])
-		} else {
-			break
-		}
-	}
-
-	return filepath.Join(commonS...), []os.FileInfo{}
-}
-
-func makePrefix(d string) string {
-	if d == "" || d[len(d)-1] != filepath.Separator {
-		return d + string(filepath.Separator)
-	}
-	return d
 }

--- a/vendor/github.com/containerd/containerd/image.go
+++ b/vendor/github.com/containerd/containerd/image.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/rootfs"
-	"github.com/containerd/containerd/snapshots"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -108,13 +107,23 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 		unpacked bool
 	)
 	for _, layer := range layers {
-		labels := map[string]string{
-			"containerd.io/uncompressed": layer.Diff.Digest.String(),
-		}
-
-		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a, snapshots.WithLabels(labels))
+		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a)
 		if err != nil {
 			return err
+		}
+
+		if unpacked {
+			// Set the uncompressed label after the uncompressed
+			// digest has been verified through apply.
+			cinfo := content.Info{
+				Digest: layer.Blob.Digest,
+				Labels: map[string]string{
+					"containerd.io/uncompressed": layer.Diff.Digest.String(),
+				},
+			}
+			if _, err := cs.Update(ctx, cinfo, "labels.containerd.io/uncompressed"); err != nil {
+				return err
+			}
 		}
 
 		chain = append(chain, layer.Diff.Digest)

--- a/vendor/github.com/containerd/containerd/rootfs/diff.go
+++ b/vendor/github.com/containerd/containerd/rootfs/diff.go
@@ -39,7 +39,7 @@ func Diff(ctx context.Context, snapshotID string, sn snapshots.Snapshotter, d di
 		if err != nil {
 			return ocispec.Descriptor{}, err
 		}
-		defer sn.Remove(ctx, lowerKey)
+		defer sn.Remove(ctx, upperKey)
 	}
 
 	return d.DiffMounts(ctx, lower, upper, opts...)

--- a/vendor/github.com/containerd/containerd/sys/socket_unix.go
+++ b/vendor/github.com/containerd/containerd/sys/socket_unix.go
@@ -7,11 +7,16 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
 // CreateUnixSocket creates a unix socket and returns the listener
 func CreateUnixSocket(path string) (net.Listener, error) {
+	// BSDs have a 104 limit
+	if len(path) > 104 {
+		return nil, errors.Errorf("%q: unix socket path too long (> 104)", path)
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0660); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containerd/containerd/vendor.conf
+++ b/vendor/github.com/containerd/containerd/vendor.conf
@@ -1,7 +1,7 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
-github.com/containerd/go-runc ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7
+github.com/containerd/go-runc 4f6e87ae043f859a38255247b49c9abc262d002f
 github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
-github.com/containerd/cgroups 29da22c6171a4316169f9205ab6c49f59b5b852f
+github.com/containerd/cgroups fe281dd265766145e943a034aa41086474ea6130
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
@@ -16,9 +16,9 @@ github.com/docker/go-units v0.3.1
 github.com/gogo/protobuf v0.5
 github.com/golang/protobuf 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
 github.com/opencontainers/runtime-spec v1.0.0
-github.com/opencontainers/runc 74a17296470088de3805e138d3d87c62e613dfc4
+github.com/opencontainers/runc 9f9c96235cc97674e935002fc3d78361b696a69e
 github.com/sirupsen/logrus v1.0.0
-github.com/containerd/btrfs cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3
+github.com/containerd/btrfs 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244
 github.com/stretchr/testify v1.1.4
 github.com/davecgh/go-spew v1.1.0
 github.com/pmezard/go-difflib v1.0.0
@@ -32,13 +32,12 @@ golang.org/x/sys 314a259e304ff91bd6985da2a7149bbf91237993 https://github.com/gol
 github.com/opencontainers/image-spec v1.0.0
 github.com/containerd/continuity cf279e6ac893682272b4479d4c67fd3abf878b4e
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
-github.com/BurntSushi/toml v0.2.0-21-g9906417
+github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
 github.com/Microsoft/go-winio v0.4.4
 github.com/Microsoft/hcsshim v0.6.7
-github.com/Microsoft/opengcs v0.3.2
 github.com/boltdb/bolt e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 github.com/dmcgowan/go-tar go1.10
-github.com/stevvooe/ttrpc 76e68349ad9ab4d03d764c713826d31216715e4f
+github.com/stevvooe/ttrpc d4528379866b0ce7e9d71f3eb96f0582fc374577

--- a/vendor/github.com/containerd/containerd/version/version.go
+++ b/vendor/github.com/containerd/containerd/version/version.go
@@ -5,7 +5,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.0.0+unknown"
+	Version = "1.0.3+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -48,274 +48,364 @@
 			"revisionTime": "2017-09-25T15:48:32Z"
 		},
 		{
-			"checksumSHA1": "3tWZA853zC/N1yoGDEkkye76Vv0=",
+			"checksumSHA1": "1ny6UV3Oq4kaqpQtM8bs9W9e3vw=",
 			"path": "github.com/containerd/containerd",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "V/ZFMKUvTntwELx2zTjn/9IFUqw=",
 			"path": "github.com/containerd/containerd/api/services/containers/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "ytKOuPbkTKeohUCQic4Lj84Ziok=",
 			"path": "github.com/containerd/containerd/api/services/content/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "eh6ojTLkyD74CdIZQ3eXfZ+PXe4=",
 			"path": "github.com/containerd/containerd/api/services/diff/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "POopGyHC86XK1x1JiWM87GTAn2Y=",
 			"path": "github.com/containerd/containerd/api/services/events/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "1dxdRVo/M+qxju/g3qJRF7YTHM0=",
 			"path": "github.com/containerd/containerd/api/services/images/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "1ZMMqlWf7pULtxt5nyuPH80d0cM=",
 			"path": "github.com/containerd/containerd/api/services/introspection/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "zXk5Iysb2WwjIqR1aI4Q5Zf3z6Q=",
 			"path": "github.com/containerd/containerd/api/services/leases/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "k3TKbtkLHuLwnkwyC2GzvVSFCvg=",
 			"path": "github.com/containerd/containerd/api/services/namespaces/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "p92B86Iterov0pPTRJeQhplmajI=",
 			"path": "github.com/containerd/containerd/api/services/snapshots/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "mAY8zwmpZNpUwADPN9Z49ms2RHg=",
 			"path": "github.com/containerd/containerd/api/services/tasks/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "Dg8dXaHGBe0cl0i2TYoF1JGosKM=",
 			"path": "github.com/containerd/containerd/api/services/version/v1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "ipG7UbQLw+D8/a4ozTU4jeYy0ms=",
 			"path": "github.com/containerd/containerd/api/types",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "SJUjrP+5a7rPcAI1b2cCyAF6tZ0=",
 			"path": "github.com/containerd/containerd/api/types/task",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
-			"checksumSHA1": "kJfhXsAcyS+vNMFrDuKmHCwVjbU=",
+			"checksumSHA1": "vmjGd4DU++wHR9j8jVfqnfJ1T10=",
 			"path": "github.com/containerd/containerd/cio",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "y6g/5Ap0iZ4raZiXxrSgrFK5uwY=",
 			"path": "github.com/containerd/containerd/containers",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
-			"checksumSHA1": "roT1XMBn4EeuAeHbnJ4X28xEY3k=",
+			"checksumSHA1": "HKpNJauKC9EFE1TRpb0OEWz7Z8k=",
 			"path": "github.com/containerd/containerd/content",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
-			"checksumSHA1": "IqqBK06hDnn7N1nd9YT9mwrr96w=",
+			"checksumSHA1": "dSA87kF3LtOulayUERfYM7pyI8E=",
 			"path": "github.com/containerd/containerd/contrib/seccomp",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
-			"checksumSHA1": "5q0XKUS32i7Ya0eRUaLEKGTdALw=",
+			"checksumSHA1": "HaGYavEIgh2i7/BlY1Cz0BUCzuk=",
 			"path": "github.com/containerd/containerd/dialer",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "ZaDOX0+f+4i5QbEX1Cj9IqTO3Dg=",
 			"path": "github.com/containerd/containerd/diff",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "UDnsOzIZ7OjbJwzsnNIjSLv2NPA=",
 			"path": "github.com/containerd/containerd/errdefs",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "kFY+ix4N/7RjphrMHysZ1fOFDaU=",
 			"path": "github.com/containerd/containerd/events",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "JIxNXnUE8cXHSs0RfR06HDg8OKA=",
 			"path": "github.com/containerd/containerd/events/exchange",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "6niiX9GDBEsr/Fspe4kKxo3LP40=",
 			"path": "github.com/containerd/containerd/filters",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
-			"checksumSHA1": "bD3NnBfoTKHZRsAvy29iApaH0zY=",
+			"checksumSHA1": "T3Mh6YtUWwvGvWISfjzV0JlUNSI=",
 			"path": "github.com/containerd/containerd/fs",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "r8cyY1bjwO/nYmhH4mZpljtKGsI=",
 			"path": "github.com/containerd/containerd/identifiers",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "pUDS7qJrPgsAhX3BK1CWvX+ocT4=",
 			"path": "github.com/containerd/containerd/images",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "LPyRLtrZmGUuVtKGR2YOEFuUYgE=",
 			"path": "github.com/containerd/containerd/leases",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "S/WJn5s0172DnsFQPUaKyMKV+y4=",
 			"path": "github.com/containerd/containerd/linux/runctypes",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "GAO2s2joEUZTNqjiGnYHSKNcKBs=",
 			"path": "github.com/containerd/containerd/log",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "9TAbHDo2J6zlyRRTdqX7sHLMM0A=",
 			"path": "github.com/containerd/containerd/mount",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "DQCB4LvBRb2YbKpX46qHUK5KUr4=",
 			"path": "github.com/containerd/containerd/namespaces",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
-			"checksumSHA1": "/9N2aS6wwe6wTw6hL+Fp0myyCQQ=",
+			"checksumSHA1": "cI6H8ev4txgLraSFUDMGcRVqrcg=",
 			"path": "github.com/containerd/containerd/oci",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "cHlAhW3GRpfMAE22/lbjL3Z9a0s=",
 			"path": "github.com/containerd/containerd/platforms",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "2JrdtO+2kyFupHzWn+EsQ0DVgAU=",
 			"path": "github.com/containerd/containerd/plugin",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "hEqrZG0ijylicdei1Kc4IScAshI=",
 			"path": "github.com/containerd/containerd/progress",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "1QZqDFrsA0ehoxh14hzwW/knL4Q=",
 			"path": "github.com/containerd/containerd/protobuf/google/rpc",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "YnpU8vh+PQIJ2pC+hdSAjYAAb8k=",
 			"path": "github.com/containerd/containerd/reference",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "nndE0L9SBDzGUNqZN562aIQC3uA=",
 			"path": "github.com/containerd/containerd/remotes",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "PriKCFVJIjLn3y1jLTNb+9RsG7A=",
 			"path": "github.com/containerd/containerd/remotes/docker",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "CHt96fWy3eXjcCqxJg5SXjkofCA=",
 			"path": "github.com/containerd/containerd/remotes/docker/schema1",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
-			"checksumSHA1": "OuOr/HVV29fKoThNjloWKOb13YE=",
+			"checksumSHA1": "eHFZrtLsqkippwdT4O1cOnadqac=",
 			"path": "github.com/containerd/containerd/rootfs",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "DzMZUrndYzzDT7nqwcxHq2oC8Kc=",
 			"path": "github.com/containerd/containerd/snapshots",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
-			"checksumSHA1": "cySW+bDNOg3QtSzk+GoHvIOJjB0=",
+			"checksumSHA1": "8u2ZojhEDaoA4Co6usLof+TKj78=",
 			"path": "github.com/containerd/containerd/sys",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
-			"checksumSHA1": "+YDgb2+Z+6ySwEF7z/jEUv8XaGo=",
+			"checksumSHA1": "grEvoaogoFLNPAH7XjjNgau3SNY=",
 			"path": "github.com/containerd/containerd/version",
-			"revision": "89623f28b87a6004d4b785663257362d1658a729",
-			"revisionTime": "2017-12-05T05:15:20Z"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "Pse/Y1lqxmWpXKh7dpbO9S+vKvU=",


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Upgrade containerd to make the pouchd stable.

The version of containerd will be changed from v1.0.0 to v1.0.3

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1141 

### Ⅲ. Describe how you did it

```
# for the vendor
$ govendor fetch github.com/containerd/containerd@v1.0.3
```

### Ⅳ. Describe how to verify it

It's the dependency upgrade. I have tested `pouch run -it busybox /bin/sh` in local and it passed.
It should be covered by CI.

### Ⅴ. Special notes for reviews

NONE
