### PR TITLE
feature: refactor exec to enable configure stdin

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -44,14 +44,7 @@ func (c *Client) ExecContainer(ctx context.Context, process *Process) error {
 		return err
 	}
 
-	// create io
-	// var io containerd.IOCreation
-	var io cio.Creation
-	if process.P.Terminal {
-		io = cio.NewIOWithTerminal(process.IO.Stdin, process.IO.Stdout, process.IO.Stderr, true)
-	} else {
-		io = cio.NewIO(process.IO.Stdin, process.IO.Stdout, process.IO.Stderr)
-	}
+	io := containerio.NewIOWithTerminal(process.IO.Stdin, process.IO.Stdout, process.IO.Stderr, process.P.Terminal, process.IO.Stdin != nil)
 
 	// create exec process in container
 	execProcess, err := pack.task.Exec(ctx, process.ExecID, process.P, io)
@@ -401,12 +394,7 @@ func (c *Client) createContainer(ctx context.Context, ref, id string, container 
 func (c *Client) createTask(ctx context.Context, id string, container containerd.Container, cc *Container) (p *containerPack, err0 error) {
 	var pack *containerPack
 
-	var io cio.Creation
-	if cc.Spec.Process.Terminal {
-		io = cio.NewIOWithTerminal(cc.IO.Stdin, cc.IO.Stdout, cc.IO.Stderr, true)
-	} else {
-		io = cio.NewIO(cc.IO.Stdin, cc.IO.Stdout, cc.IO.Stderr)
-	}
+	io := containerio.NewIOWithTerminal(cc.IO.Stdin, cc.IO.Stdout, cc.IO.Stderr, cc.Spec.Process.Terminal, cc.IO.Stdin != nil)
 
 	// create task
 	task, err := container.NewTask(ctx, io)

--- a/daemon/containerio/cio.go
+++ b/daemon/containerio/cio.go
@@ -1,0 +1,202 @@
+package containerio
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	containerdio "github.com/containerd/containerd/cio"
+	"github.com/containerd/fifo"
+)
+
+// cio is a basic container IO implementation.
+type cio struct {
+	config containerdio.Config
+
+	closer *wgCloser
+}
+
+func (c *cio) Config() containerdio.Config {
+	return c.config
+}
+
+func (c *cio) Cancel() {
+	if c.closer == nil {
+		return
+	}
+	c.closer.Cancel()
+}
+
+func (c *cio) Wait() {
+	if c.closer == nil {
+		return
+	}
+	c.closer.Wait()
+}
+
+func (c *cio) Close() error {
+	if c.closer == nil {
+		return nil
+	}
+	return c.closer.Close()
+}
+
+// FIFOSet is a set of fifos for use with tasks
+type FIFOSet struct {
+	// Dir is the directory holding the task fifos
+	Dir string
+	// In, Out, and Err fifo paths
+	In, Out, Err string
+	// Terminal returns true if a terminal is being used for the task
+	Terminal bool
+}
+
+// NewFifos returns a new set of fifos for the task
+func NewFifos(id string, stdin bool) (*FIFOSet, error) {
+	root := "/run/containerd/fifo"
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return nil, err
+	}
+	dir, err := ioutil.TempDir(root, "")
+	if err != nil {
+		return nil, err
+	}
+	fifos := &FIFOSet{
+		Dir: dir,
+		In:  filepath.Join(dir, id+"-stdin"),
+		Out: filepath.Join(dir, id+"-stdout"),
+		Err: filepath.Join(dir, id+"-stderr"),
+	}
+
+	if !stdin {
+		fifos.In = ""
+	}
+
+	return fifos, nil
+}
+
+type ioSet struct {
+	in       io.Reader
+	out, err io.Writer
+}
+
+type wgCloser struct {
+	wg     *sync.WaitGroup
+	dir    string
+	set    []io.Closer
+	cancel context.CancelFunc
+}
+
+func (g *wgCloser) Wait() {
+	g.wg.Wait()
+}
+
+func (g *wgCloser) Close() error {
+	for _, f := range g.set {
+		f.Close()
+	}
+	if g.dir != "" {
+		return os.RemoveAll(g.dir)
+	}
+	return nil
+}
+
+func (g *wgCloser) Cancel() {
+	g.cancel()
+}
+
+func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
+	var (
+		f           io.ReadWriteCloser
+		set         []io.Closer
+		ctx, cancel = context.WithCancel(context.Background())
+		wg          = &sync.WaitGroup{}
+	)
+	defer func() {
+		if err != nil {
+			for _, f := range set {
+				f.Close()
+			}
+			cancel()
+		}
+	}()
+
+	if fifos.In != "" {
+		if f, err = fifo.OpenFifo(ctx, fifos.In, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+			return nil, err
+		}
+		set = append(set, f)
+		go func(w io.WriteCloser) {
+			io.Copy(w, ioset.in)
+			w.Close()
+		}(f)
+	}
+
+	if f, err = fifo.OpenFifo(ctx, fifos.Out, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+		return nil, err
+	}
+	set = append(set, f)
+	wg.Add(1)
+	go func(r io.ReadCloser) {
+		io.Copy(ioset.out, r)
+		r.Close()
+		wg.Done()
+	}(f)
+
+	if f, err = fifo.OpenFifo(ctx, fifos.Err, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+		return nil, err
+	}
+	set = append(set, f)
+
+	if !tty {
+		wg.Add(1)
+		go func(r io.ReadCloser) {
+			io.Copy(ioset.err, r)
+			r.Close()
+			wg.Done()
+		}(f)
+	}
+	return &wgCloser{
+		wg:     wg,
+		dir:    fifos.Dir,
+		set:    set,
+		cancel: cancel,
+	}, nil
+}
+
+// NewIOWithTerminal creates a new io set with the provied io.Reader/Writers for use with a terminal
+func NewIOWithTerminal(stdin io.Reader, stdout, stderr io.Writer, terminal bool, stdinEnable bool) containerdio.Creation {
+	return func(id string) (_ containerdio.IO, err error) {
+		paths, err := NewFifos(id, stdinEnable)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if err != nil && paths.Dir != "" {
+				os.RemoveAll(paths.Dir)
+			}
+		}()
+		cfg := containerdio.Config{
+			Terminal: terminal,
+			Stdout:   paths.Out,
+			Stderr:   paths.Err,
+			Stdin:    paths.In,
+		}
+		i := &cio{config: cfg}
+		set := &ioSet{
+			in:  stdin,
+			out: stdout,
+			err: stderr,
+		}
+		closer, err := copyIO(paths, set, cfg.Terminal)
+		if err != nil {
+			return nil, err
+		}
+		i.closer = closer
+		return i, nil
+	}
+}

