### PR TITLE
bugfix: set container env failed Invalid cross-device link

### DIFF
--- a/daemon/mgr/spec_hook.go
+++ b/daemon/mgr/spec_hook.go
@@ -52,22 +52,24 @@ func setupHook(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) 
 
 	// setup diskquota hook, if rootFSQuota not set skip this part.
 	rootFSQuota := quota.GetDefaultQuota(c.Config.DiskQuota)
-	if rootFSQuota != "" {
-		qid := "0"
-		if c.Config.QuotaID != "" {
-			qid = c.Config.QuotaID
-		}
-
-		target, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe"))
-		if err != nil {
-			return err
-		}
-
-		s.Hooks.Prestart = append(s.Hooks.Prestart, specs.Hook{
-			Path: target,
-			Args: []string{"set-diskquota", c.BaseFS, rootFSQuota, qid},
-		})
+	if rootFSQuota == "" {
+		return nil
 	}
+
+	qid := "0"
+	if c.Config.QuotaID != "" {
+		qid = c.Config.QuotaID
+	}
+
+	target, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe"))
+	if err != nil {
+		return err
+	}
+
+	s.Hooks.Prestart = append(s.Hooks.Prestart, specs.Hook{
+		Path: target,
+		Args: []string{"set-diskquota", c.BaseFS, rootFSQuota, qid},
+	})
 
 	return nil
 }

--- a/storage/quota/quota.go
+++ b/storage/quota/quota.go
@@ -164,12 +164,13 @@ func SetRootfsDiskQuota(basefs, size string, quotaID uint32) error {
 			return fmt.Errorf("failed to set subtree: %v", err)
 		}
 
-		err = SetDiskQuota(dir, size, quotaID)
-		if err != nil {
+		if err := SetDiskQuota(dir, size, quotaID); err != nil {
 			return fmt.Errorf("failed to set disk quota: %v", err)
 		}
 
-		return setQuotaForDir(dir, quotaID)
+		if err := setQuotaForDir(dir, quotaID); err != nil {
+			return fmt.Errorf("failed to set dir quota: %v", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>


### Ⅰ. Describe what this PR did
Update env of running container failed: Invalid cross-device link, caused by not set overlayfs `work` diskquota

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
wrong container's disk quota:
```
[root@e19h16400.et15sqa /home/ziren.wzr]
#lsattr -p /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/170
    0 --------------e---- /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/170/work
16777514 --------------e---P /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/170/fs
```

normal container's disk quota, `workdir` disk quota is 0:
```
[root@e19h16400.et15sqa /home/ziren.wzr]
#lsattr -p /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/171
16777514 --------------e---P /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/171/work
16777514 --------------e---P /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/171/fs
```
### Ⅴ. Special notes for reviews


