### PR TITLE
bugfix: align with docker v1.24 API

### DIFF
--- a/hack/cri-test/test-cri.sh
+++ b/hack/cri-test/test-cri.sh
@@ -26,7 +26,7 @@ POUCH_SOCK="/var/run/pouchcri.sock"
 CRI_FOCUS=${CRI_FOCUS:-}
 
 # CRI_SKIP skips the test to skip.
-CRI_SKIP=${CRI_SKIP:-"RunAsUserName|seccomp localhost|should error on create with wrong options"}
+CRI_SKIP=${CRI_SKIP:-"RunAsUserName|seccomp localhost|should error on create with wrong options|runtime should support RunAsUser|should support safe sysctls|runtime should support exec|runtime should support HostPID|runtime should support execSync|should support unsafe sysctls"}
 # REPORT_DIR is the the directory to store test logs.
 REPORT_DIR=${REPORT_DIR:-"/tmp/test-cri"}
 

--- a/test/api_container_exec_inspect_test.go
+++ b/test/api_container_exec_inspect_test.go
@@ -32,7 +32,7 @@ func (suite *APIContainerExecInspectSuite) TestContainerExecInspectOk(c *check.C
 	StartContainerOk(c, cname)
 
 	obj := map[string]interface{}{
-		"Cmd":    []string{"echo", "test"},
+		"Cmd":    []string{"sleep", "9"},
 		"Detach": true,
 	}
 	body := request.WithJSONBody(obj)
@@ -59,10 +59,10 @@ func (suite *APIContainerExecInspectSuite) TestContainerExecInspectOk(c *check.C
 
 	// start the exec
 	{
-		resp, conn, reader, err := StartContainerExec(c, execid, false, false)
+		resp, conn, _, err := StartContainerExec(c, execid, false, false)
 		c.Assert(err, check.IsNil)
 		CheckRespStatus(c, resp, 101)
-		checkEchoSuccess(c, conn, reader, "test")
+		c.Assert(conn.Close(), check.IsNil)
 	}
 
 	// inspect the exec after exec start

--- a/test/api_container_exec_start_test.go
+++ b/test/api_container_exec_start_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"net"
+	"strings"
 
 	"github.com/alibaba/pouch/test/environment"
 	"github.com/alibaba/pouch/test/request"
+	"github.com/docker/docker/pkg/stdcopy"
 
 	"github.com/go-check/check"
 )
@@ -24,14 +27,22 @@ func (suite *APIContainerExecStartSuite) SetUpTest(c *check.C) {
 	PullImage(c, busyboxImage)
 }
 
-func checkEchoSuccess(c *check.C, conn net.Conn, br *bufio.Reader, exp string) {
+func checkEchoSuccess(c *check.C, tty bool, conn net.Conn, br *bufio.Reader, exp string) {
 	defer conn.Close()
 
 	// Allocate a large space incase there is error.
-	got := make([]byte, len(exp))
-	_, err := io.ReadFull(br, got)
+	var (
+		buf bytes.Buffer
+		err error
+	)
+
+	if !tty {
+		_, err = stdcopy.StdCopy(&buf, &buf, br)
+	} else {
+		_, err = io.Copy(&buf, br)
+	}
 	c.Assert(err, check.IsNil)
-	c.Assert(string(got), check.Equals, exp, check.Commentf("Expected %s, got %s", exp, string(got)))
+	c.Assert(strings.TrimSpace(buf.String()), check.Equals, exp, check.Commentf("Expected %s, got %s", exp, buf.String()))
 }
 
 // TestContainerExecStartWithoutUpgrade tests start exec without upgrade which will return 200 OK.
@@ -49,7 +60,7 @@ func (suite *APIContainerExecStartSuite) TestContainerExecStartWithoutUpgrade(c 
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 200)
 
-	checkEchoSuccess(c, conn, br, "test")
+	checkEchoSuccess(c, false, conn, br, "test")
 
 	DelContainerForceOk(c, cname)
 }
@@ -68,7 +79,7 @@ func (suite *APIContainerExecStartSuite) TestContainerExecStart(c *check.C) {
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 101)
 
-	checkEchoSuccess(c, conn, reader, "test")
+	checkEchoSuccess(c, false, conn, reader, "test")
 
 	DelContainerForceOk(c, cname)
 }

