### PR TITLE
bugfix: update label compatibility with alidocker

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2110,10 +2110,10 @@ definitions:
             type: "array"
             items:
               type: "string"
-          Labels:
+          Label:
             description: "List of labels set to container."
-            type: "object"
-            additionalProperties:
+            type: "array"
+            items:
               type: "string"
 
   ContainerUpgradeConfig:

--- a/apis/types/update_config.go
+++ b/apis/types/update_config.go
@@ -23,7 +23,7 @@ type UpdateConfig struct {
 	Env []string `json:"Env"`
 
 	// List of labels set to container.
-	Labels map[string]string `json:"Labels,omitempty"`
+	Label []string `json:"Label"`
 
 	// restart policy
 	RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
@@ -41,7 +41,7 @@ func (m *UpdateConfig) UnmarshalJSON(raw []byte) error {
 	var data struct {
 		Env []string `json:"Env,omitempty"`
 
-		Labels map[string]string `json:"Labels,omitempty"`
+		Label []string `json:"Label,omitempty"`
 
 		RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
 	}
@@ -51,7 +51,7 @@ func (m *UpdateConfig) UnmarshalJSON(raw []byte) error {
 
 	m.Env = data.Env
 
-	m.Labels = data.Labels
+	m.Label = data.Label
 
 	m.RestartPolicy = data.RestartPolicy
 
@@ -71,14 +71,14 @@ func (m UpdateConfig) MarshalJSON() ([]byte, error) {
 	var data struct {
 		Env []string `json:"Env,omitempty"`
 
-		Labels map[string]string `json:"Labels,omitempty"`
+		Label []string `json:"Label,omitempty"`
 
 		RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
 	}
 
 	data.Env = m.Env
 
-	data.Labels = m.Labels
+	data.Label = m.Label
 
 	data.RestartPolicy = m.RestartPolicy
 
@@ -103,6 +103,10 @@ func (m *UpdateConfig) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateLabel(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateRestartPolicy(formats); err != nil {
 		res = append(res, err)
 	}
@@ -116,6 +120,15 @@ func (m *UpdateConfig) Validate(formats strfmt.Registry) error {
 func (m *UpdateConfig) validateEnv(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Env) { // not required
+		return nil
+	}
+
+	return nil
+}
+
+func (m *UpdateConfig) validateLabel(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Label) { // not required
 		return nil
 	}
 

--- a/cli/update.go
+++ b/cli/update.go
@@ -58,10 +58,11 @@ func (uc *UpdateCommand) updateRun(args []string) error {
 	container := args[0]
 	ctx := context.Background()
 
-	labels, err := opts.ParseLabels(uc.labels)
-	if err != nil {
-		return err
-	}
+	// UpdateConfig.Label's type change to []string
+	// labels, err := opts.ParseLabels(uc.labels)
+	// if err != nil {
+	// 	return err
+	// }
 
 	if err := opts.ValidateMemorySwappiness(uc.memorySwappiness); err != nil {
 		return err
@@ -95,7 +96,7 @@ func (uc *UpdateCommand) updateRun(args []string) error {
 
 	updateConfig := &types.UpdateConfig{
 		Env:           uc.env,
-		Labels:        labels,
+		Label:         uc.labels,
 		RestartPolicy: restartPolicy,
 		Resources:     resource,
 	}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
fix  update compatibility with  alidocker
alidocker update container label is `[]string`
pouch `UpdateConfig.Label` is `map[string]string`

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