--- a/daemon/containerio/options.go
+++ b/daemon/containerio/options.go
@@ -12,6 +12,7 @@ import (
 type Option struct {
 	id            string
 	rootDir       string
+	stdin         bool
 	backends      map[string]struct{}
 	hijack        http.Hijacker
 	hijackUpgrade bool
@@ -43,6 +44,13 @@ func WithID(id string) func(*Option) {
 func WithRootDir(dir string) func(*Option) {
 	return func(opt *Option) {
 		opt.rootDir = dir
+	}
+}
+
+// WithStdin specified whether open the container's stdin.
+func WithStdin(stdin bool) func(*Option) {
+	return func(opt *Option) {
+		opt.stdin = stdin
 	}
 }
 

--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -645,11 +645,20 @@ func (c *CriManager) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 
 	labels, annotations := extractLabels(container.Config.Labels)
 
+	imageRef := container.Image
+	imageInfo, err := c.ImageMgr.GetImage(ctx, strings.TrimPrefix(imageRef, "sha256:"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get image %s: %v", imageRef, err)
+	}
+	if len(imageInfo.RepoDigests) > 0 {
+		imageRef = imageInfo.RepoDigests[0]
+	}
+
 	status := &runtime.ContainerStatus{
 		Id:          container.ID,
 		Metadata:    metadata,
 		Image:       &runtime.ImageSpec{Image: container.Config.Image},
-		ImageRef:    container.Image,
+		ImageRef:    imageRef,
 		Mounts:      mounts,
 		ExitCode:    exitCode,
 		State:       state,

--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -348,7 +348,7 @@ func (suite *PouchNetworkSuite) TestNetworkPortMapping(c *check.C) {
 func (suite *PouchNetworkSuite) TestNetworkDisconnect(c *check.C) {
 	name := "TestNetworkDisconnect"
 
-	command.PouchRun("run", "-d", "--name", name, "--net", "bridge", busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "--name", name, "--net", "bridge", busyboxImage, "top").Assert(c, icmd.Success)
 
 	inspectInfo := command.PouchRun("inspect", name).Stdout()
 	metaJSON := []types.ContainerJSON{}

--- a/test/cli_ps_test.go
+++ b/test/cli_ps_test.go
@@ -40,7 +40,7 @@ func (suite *PouchPsSuite) TestPsWorks(c *check.C) {
 
 	// create
 	{
-		command.PouchRun("create", "--name", name, busyboxImage).Assert(c, icmd.Success)
+		command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 		res := command.PouchRun("ps", "-a").Assert(c, icmd.Success)
 		kv := psToKV(res.Combined())

--- a/test/cli_restart_test.go
+++ b/test/cli_restart_test.go
@@ -34,7 +34,7 @@ func (suite *PouchRestartSuite) TearDownTest(c *check.C) {
 func (suite *PouchRestartSuite) TestPouchRestart(c *check.C) {
 	name := "TestPouchRestart"
 
-	command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	res := command.PouchRun("restart", "-t", "1", name)
 	c.Assert(res.Error, check.IsNil)

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -42,7 +42,7 @@ func (suite *PouchRunSuite) TearDownTest(c *check.C) {
 func (suite *PouchRunSuite) TestRun(c *check.C) {
 	name := "test-run"
 
-	command.PouchRun("run", "-d", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	res := command.PouchRun("ps").Assert(c, icmd.Success)
 	if out := res.Combined(); !strings.Contains(out, name) {
@@ -268,7 +268,7 @@ func (suite *PouchRunSuite) TestRunWithSysctls(c *check.C) {
 	sysctl := "net.ipv4.ip_forward=1"
 	name := "run-sysctl"
 
-	res := command.PouchRun("run", "-d", "--name", name, "--sysctl", sysctl, busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, "--sysctl", sysctl, busyboxImage, "top")
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("exec", name, "cat", "/proc/sys/net/ipv4/ip_forward").Stdout()
@@ -283,7 +283,7 @@ func (suite *PouchRunSuite) TestRunWithUser(c *check.C) {
 	user := "1001"
 	name := "run-user"
 
-	res := command.PouchRun("run", "-d", "--name", name, "--user", user, busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, "--user", user, busyboxImage, "top")
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("exec", name, "id", "-u").Stdout()
@@ -293,7 +293,7 @@ func (suite *PouchRunSuite) TestRunWithUser(c *check.C) {
 	DelContainerForceMultyTime(c, name)
 
 	name = "run-user-admin"
-	command.PouchRun("run", "-d", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 	command.PouchRun("exec", name, "adduser", "--disabled-password", "admin").Assert(c, icmd.Success)
 	output = command.PouchRun("exec", "-u", "admin", name, "whoami").Stdout()
 	if !strings.Contains(output, "admin") {
@@ -402,7 +402,7 @@ func checkFileContains(c *check.C, fname string, expt string) {
 // TestRunWithLimitedMemory is to verify the valid running container with -m
 func (suite *PouchRunSuite) TestRunWithLimitedMemory(c *check.C) {
 	cname := "TestRunWithLimitedMemory"
-	command.PouchRun("run", "-d", "-m", "100m", "--name", cname, busyboxImage).Stdout()
+	command.PouchRun("run", "-d", "-m", "100m", "--name", cname, busyboxImage, "top").Stdout()
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -746,7 +746,7 @@ func (suite *PouchRunSuite) TestRunWithCgroupParent(c *check.C) {
 }
 
 func testRunWithCgroupParent(c *check.C, cgroupParent, name string) {
-	command.PouchRun("run", "-d", "-m", "300M", "--cgroup-parent", cgroupParent, "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "-m", "300M", "--cgroup-parent", cgroupParent, "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}

--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -38,7 +38,7 @@ func (suite *PouchStartSuite) TearDownTest(c *check.C) {
 // TestStartCommand tests "pouch start" work.
 func (suite *PouchStartSuite) TestStartCommand(c *check.C) {
 	name := "start-normal"
-	command.PouchRun("create", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 
@@ -93,7 +93,7 @@ func (suite *PouchStartSuite) TestStartWithEnv(c *check.C) {
 	name := "start-env"
 	env := "abc=123"
 
-	command.PouchRun("create", "--name", name, "-e", env, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("create", "--name", name, "-e", env, busyboxImage, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
@@ -154,7 +154,7 @@ func (suite *PouchStartSuite) TestStartWithHostname(c *check.C) {
 	name := "start-hostname"
 	hostname := "pouch"
 
-	command.PouchRun("create", "--name", name, "--hostname", hostname, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("create", "--name", name, "--hostname", hostname, busyboxImage, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
@@ -171,7 +171,7 @@ func (suite *PouchStartSuite) TestStartWithSysctls(c *check.C) {
 	sysctl := "net.ipv4.ip_forward=1"
 	name := "start-sysctl"
 
-	command.PouchRun("create", "--name", name, "--sysctl", sysctl, busyboxImage)
+	command.PouchRun("create", "--name", name, "--sysctl", sysctl, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
@@ -188,7 +188,7 @@ func (suite *PouchStartSuite) TestStartWithAppArmor(c *check.C) {
 	appArmor := "apparmor=unconfined"
 	name := "start-apparmor"
 
-	command.PouchRun("create", "--name", name, "--security-opt", appArmor, busyboxImage)
+	command.PouchRun("create", "--name", name, "--security-opt", appArmor, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
@@ -203,7 +203,7 @@ func (suite *PouchStartSuite) TestStartWithSeccomp(c *check.C) {
 	seccomp := "seccomp=unconfined"
 	name := "start-seccomp"
 
-	command.PouchRun("create", "--name", name, "--security-opt", seccomp, busyboxImage)
+	command.PouchRun("create", "--name", name, "--security-opt", seccomp, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -36,7 +36,7 @@ func (suite *PouchStopSuite) TearDownTest(c *check.C) {
 func (suite *PouchStopSuite) TestStopWorks(c *check.C) {
 	name := "stop-normal"
 
-	command.PouchRun("create", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
@@ -84,8 +84,8 @@ func (suite *PouchStopSuite) TestStopMultiContainers(c *check.C) {
 	name1 := "TestStopMultiContainer-1"
 	name2 := "TestStopMultiContainer-2"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name1, busyboxImage).Assert(c, icmd.Success)
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name2, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "-m", "300M", "--name", name1, busyboxImage, "top").Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "-m", "300M", "--name", name2, busyboxImage, "top").Assert(c, icmd.Success)
 
 	command.PouchRun("stop", "-t", "3", name1, name2).Assert(c, icmd.Success)
 

--- a/test/cli_top_test.go
+++ b/test/cli_top_test.go
@@ -55,7 +55,7 @@ func (suite *PouchTopSuite) TestTopStoppedContainer(c *check.C) {
 func (suite *PouchTopSuite) TestTopContainer(c *check.C) {
 	name := "TestTopContainer"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	res := command.PouchRun("top", name)
 	c.Assert(res.Error, check.IsNil)

--- a/test/cli_unpause_test.go
+++ b/test/cli_unpause_test.go
@@ -30,7 +30,7 @@ func (suite *PouchUnpauseSuite) TearDownTest(c *check.C) {
 func (suite *PouchUnpauseSuite) TestUnpauseWorks(c *check.C) {
 	containernames := []string{"bar1", "bar2"}
 	for _, name := range containernames {
-		command.PouchRun("create", "--name", name, busyboxImage).Assert(c, icmd.Success)
+		command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 		command.PouchRun("start", name).Assert(c, icmd.Success)
 

--- a/test/cli_update_test.go
+++ b/test/cli_update_test.go
@@ -38,7 +38,7 @@ func (suite *PouchUpdateSuite) TearDownTest(c *check.C) {
 func (suite *PouchUpdateSuite) TestUpdateCpu(c *check.C) {
 	name := "update-container-cpu"
 
-	command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}
@@ -78,7 +78,7 @@ func (suite *PouchUpdateSuite) TestUpdateCpu(c *check.C) {
 func (suite *PouchUpdateSuite) TestUpdateRunningContainer(c *check.C) {
 	name := "update-running-container"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}
@@ -118,7 +118,7 @@ func (suite *PouchUpdateSuite) TestUpdateRunningContainer(c *check.C) {
 func (suite *PouchUpdateSuite) TestUpdateStoppedContainer(c *check.C) {
 	name := "update-stopped-container"
 
-	command.PouchRun("create", "-m", "300M", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("create", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}
@@ -160,7 +160,7 @@ func (suite *PouchUpdateSuite) TestUpdateStoppedContainer(c *check.C) {
 func (suite *PouchUpdateSuite) TestUpdateContainerInvalidValue(c *check.C) {
 	name := "update-container-with-invalid-value"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	res := command.PouchRun("update", "--memory-swappiness", "-2", name)
 	c.Assert(res.Error, check.NotNil)
@@ -177,7 +177,7 @@ func (suite *PouchUpdateSuite) TestUpdateContainerInvalidValue(c *check.C) {
 func (suite *PouchUpdateSuite) TestUpdateContainerWithoutFlag(c *check.C) {
 	name := "update-container-without-flag"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	command.PouchRun("update", name).Assert(c, icmd.Success)
 

--- a/test/cli_upgrade_test.go
+++ b/test/cli_upgrade_test.go
@@ -94,7 +94,7 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeStoppedContainer(c *check.C) {
 func (suite *PouchUpgradeSuite) TestPouchUpgradeContainerMemCpu(c *check.C) {
 	name := "TestPouchUpgradeContainerMemCpu"
 
-	command.PouchRun("run", "-d", "-m", "300m", "--cpu-share", "20", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "-m", "300m", "--cpu-share", "20", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	command.PouchRun("upgrade", "-m", "500m", "--cpu-share", "40", "--name", name, busyboxImage125).Assert(c, icmd.Success)
 

--- a/test/z_cli_daemon_test.go
+++ b/test/z_cli_daemon_test.go
@@ -259,7 +259,7 @@ func (suite *PouchDaemonSuite) TestDaemonRestart(c *check.C) {
 	{
 		result := RunWithSpecifiedDaemon(dcfg, "run", "-d", "--name", cname,
 			"-p", "1234:80",
-			busyboxImage)
+			busyboxImage, "top")
 		if result.ExitCode != 0 {
 			dcfg.DumpLog()
 			c.Fatalf("run container failed, err:%v", result)


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Before this PR, we open the stdin of container IO by default.

Actually it's wrong, we should close it by default. 

Unless user specify like `pouch run -i ....`, then we should open it.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


