### PR TITLE
bugfix: add newline for id when create container

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -68,7 +68,7 @@ func (cc *CreateCommand) runCreate(args []string) error {
 	if len(result.Warnings) != 0 {
 		fmt.Printf("WARNING: %s \n", strings.Join(result.Warnings, "\n"))
 	}
-	fmt.Printf(result.ID)
+	fmt.Println(result.ID)
 	return nil
 }
 

--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
-	"github.com/stretchr/testify/assert"
+	digest "github.com/opencontainers/go-digest"
 )
 
 // PouchCreateSuite is the test suite for create CLI.
@@ -43,6 +43,10 @@ func (suite *PouchCreateSuite) TestCreateName(c *check.C) {
 
 	res.Assert(c, icmd.Success)
 
+	// create command should add newline at the end of result
+	digStr := strings.TrimSpace(res.Combined())
+	c.Assert(res.Combined(), check.Equals, fmt.Sprintf("%s\n", digStr))
+
 	defer DelContainerForceMultyTime(c, name)
 }
 
@@ -57,7 +61,10 @@ func (suite *PouchCreateSuite) TestCreateNameByImageID(c *check.C) {
 	res = command.PouchRun("create", "--name", name, imageID)
 
 	res.Assert(c, icmd.Success)
-	assert.Equal(c, len(res.Combined()), 64)
+
+	digHexStr := strings.TrimSpace(res.Combined())
+	_, err := digest.Parse(fmt.Sprintf("%s:%s", digest.SHA256, digHexStr))
+	c.Assert(err, check.IsNil)
 
 	DelContainerForceMultyTime(c, name)
 }


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add newline for id when create container

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

use `fmt.Println`

### Ⅳ. Describe how to verify it

```
➜  /tmp pouch create busybox:latest top && echo test
26593eb31c06dd05926ea91c6b2241ba82b44ae7e9214bcea5bafcd43e90006c
test
```

### Ⅴ. Special notes for reviews

NONE

