### PR TITLE
bugfix: make logrus detect whether output with color

### DIFF
--- a/main.go
+++ b/main.go
@@ -235,7 +235,6 @@ func initLog() {
 	}
 
 	formatter := &logrus.TextFormatter{
-		ForceColors:     true,
 		FullTimestamp:   true,
 		TimestampFormat: "2006-01-02 15:04:05.000000000",
 	}


### PR DESCRIPTION
Signed-off-by: Frank Yang <yyb196@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
make logrus detect whether output with color instead of always output with color.

when redirect pouchd output a file, avoid outputting message like `ESC[34mINFOESC[0m` to the file.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


