### PR TITLE
remove log format type check

### DIFF
--- a/cli/logs.go
+++ b/cli/logs.go
@@ -63,15 +63,6 @@ func (lc *LogsCommand) runLogs(args []string) error {
 	ctx := context.Background()
 	apiClient := lc.cli.Client()
 
-	c, err := apiClient.ContainerGet(ctx, containerName)
-	if err != nil {
-		return err
-	}
-
-	if !validDrivers[c.HostConfig.LogConfig.Type] {
-		return fmt.Errorf("\"logs\" command is supported only for \"json-file\" and \"journald\" logging drivers (got; %s)", c.HostConfig.LogConfig.Type)
-	}
-
 	opts := types.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,


### PR DESCRIPTION
Option `LogConfig` is omitempty in config. That means we allow `c.HostConfig.LogConfig` is nil. 

There is no need to check the log type, we don't use it now in `log` sub command, maybe in the furture.

Fix #1075 
Fix #1072 