### PR TITLE
bugfix: remove the DiskQuota useless field from Resource

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2225,10 +2225,6 @@ definitions:
         items:
           type: "string"
           example: "c 13:* rwm"
-      DiskQuota:
-        description: "Disk limit (in bytes)."
-        type: "integer"
-        format: "int64"
       KernelMemory:
         description: "Kernel memory limit in bytes."
         type: "integer"

--- a/apis/types/resources.go
+++ b/apis/types/resources.go
@@ -92,9 +92,6 @@ type Resources struct {
 	// A list of devices to add to the container.
 	Devices []*DeviceMapping `json:"Devices"`
 
-	// Disk limit (in bytes).
-	DiskQuota int64 `json:"DiskQuota,omitempty"`
-
 	// Maximum IO in bytes per second for the container system drive (Windows only)
 	IOMaximumBandwidth uint64 `json:"IOMaximumBandwidth,omitempty"`
 
@@ -195,8 +192,6 @@ type Resources struct {
 /* polymorph Resources DeviceCgroupRules false */
 
 /* polymorph Resources Devices false */
-
-/* polymorph Resources DiskQuota false */
 
 /* polymorph Resources IOMaximumBandwidth false */
 


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Remove the `DiskQuota` useless field from Resource


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it

None

### Ⅳ. Describe how to verify it

None

### Ⅴ. Special notes for reviews

None