### PR TITLE
bugfix: fix mountpoint binary not found error

### DIFF
--- a/pkg/utils/mount.go
+++ b/pkg/utils/mount.go
@@ -39,7 +39,7 @@ func MountVolume(mountCmd []string, devicePath, mountPath string, timeout time.D
 
 // IsMountpoint is used to check the directory is mountpoint or not.
 func IsMountpoint(dir string) bool {
-	exit, _, _, err := exec.Run(10*time.Second, "/usr/bin/mountpoint", dir)
+	exit, _, _, err := exec.Run(10*time.Second, "mountpoint", dir)
 	if err != nil {
 		return false
 	} else if exit != 0 {


### PR DESCRIPTION
In some linux releases, the mountpoint is not under /usr/bin dir, which
causes the failure of tmpfs detachment. So we only use the mountpoint,
which is in the system path

Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In some linux releases, the mountpoint is not under /usr/bin dir, which
causes the failure of tmpfs detachment. So we only use the mountpoint,
which is in the system path


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1252


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


