### PR TITLE
bugfix: can't stop a paused container

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -180,11 +180,12 @@ func (mgr *ContainerManager) Restore(ctx context.Context) error {
 		// put container into cache.
 		mgr.cache.Put(containerMeta.ID, &Container{meta: containerMeta})
 
-		if containerMeta.State.Status != types.StatusRunning {
+		if containerMeta.State.Status != types.StatusRunning &&
+			containerMeta.State.Status != types.StatusPaused {
 			return nil
 		}
 
-		// recover the running container.
+		// recover the running or paused container.
 		io, err := mgr.openContainerIO(containerMeta.ID, containerMeta.Config.OpenStdin)
 		if err != nil {
 			logrus.Errorf("failed to recover container: %s,  %v", containerMeta.ID, err)
@@ -695,7 +696,7 @@ func (mgr *ContainerManager) Stop(ctx context.Context, name string, timeout int6
 	c.Lock()
 	defer c.Unlock()
 
-	if !c.IsRunning() {
+	if !c.IsRunning() && !c.IsPaused() {
 		// stopping a non-running container is valid.
 		return nil
 	}
@@ -1374,8 +1375,8 @@ func (mgr *ContainerManager) Restart(ctx context.Context, name string, timeout i
 		timeout = c.StopTimeout()
 	}
 
-	if c.IsRunning() {
-		// stop container if it is running.
+	if c.IsRunning() || c.IsPaused() {
+		// stop container if it is running or paused.
 		if err := mgr.stop(ctx, c, timeout); err != nil {
 			logrus.Errorf("failed to stop container %s when restarting: %v", c.ID(), err)
 			return errors.Wrapf(err, fmt.Sprintf("failed to stop container %s", c.ID()))

--- a/test/api_container_restart_test.go
+++ b/test/api_container_restart_test.go
@@ -58,3 +58,20 @@ func (suite *APIContainerRestartSuite) TestAPIRestartStoppedContainer(c *check.C
 
 	DelContainerForceOk(c, cname)
 }
+
+// TestAPIRestartPausedContainer is to verify restarting a paused container.
+func (suite *APIContainerRestartSuite) TestAPIRestartPausedContainer(c *check.C) {
+	cname := "TestAPIRestartPauseContainer"
+
+	CreateBusyboxContainerOk(c, cname)
+	StartContainerOk(c, cname)
+	PauseContainerOk(c, cname)
+
+	q := url.Values{}
+	q.Add("t", "1")
+	query := request.WithQuery(q)
+
+	resp, err := request.Post("/containers/"+cname+"/restart", query)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 204)
+}

--- a/test/cli_restart_test.go
+++ b/test/cli_restart_test.go
@@ -58,3 +58,17 @@ func (suite *PouchRestartSuite) TestPouchRestartStoppedContainer(c *check.C) {
 
 	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
+
+// TestPouchRestartPausedContainer is to verify restart paused container
+func (suite *PouchRestartSuite) TestPouchRestartPausedContainer(c *check.C) {
+	name := "TestPouchRestartPausedContainer"
+
+	command.PouchRun("run", "-d", "--name", name, busyboxImage).Assert(c, icmd.Success)
+
+	command.PouchRun("pause", name).Assert(c, icmd.Success)
+
+	res := command.PouchRun("restart", name)
+	c.Assert(res.Error, check.IsNil)
+
+	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
+}


### PR DESCRIPTION
can't stop a paused container
after restart pouch, can't unpause a paused container

Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

fixes #1268

* can't stop a paused container
* after restart pouch, can't unpause a paused container

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

* when stop the container, if the container is paused, allow it
* restore a paused container when start the pouchd daemon


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


