### PR TITLE
fix: make stopping non-running container valid

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -709,8 +709,8 @@ func (mgr *ContainerManager) Stop(ctx context.Context, name string, timeout int6
 	c.Lock()
 	defer c.Unlock()
 
-	if c.IsStopped() {
-		// stopping a stopped container is valid.
+	if !c.IsRunning() {
+		// stopping a non-running container is valid.
 		return nil
 	}
 

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -39,6 +39,10 @@ func (suite *PouchStopSuite) TestStopWorks(c *check.C) {
 	command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
+	// test stop a created container
+	command.PouchRun("stop", name).Assert(c, icmd.Success)
+
+	// start the created container
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 
 	// test stop a running container


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

make stopping non-running container valid

make this be compatible  with moby's api.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix #1207 


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


