### PR TITLE
bugfix: setRawMode can only be set when the user set tty

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -100,15 +100,17 @@ func (rc *RunCommand) runRun(args []string) error {
 	wait := make(chan struct{})
 
 	if rc.attach || rc.stdin {
-		in, out, err := setRawMode(rc.stdin, false)
-		if err != nil {
-			return fmt.Errorf("failed to set raw mode")
-		}
-		defer func() {
-			if err := restoreMode(in, out); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to restore term mode")
+		if rc.tty {
+			in, out, err := setRawMode(rc.stdin, false)
+			if err != nil {
+				return fmt.Errorf("failed to set raw mode")
 			}
-		}()
+			defer func() {
+				if err := restoreMode(in, out); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to restore term mode")
+				}
+			}()
+		}
 
 		conn, br, err := apiClient.ContainerAttach(ctx, containerName, rc.stdin)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

`setRawMode` is used to terminal case. If the shell is non-interactive or non-terminal, we should not set the raw mode for the input.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

None

### Ⅲ. Describe how you did it

check tty before set the raw mode

### Ⅳ. Describe how to verify it

we need to set the shell in no-interactive mode, please use the following the script:
```
#!/bin/bash

cat >test <<'EOF'
set +i # set non-interactive
pouch run -i busybox:latest echo test
EOF

echo 'running bash -i <test'
bash -i <test
```

before this change:
```
➜  /tmp sh ./test-interactive
running bash -i <test
root@ubuntu-xenial:/tmp# set +i # set non-interactive
root@ubuntu-xenial:/tmp# pouch run -i busybox:latest echo test
Error: failed to set raw mode
root@ubuntu-xenial:/tmp# exit
```

after this change:
```
➜  /tmp sh ./test-interactive
running bash -i <test
root@ubuntu-xenial:/tmp# set +i # set non-interactive
root@ubuntu-xenial:/tmp# pouch run -i busybox:latest echo test
test
root@ubuntu-xenial:/tmp# exit
```

### Ⅴ. Special notes for reviews


