### PR TITLE
bugfix: fix the mount path of tmpfs volume and some misspells

### DIFF
--- a/daemon/mgr/volume.go
+++ b/daemon/mgr/volume.go
@@ -44,7 +44,7 @@ type VolumeManager struct {
 
 // NewVolumeManager creates a brand new volume manager.
 func NewVolumeManager(cfg volume.Config) (*VolumeManager, error) {
-	// init voluem config
+	// init volume config
 	cfg.RemoveVolume = true
 	cfg.DefaultBackend = "local"
 

--- a/storage/volume/modules/tmpfs/tmpfs.go
+++ b/storage/volume/modules/tmpfs/tmpfs.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	dataDir = "/etc/docker/plugins/tmpfs"
+	dataDir = "/mnt/tmpfs"
 )
 
 func init() {


### PR DESCRIPTION
The tmpfs volume is now mounted in the /etc/docker/plugins/tmpfs. It
should be mounted in /mnt/tmpfs

Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

The tmpfs volume is now mounted in the /etc/docker/plugins/tmpfs. It
should be mounted in /mnt/tmpfs

fix some misspells


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it

1. create tmpfs volume

```
root@ubuntu-1:~# pouch volume create -d tmpfs -n tmp_vol1
CreatedAt:    2018-4-28 11:17:36
Driver:       tmpfs
Labels:       map[]
Mountpoint:   /mnt/tmpfs/tmp_vol1
Name:         tmp_vol1
Scope:        
Status:       map[sifter:Default]
```

2. run container with the volume

```
root@ubuntu-1:~# pouch run -v tmp_vol1:/test -d reg.docker.alibaba-inc.com/redis
3a841472c493934885cbed99dd56c75ac48fbfaa32a9f3626e5e9701d5cb82a0
```

3. see the mount path

```
root@ubuntu-1:~# mount |grep tmp_vol1
shm on /mnt/tmpfs/tmp_vol1 type tmpfs (rw,nosuid,nodev,noexec,relatime,size=0k)
```

### Ⅴ. Special notes for reviews


