### PR TITLE
bugfix: if user rename container with id use the real name to clean the cache

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -859,7 +859,7 @@ func (mgr *ContainerManager) Rename(ctx context.Context, oldName, newName string
 	c.Lock()
 	defer c.Unlock()
 
-	mgr.NameToID.Remove(oldName)
+	mgr.NameToID.Remove(c.Name())
 	mgr.NameToID.Put(newName, c.ID())
 
 	c.meta.Name = newName


### PR DESCRIPTION
Signed-off-by: Frank Yang <yyb196@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
because when doing rename, user may specify container id instead of container name, in the processing of clean the old name from `nameToId` cache, we cannot suppose that the `oldName` is the name of the old container. we use the real name to clean the cache.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1174 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


