### PR TITLE
bugfix: failed to create 'volumefrom' container

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1467,7 +1467,6 @@ func (mgr *ContainerManager) parseBinds(ctx context.Context, meta *ContainerMeta
 
 		for _, oldMountPoint := range oldMeta.Mounts {
 			mp := &types.MountPoint{
-				Name:        oldMountPoint.Name,
 				Source:      oldMountPoint.Source,
 				Destination: oldMountPoint.Destination,
 				Driver:      oldMountPoint.Driver,
@@ -1476,7 +1475,7 @@ func (mgr *ContainerManager) parseBinds(ctx context.Context, meta *ContainerMeta
 				Propagation: oldMountPoint.Propagation,
 			}
 
-			if _, exist := meta.Config.Volumes[oldMountPoint.Name]; !exist {
+			if _, exist := meta.Config.Volumes[oldMountPoint.Name]; len(oldMountPoint.Name) > 0 && !exist {
 				mp.Name = oldMountPoint.Name
 				mp.Source, mp.Driver, err = mgr.bindVolume(ctx, oldMountPoint.Name, meta)
 				if err != nil {

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -941,6 +941,7 @@ func (suite *PouchRunSuite) TestRunWithVolumesFrom(c *check.C) {
 	// run container1
 	command.PouchRun("run", "-d",
 		"-v", volumeName+":/mnt",
+		"-v", "/tmp:/tmp",
 		"--name", containerName1, busyboxImage, "top").Assert(c, icmd.Success)
 	defer func() {
 		command.PouchRun("rm", "-f", containerName1).Assert(c, icmd.Success)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
old container has bind directory into container, such as "-v /tmp:/tmp",
when use 'volumefrom' to create new container, it will be failed when
setup volumes.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>