### PR TITLE
bugfix: Volume info of inspect output is incompatible with Moby API

### DIFF
--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -970,7 +970,7 @@ func (suite *PouchRunSuite) TestRunWithVolumesFrom(c *check.C) {
 
 	volumeFound := false
 	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains(line, "\"volumesfrom-test-volume\": \"/mnt\"") {
+		if strings.Contains(line, "\"volumesfrom-test-volume\"") {
 			volumeFound = true
 			break
 		}
@@ -1019,7 +1019,7 @@ func (suite *PouchRunSuite) TestRunWithVolumesFromWithDupclicate(c *check.C) {
 
 	volumeFound := false
 	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains(line, "\"volumesfromDupclicate-test-volume\": \"/mnt\"") {
+		if strings.Contains(line, "\"volumesfromDupclicate-test-volume\"") {
 			volumeFound = true
 			break
 		}


### PR DESCRIPTION


Signed-off-by: Michael Wan <zirenwan@gmail.com>


### Ⅰ. Describe what this PR did
#./docker -H unix:///run/pouchd.sock inspect eff3a2846686
[]
json: cannot unmarshal string into Go value of type struct {}

### Ⅱ. Does this pull request fix one issue?
fixes https://github.com/alibaba/pouch/issues/1211


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
```
root@osboxes:test (zr/fix-volume-struct *) -> docker -H unix:///run/pouchd.sock inspect test2
[
    {
        "Args": null,
        "Config": {
            "Cmd": [
                "/bin/bash"
            ],
            "Entrypoint": null,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Hostname": "osboxes",
            "Image": "registry.hub.docker.com/library/ubuntu:14.04",
            "OnBuild": null,
            "Shell": null,
            "Volumes": {
                "/mnt": null
            }
        },
        "Created": "2018-04-25T11:50:50.324220921Z",
        "GraphDriver": {
```

### Ⅴ. Special notes for reviews


