### PR TITLE
bugfix: make infra image configurable

### DIFF
--- a/cri/config.go
+++ b/cri/config.go
@@ -8,4 +8,6 @@ type Config struct {
 	NetworkPluginBinDir string
 	// NetworkPluginConfDir is the directory in which the admin places a CNI conf.
 	NetworkPluginConfDir string
+	// SandboxImage is the image used by sandbox container.
+	SandboxImage string
 }

--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -47,8 +47,6 @@ const (
 	// nameDelimiter is used to construct pouch container names.
 	nameDelimiter = "_"
 
-	defaultSandboxImage = "k8s.gcr.io/pause-amd64:3.0"
-
 	// Address and port of stream server.
 	// TODO: specify them in the parameters of pouchd.
 	streamServerAddress = ""
@@ -92,6 +90,8 @@ type CriManager struct {
 
 	// SandboxStore stores the configuration of sandboxes.
 	SandboxStore *collect.SafeMap
+	// SandboxImage is the image used by sandbox container.
+	SandboxImage string
 }
 
 // NewCriManager creates a brand new cri manager.
@@ -108,6 +108,7 @@ func NewCriManager(config *config.Config, ctrMgr ContainerMgr, imgMgr ImageMgr) 
 		StreamServer:   streamServer,
 		SandboxBaseDir: path.Join(config.HomeDir, "sandboxes"),
 		SandboxStore:   collect.NewSafeMap(),
+		SandboxImage:   config.CriConfig.SandboxImage,
 	}
 
 	return NewCriWrapper(c), nil
@@ -136,8 +137,7 @@ func (c *CriManager) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	config := r.GetConfig()
 
 	// Step 1: Prepare image for the sandbox.
-	// TODO: make sandbox image configurable.
-	image := defaultSandboxImage
+	image := c.SandboxImage
 
 	// Make sure the sandbox image exists.
 	err := c.ensureSandboxImageExists(ctx, image)

--- a/docs/kubernetes/pouch_with_kubernetes_deploying.md
+++ b/docs/kubernetes/pouch_with_kubernetes_deploying.md
@@ -225,4 +225,8 @@ rtt min/avg/max/mdev = 0.041/0.055/0.068/0.012 ms
 
 - Kubernetes 1.10.0 has been released recently and you may install it by default.However, for the NOTE metioned above, Kubernetes 1.9.X is recommanded for current Pouch.In ubuntu, we could use `apt-cache madison kubelet` to search the Kubernetes version which is available, then specify the version when install it, like `apt-get install kubelet=1.9.4-00`.
 
+- By default Pouch will not enable the CRI. If you'd like to deploy Kubernetes with Pouch, you should start pouchd with the configuration like `pouchd --enable-cri`.
+
+- By default Pouch will use `registry.cn-hangzhou.aliyuncs.com/google-containers/pause-amd64:3.0` as the image of infra container. If you'd like use image other than that, you could start pouchd with the configuration like `pouchd --enable-cri --sandbox-image XXX`.
+
 - Any other troubles? Make an issue to connect with us!

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func setupFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.CriConfig.Listen, "listen-cri", "/var/run/pouchcri.sock", "Specify listening address of CRI")
 	flagSet.StringVar(&cfg.CriConfig.NetworkPluginBinDir, "cni-bin-dir", "/opt/cni/bin", "The directory for putting cni plugin binaries.")
 	flagSet.StringVar(&cfg.CriConfig.NetworkPluginConfDir, "cni-conf-dir", "/etc/cni/net.d", "The directory for putting cni plugin configuration files.")
+	flagSet.StringVar(&cfg.CriConfig.SandboxImage, "sandbox-image", "registry.cn-hangzhou.aliyuncs.com/google-containers/pause-amd64:3.0", "The image used by sandbox container.")
 	flagSet.BoolVarP(&cfg.Debug, "debug", "D", false, "Switch daemon log level to DEBUG mode")
 	flagSet.StringVarP(&cfg.ContainerdAddr, "containerd", "c", "/var/run/containerd.sock", "Specify listening address of containerd")
 	flagSet.StringVar(&cfg.ContainerdPath, "containerd-path", "", "Specify the path of containerd binary")


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

If we want to use other images of infra container other than default "k8s.gcr.io/pause-amd64:3.0",

we should specify pouchd's configuration like "pouchd --enable-cri --sandbox-image XXX"


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1158 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


