### PR TITLE
enhance: add more field in 'pouch info' command

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/client"
 	"github.com/alibaba/pouch/cri"
 	"github.com/alibaba/pouch/network"
@@ -97,6 +98,12 @@ type Config struct {
 
 	// Pidfile keeps daemon pid
 	Pidfile string `json:"pidfile,omitempty"`
+
+	// Default log configuration
+	DefaultLogConfig types.HostConfigAO0LogConfig `json:"default-log-config, omitempty"`
+
+	// RegistryService
+	RegistryService types.RegistryServiceConfig `json:"registry-service, omitempty" `
 }
 
 // Validate validates the user input config.

--- a/internal/generator.go
+++ b/internal/generator.go
@@ -30,7 +30,7 @@ func GenContainerMgr(ctx context.Context, d DaemonProvider) (mgr.ContainerMgr, e
 
 // GenSystemMgr generates a SystemMgr instance according to config cfg.
 func GenSystemMgr(cfg *config.Config, d DaemonProvider) (mgr.SystemMgr, error) {
-	return mgr.NewSystemManager(cfg, d.MetaStore())
+	return mgr.NewSystemManager(cfg, d.MetaStore(), d.ImgMgr())
 }
 
 // GenImageMgr generates a ImageMgr instance according to config cfg.


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This pr adds the value assertion of 'Architecture/Images/LoggingDriver/RegistryConfig' on daemon side, in which case 'pouch info' command wil output more field value.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
[root@instance-1 zouruicloud]# pouch info
Containers: 0
 Running: 0
 Paused: 0
 Stopped: 0
Images:  1
ID: 
Name: instance-1
Server Version: 0.4.0
Storage Driver: overlayfs
Driver Status: []
Logging Driver: 
Cgroup Driver: 
runc: <nil>
containerd: <nil>
Security Options: []
Kernel Version: 3.10.0-693.11.1.el7.x86_64
Operating System: "CentOS Linux 7 (Core)"
OSType: linux
Architecture: amd64
HTTP Proxy: 
HTTPS Proxy: 
Registry: https://index.docker.io/v1/
Experimental: false
Debug: false
Labels:
  node_ip=10.142.0.2
  SN=GoogleCloud-0F7AA324BDD10D51358D5410E1D02814
CPUs: 1
Total Memory: 3.456 GiB
Pouch Root Dir: /var/lib/pouch
LiveRestoreEnabled: true
LxcfsEnabled: false
Daemon Listen Addresses: [unix:///var/run/pouchd.sock]

### Ⅴ. Special notes for reviews


