### PR TITLE
bugfix: add default tag ":latest" when using pouch rmi to remove untagged container images.

### DIFF
--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -145,6 +145,10 @@ func (mgr *ImageManager) RemoveImage(ctx context.Context, image *types.ImageInfo
 	}
 	if refTagged, ok := refNamed.(reference.Tagged); ok {
 		ref = refTagged.String()
+	} else {
+		// add default tag ":latest" for image which is to be removed
+		defaultTaggedRef := reference.WithDefaultTagIfMissing(refNamed).(reference.Tagged)
+		ref = defaultTaggedRef.Name() + ":" + defaultTaggedRef.Tag()
 	}
 
 	if err := mgr.client.RemoveImage(ctx, ref); err != nil {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
add default tag ":latest" when using `pouch rmi` to remove untagged container images.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1104

### Ⅲ. Describe how you did it
just use the same way as `pouch pull`

### Ⅳ. Describe how to verify it
frist, pull some images:
```
pouch pull library/busybox
pouch pull library/hello-world
```

then, just remove them:
```
pouch rmi library/busybox library/hello-world
```

### Ⅴ. Special notes for reviews


