### PR TITLE
bugfix:  restart_paused_container ci failed

### DIFF
--- a/test/cli_restart_test.go
+++ b/test/cli_restart_test.go
@@ -63,7 +63,7 @@ func (suite *PouchRestartSuite) TestPouchRestartStoppedContainer(c *check.C) {
 func (suite *PouchRestartSuite) TestPouchRestartPausedContainer(c *check.C) {
 	name := "TestPouchRestartPausedContainer"
 
-	command.PouchRun("run", "-d", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 
 	command.PouchRun("pause", name).Assert(c, icmd.Success)
 


### PR DESCRIPTION
Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

restart_paused_container ci failed

```
FAIL: /go/src/github.com/alibaba/pouch/test/cli_restart_test.go:63: PouchRestartSuite.TestPouchRestartPausedContainer
/go/src/github.com/alibaba/pouch/test/cli_restart_test.go:68:
    command.PouchRun("pause", name).Assert(c, icmd.Success)
/go/src/github.com/alibaba/pouch/vendor/github.com/gotestyourself/gotestyourself/icmd/command.go:61:
    t.Fatalf("at %s:%d - %s\n", filepath.Base(file), line, err.Error())
... Error: at cli_restart_test.go:68 - 
Command:  /usr/local/bin/pouch pause TestPouchRestartPausedContainer
ExitCode: 1
Error:    exit status 1
Stdout:   
Stderr:   Error: failed to pause container TestPouchRestartPausedContainer: {"message":"container's status is not running: exited"}
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