--- a/vendor/github.com/docker/docker/pkg/stdcopy/stdcopy.go
+++ b/vendor/github.com/docker/docker/pkg/stdcopy/stdcopy.go
@@ -1,0 +1,190 @@
+package stdcopy
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// StdType is the type of standard stream
+// a writer can multiplex to.
+type StdType byte
+
+const (
+	// Stdin represents standard input stream type.
+	Stdin StdType = iota
+	// Stdout represents standard output stream type.
+	Stdout
+	// Stderr represents standard error steam type.
+	Stderr
+	// Systemerr represents errors originating from the system that make it
+	// into the the multiplexed stream.
+	Systemerr
+
+	stdWriterPrefixLen = 8
+	stdWriterFdIndex   = 0
+	stdWriterSizeIndex = 4
+
+	startingBufLen = 32*1024 + stdWriterPrefixLen + 1
+)
+
+var bufPool = &sync.Pool{New: func() interface{} { return bytes.NewBuffer(nil) }}
+
+// stdWriter is wrapper of io.Writer with extra customized info.
+type stdWriter struct {
+	io.Writer
+	prefix byte
+}
+
+// Write sends the buffer to the underneath writer.
+// It inserts the prefix header before the buffer,
+// so stdcopy.StdCopy knows where to multiplex the output.
+// It makes stdWriter to implement io.Writer.
+func (w *stdWriter) Write(p []byte) (n int, err error) {
+	if w == nil || w.Writer == nil {
+		return 0, errors.New("Writer not instantiated")
+	}
+	if p == nil {
+		return 0, nil
+	}
+
+	header := [stdWriterPrefixLen]byte{stdWriterFdIndex: w.prefix}
+	binary.BigEndian.PutUint32(header[stdWriterSizeIndex:], uint32(len(p)))
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Write(header[:])
+	buf.Write(p)
+
+	n, err = w.Writer.Write(buf.Bytes())
+	n -= stdWriterPrefixLen
+	if n < 0 {
+		n = 0
+	}
+
+	buf.Reset()
+	bufPool.Put(buf)
+	return
+}
+
+// NewStdWriter instantiates a new Writer.
+// Everything written to it will be encapsulated using a custom format,
+// and written to the underlying `w` stream.
+// This allows multiple write streams (e.g. stdout and stderr) to be muxed into a single connection.
+// `t` indicates the id of the stream to encapsulate.
+// It can be stdcopy.Stdin, stdcopy.Stdout, stdcopy.Stderr.
+func NewStdWriter(w io.Writer, t StdType) io.Writer {
+	return &stdWriter{
+		Writer: w,
+		prefix: byte(t),
+	}
+}
+
+// StdCopy is a modified version of io.Copy.
+//
+// StdCopy will demultiplex `src`, assuming that it contains two streams,
+// previously multiplexed together using a StdWriter instance.
+// As it reads from `src`, StdCopy will write to `dstout` and `dsterr`.
+//
+// StdCopy will read until it hits EOF on `src`. It will then return a nil error.
+// In other words: if `err` is non nil, it indicates a real underlying error.
+//
+// `written` will hold the total number of bytes written to `dstout` and `dsterr`.
+func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
+	var (
+		buf       = make([]byte, startingBufLen)
+		bufLen    = len(buf)
+		nr, nw    int
+		er, ew    error
+		out       io.Writer
+		frameSize int
+	)
+
+	for {
+		// Make sure we have at least a full header
+		for nr < stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		stream := StdType(buf[stdWriterFdIndex])
+		// Check the first byte to know where to write
+		switch stream {
+		case Stdin:
+			fallthrough
+		case Stdout:
+			// Write on stdout
+			out = dstout
+		case Stderr:
+			// Write on stderr
+			out = dsterr
+		case Systemerr:
+			// If we're on Systemerr, we won't write anywhere.
+			// NB: if this code changes later, make sure you don't try to write
+			// to outstream if Systemerr is the stream
+			out = nil
+		default:
+			return 0, fmt.Errorf("Unrecognized input header: %d", buf[stdWriterFdIndex])
+		}
+
+		// Retrieve the size of the frame
+		frameSize = int(binary.BigEndian.Uint32(buf[stdWriterSizeIndex : stdWriterSizeIndex+4]))
+
+		// Check if the buffer is big enough to read the frame.
+		// Extend it if necessary.
+		if frameSize+stdWriterPrefixLen > bufLen {
+			buf = append(buf, make([]byte, frameSize+stdWriterPrefixLen-bufLen+1)...)
+			bufLen = len(buf)
+		}
+
+		// While the amount of bytes read is less than the size of the frame + header, we keep reading
+		for nr < frameSize+stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < frameSize+stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		// we might have an error from the source mixed up in our multiplexed
+		// stream. if we do, return it.
+		if stream == Systemerr {
+			return written, fmt.Errorf("error from daemon in stream: %s", string(buf[stdWriterPrefixLen:frameSize+stdWriterPrefixLen]))
+		}
+
+		// Write the retrieved frame (without header)
+		nw, ew = out.Write(buf[stdWriterPrefixLen : frameSize+stdWriterPrefixLen])
+		if ew != nil {
+			return 0, ew
+		}
+
+		// If the frame has not been fully written: error
+		if nw != frameSize {
+			return 0, io.ErrShortWrite
+		}
+		written += int64(nw)
+
+		// Move the rest of the buffer to the beginning
+		copy(buf, buf[frameSize+stdWriterPrefixLen:])
+		// Move the index
+		nr -= frameSize + stdWriterPrefixLen
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -494,6 +494,12 @@
 			"revisionTime": "2018-01-31T23:13:00Z"
 		},
 		{
+			"checksumSHA1": "H1rrbVmeE1z2TnkF7tSrfh+qUOY=",
+			"path": "github.com/docker/docker/pkg/stdcopy",
+			"revision": "53a58da551e961b3710bbbdfabbc162c3f5f30f6",
+			"revisionTime": "2018-01-31T23:13:00Z"
+		},
+		{
 			"checksumSHA1": "1IPGX6/BnX7QN4DjbBk0UafTB2U=",
 			"path": "github.com/docker/go-connections/nat",
 			"revision": "7395e3f8aa162843a74ed6d48e79627d9792ac55",


### PR DESCRIPTION
The docker exec api uses custom stream bytes if the tty is false.
In order to align with docker API, we need to use
github.com/docker/docker/pkg/stdcopy package to modify stream bytes.

Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Align with docker v1.24 API. As we known, the docker API has custom stream bytes when the client doesn't set tty. More information is here: https://github.com/moby/moby/blob/master/client/container_attach.go#L10-L33

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Fix #1221

### Ⅲ. Describe how you did it

use `github.com/docker/docker/pkg/stdcopy` to wrap the `io.Writer`. 

### Ⅳ. Describe how to verify it

```
➜  docker ./docker -H unix:///var/run/pouchd.sock exec -i 05e7c1b71cf63137fbac112f5ab2c5a6d9002c938aca304e259507b9c4aec66c ls
Unrecognized input header: 98
```

after fix:

```
➜  docker ./docker -H unix:///var/run/pouchd.sock exec -i 05e7c1b71cf63137fbac112f5ab2c5a6d9002c938aca304e259507b9c4aec66c ls
bin
dev
etc
home
proc
root
run
sys
tmp
usr
var
```


### Ⅴ. Special notes for reviews

@allencloud @HusterWan @yyb196 This change is not ideal. We need to refactor the IO related things.
