### PR TITLE
feature: record container last exit time

### DIFF
--- a/daemon/mgr/container_types_test.go
+++ b/daemon/mgr/container_types_test.go
@@ -31,13 +31,27 @@ func TestContainerMeta_FormatStatus(t *testing.T) {
 			err:      nil,
 		},
 		{
+			name: "Exited",
+			input: &ContainerMeta{
+				State: &types.ContainerState{
+					Status:     types.StatusExited,
+					FinishedAt: time.Now().Add(0 - utils.Hour).UTC().Format(utils.TimeLayout),
+					ExitCode:   0,
+				},
+			},
+			expected: "Exited (0) 1 hour",
+			err:      nil,
+		},
+		{
 			name: "Stopped",
 			input: &ContainerMeta{
 				State: &types.ContainerState{
-					Status: types.StatusStopped,
+					Status:     types.StatusStopped,
+					FinishedAt: time.Now().Add(0 - utils.Minute).UTC().Format(utils.TimeLayout),
+					ExitCode:   1,
 				},
 			},
-			expected: string(types.StatusStopped),
+			expected: "Stopped (1) 1 minute",
 			err:      nil,
 		},
 		{

--- a/test/cli_ps_test.go
+++ b/test/cli_ps_test.go
@@ -66,7 +66,7 @@ func (suite *PouchPsSuite) TestPsWorks(c *check.C) {
 		res := command.PouchRun("ps", "-a").Assert(c, icmd.Success)
 		kv := psToKV(res.Combined())
 
-		c.Assert(kv[name].status[0], check.Equals, "stopped")
+		c.Assert(kv[name].status[0], check.Equals, "Stopped")
 	}
 
 	defer DelContainerForceMultyTime(c, name)
@@ -164,6 +164,11 @@ func psToKV(ps string) map[string]psTable {
 			pst.created = items[5:8]
 			pst.image = items[8]
 			pst.runtime = items[9]
+		} else if items[2] == "Stopped" || items[2] == "Exited" {
+			pst.status = items[2:6]
+			pst.created = items[6:9]
+			pst.image = items[9]
+			pst.runtime = items[10]
 		} else {
 			pst.status = items[2:3]
 			pst.created = items[3:6]

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -46,7 +46,7 @@ func (suite *PouchStopSuite) TestStopWorks(c *check.C) {
 	res := command.PouchRun("ps", "-a")
 
 	// FIXME: It's better if we use inspect to filter status.
-	if out := res.Combined(); !strings.Contains(out, "stopped") {
+	if out := res.Combined(); !strings.Contains(out, "Stopped") {
 		c.Fatalf("unexpected output %s expected Stopped\n", out)
 	}
 
@@ -57,7 +57,7 @@ func (suite *PouchStopSuite) TestStopWorks(c *check.C) {
 	res = command.PouchRun("ps", "-a")
 
 	// FIXME: It's better if we use inspect to filter status.
-	if out := res.Combined(); !strings.Contains(out, "stopped") {
+	if out := res.Combined(); !strings.Contains(out, "Stopped") {
 		c.Fatalf("unexpected output %s expected Stopped\n", out)
 	}
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

record stopped container last exit time, like
```
$ pouch ps
Name     ID       Status                     Created          Image            Runtime
356700   356700   stopped (137) 36 minutes   36 minutes ago   busybox:latest   runc
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


