### PR TITLE
feature: make markdownlint in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
     gcc \
     vim \
     tree \
+    rubygems \
     && apt-get clean
 
 # set go version this image use
@@ -35,6 +36,14 @@ RUN go get -u github.com/golang/lint/golint
 # install swagger 0.12.0
 RUN wget --quiet -O /bin/swagger https://github.com/go-swagger/go-swagger/releases/download/0.12.0/swagger_linux_amd64 \
     && chmod +x /bin/swagger
+
+# install markdownlint tool
+RUN gem install rake \
+    && gem install bundler \
+    && git clone https://github.com/markdownlint/markdownlint.git \
+    && cd markdownlint \
+    && git checkout v0.4.0 \
+    && rake install
 
 COPY . /go/src/github.com/alibaba/pouch
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

We wish to add all repo needed software in Dockerfile, so we could use a single to image to integration test, circleci testing and no dependency with outer link.

We need to add all the following software:

* golint (https://github.com/golang/lint)
* markdownlint (https://github.com/markdownlint/markdownlint)
* go-swagger (https://github.com/go-swagger/go-swagger)

With this pull request passed and merged, we need to update file https://github.com/alibaba/pouch/blob/master/.circleci/config.yml to use a single one image.

My plan is to build this Dockerfile to be allencloud/pouch:base20180426.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Describe how you did it
none


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews
none


