### PR TITLE
feature: add lxcfs enabled info to 'pouch info'

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1352,6 +1352,13 @@ definitions:
         x-nullable: false
         default: false
         example: false
+      LxcfsEnabled:
+        description: |
+          Indicates if lxcfs is enabled.
+        type: "boolean"
+        x-nullable: false
+        default: false
+        example: false
       ContainerdCommit:
         $ref: "#/definitions/Commit"
       RuncCommit:

--- a/apis/types/graph_driver_data.go
+++ b/apis/types/graph_driver_data.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// GraphDriverData Information about a container's snapshotter.
+// GraphDriverData Information about a container's graph driver.
 // swagger:model GraphDriverData
 
 type GraphDriverData struct {

--- a/apis/types/system_info.go
+++ b/apis/types/system_info.go
@@ -139,6 +139,10 @@ type SystemInfo struct {
 	//
 	LoggingDriver string `json:"LoggingDriver,omitempty"`
 
+	// Indicates if lxcfs is enabled.
+	//
+	LxcfsEnabled bool `json:"LxcfsEnabled,omitempty"`
+
 	// Total amount of physical memory available on the host, in kilobytes (kB).
 	//
 	MemTotal int64 `json:"MemTotal,omitempty"`
@@ -250,6 +254,8 @@ type SystemInfo struct {
 /* polymorph SystemInfo LiveRestoreEnabled false */
 
 /* polymorph SystemInfo LoggingDriver false */
+
+/* polymorph SystemInfo LxcfsEnabled false */
 
 /* polymorph SystemInfo MemTotal false */
 

--- a/cli/info.go
+++ b/cli/info.go
@@ -101,6 +101,7 @@ func prettyPrintInfo(cli *Cli, info *types.SystemInfo) error {
 	fmt.Fprintln(os.Stdout, "Total Memory: "+units.BytesSize(float64(info.MemTotal)))
 	fmt.Fprintln(os.Stdout, "Pouch Root Dir:", info.PouchRootDir)
 	fmt.Fprintln(os.Stdout, "LiveRestoreEnabled:", info.LiveRestoreEnabled)
+	fmt.Fprintln(os.Stdout, "LxcfsEnabled:", info.LxcfsEnabled)
 	if info.RegistryConfig != nil && (len(info.RegistryConfig.InsecureRegistryCIDRs) > 0 || len(info.RegistryConfig.IndexConfigs) > 0) {
 		fmt.Fprintln(os.Stdout, "Insecure Registries:")
 		for _, registry := range info.RegistryConfig.IndexConfigs {

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -120,6 +120,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		Labels:             mgr.config.Labels,
 		// LiveRestoreEnabled: ,
 		// LoggingDriver: ,
+		LxcfsEnabled:    mgr.config.IsLxcfsEnabled,
 		MemTotal:        totalMem,
 		Name:            hostname,
 		NCPU:            int64(runtime.NumCPU()),


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This pr enhance the output of 'pouch info' by adding the info of lxcfs-enabled.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1137 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
```bash
$ lxcfs /var/lib/lxcfs # launch lxcfs
$ pouchd --enable-lxcfs
$ pouch info
Containers: 0
 Running: 0
 Paused: 0
 Stopped: 0
Images:  0
ID: 
Name: vm
Server Version: 0.4.0-dev
Storage Driver: overlayfs
Driver Status: []
Logging Driver: 
Cgroup Driver: 
runc: <nil>
containerd: <nil>
Security Options: []
Kernel Version: 4.13.0-38-generic
Operating System: "Ubuntu 16.04.3 LTS"
OSType: linux
Architecture: 
HTTP Proxy: 
HTTPS Proxy: 
Registry: https://index.docker.io/v1/
Experimental: false
Debug: false
Labels:
  node_ip=192.168.199.128
  SN=Parallels-11
CPUs: 4
Total Memory: 3.847 GiB
Pouch Root Dir: /var/lib/pouch
LiveRestoreEnabled: false
LxcfsEnabled: true
Daemon Listen Addresses: [unix:///var/run/pouchd.sock]

```

### Ⅴ. Special notes for reviews

