### PR TITLE
bugfix: fix volume size without unit

### DIFF
--- a/pkg/bytefmt/bytefmt.go
+++ b/pkg/bytefmt/bytefmt.go
@@ -87,6 +87,15 @@ func ToKilobytes(s string) (uint64, error) {
 
 // ToBytes parses a string formatted by ByteSize as bytes.
 func ToBytes(s string) (uint64, error) {
+	l := len(s)
+	if l < 1 {
+		return 0, ErrorInvalidByte
+	}
+
+	if s[l-1] != 'b' && s[l-1] != 'B' {
+		s = s + "B"
+	}
+
 	parts := bytesPattern.FindStringSubmatch(strings.TrimSpace(s))
 	if len(parts) < 3 {
 		return 0, ErrorInvalidByte

--- a/pkg/bytefmt/bytefmt_test.go
+++ b/pkg/bytefmt/bytefmt_test.go
@@ -96,6 +96,11 @@ func TestToBytes(t *testing.T) {
 			expect: uint64(10.5 * 1024),
 			err:    nil,
 		},
+		{
+			input:  "1024000",
+			expect: 1024000,
+			err:    nil,
+		},
 	}
 	for _, test := range tests {
 		out, err := ToBytes(test.input)

--- a/test/cli_volume_test.go
+++ b/test/cli_volume_test.go
@@ -167,6 +167,19 @@ func (suite *PouchVolumeSuite) TestVolumeCreateWithSelector(c *check.C) {
 	command.PouchRun("volume", "remove", funcname)
 }
 
+// TestVolumeCreateWithSize tests creating volume with -o size=xxx.
+func (suite *PouchVolumeSuite) TestVolumeCreateWithSize(c *check.C) {
+	pc, _, _, _ := runtime.Caller(0)
+	tmpname := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+	var funcname string
+	for i := range tmpname {
+		funcname = tmpname[i]
+	}
+
+	command.PouchRun("volume", "create", "--name", funcname, "-o", "size=1048576").Assert(c, icmd.Success)
+	command.PouchRun("volume", "remove", funcname)
+}
+
 // TestVolumeInspectFormat tests the inspect format of volume works.
 func (suite *PouchVolumeSuite) TestVolumeInspectFormat(c *check.C) {
 	pc, _, _, _ := runtime.Caller(0)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
fix volume size without unit, such as size=1024 will be failed.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONO

### Ⅲ. Describe how you did it
check the size has unit or not, if it has no unit size, we will add "B" at the end of size.

### Ⅳ. Describe how to verify it
```
# pouch volume create -d local -o size=1048576 -n test
Mountpoint:   /data/pouch/volume/test
Name:         test
Scope:
Status:       map[sifter:Default size:1048576 mount:/data/pouch/volume]
CreatedAt:    2018-4-25 21:28:44
Driver:       local
Labels:       map[]
```

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
