### PR TITLE
test: make test more robust

### DIFF
--- a/test/api_image_create_test.go
+++ b/test/api_image_create_test.go
@@ -27,7 +27,7 @@ func (suite *APIImageCreateSuite) SetUpTest(c *check.C) {
 func (suite *APIImageCreateSuite) TestImageCreateOk(c *check.C) {
 	q := url.Values{}
 	q.Add("fromImage", environment.HelloworldRepo)
-	q.Add("tag", "linux")
+	q.Add("tag", "latest")
 	query := request.WithQuery(q)
 	resp, err := request.Post("/images/create", query)
 	c.Assert(err, check.IsNil)
@@ -36,7 +36,7 @@ func (suite *APIImageCreateSuite) TestImageCreateOk(c *check.C) {
 	// TODO: add a waituntil func to check the exsitence of image
 	time.Sleep(5000 * time.Millisecond)
 
-	resp, err = request.Delete("/images/" + environment.HelloworldRepo + ":linux")
+	resp, err = request.Delete("/images/" + environment.HelloworldRepo + ":latest")
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 204)
 }

--- a/test/api_system_test.go
+++ b/test/api_system_test.go
@@ -73,13 +73,8 @@ func (suite *APISystemSuite) TestVersion(c *check.C) {
 	got.KernelVersion = ""
 	got.BuildTime = ""
 
-	c.Assert(got, check.Equals, types.SystemVersion{
-		APIVersion: version.APIVersion,
-		Arch:       runtime.GOARCH,
-		GoVersion:  runtime.Version(),
-		Os:         runtime.GOOS,
-		Version:    version.Version,
-	})
+	c.Assert(got.APIVersion, check.Equals, version.APIVersion)
+	c.Assert(got.Version, check.Equals, version.Version)
 }
 
 // If the /auth is ready, we can login to the registry.

--- a/test/api_volume_list_test.go
+++ b/test/api_volume_list_test.go
@@ -25,10 +25,12 @@ func (suite *APIVolumeListSuite) TestVolumeListOk(c *check.C) {
 	// Create a volume with the name "TestVolume1".
 	err := CreateVolume(c, "TestVolume1", "local")
 	c.Assert(err, check.IsNil)
+	defer RemoveVolume(c, "TestVolume1")
 
 	// Create a volume with the name "TestVolume1".
 	err = CreateVolume(c, "TestVolume2", "local")
 	c.Assert(err, check.IsNil)
+	defer RemoveVolume(c, "TestVolume2")
 
 	// Test volume list feature.
 	path := "/volumes"
@@ -40,13 +42,13 @@ func (suite *APIVolumeListSuite) TestVolumeListOk(c *check.C) {
 	volumeListResp := &types.VolumeListResp{}
 	err = request.DecodeBody(volumeListResp, resp.Body)
 	c.Assert(err, check.IsNil)
-	c.Assert(len(volumeListResp.Volumes), check.Equals, 2)
 
-	// Delete the TestVolume1.
-	err = RemoveVolume(c, "TestVolume1")
-	c.Assert(err, check.IsNil)
-
-	// Delete the TestVolume2.
-	err = RemoveVolume(c, "TestVolume2")
-	c.Assert(err, check.IsNil)
+	// Check response having the pre-created two volumes.
+	found := 0
+	for _, volume := range volumeListResp.Volumes {
+		if volume.Name == "TestVolume1" || volume.Name == "TestVolume2" {
+			found++
+		}
+	}
+	c.Assert(found, check.Equals, 2)
 }

--- a/test/cli_alikernel_test.go
+++ b/test/cli_alikernel_test.go
@@ -57,7 +57,7 @@ func (suite *PouchAliKernelSuite) TestAliKernelDiskQuotaWorks(c *check.C) {
 	// generate a file larger than 1G should fail.
 	expct = icmd.Expected{
 		// TODO: Add exit code check when pouch exec return the exit code of process
-		Out: "Disk quota exceeded",
+		Error: "Disk quota exceeded",
 	}
 	cmd := "dd if=/dev/zero of=/mnt/test bs=1024k count=1500"
 	err = command.PouchRun("exec", funcname, "sh", "-c", cmd).Compare(expct)

--- a/test/cli_images_test.go
+++ b/test/cli_images_test.go
@@ -34,7 +34,7 @@ func (suite *PouchImagesSuite) SetUpSuite(c *check.C) {
 	PullImage(c, busyboxImage)
 }
 
-// TestImagesWorks tests "pouch image" work.
+// TestImagesWorks tests "pouch images" work.
 func (suite *PouchImagesSuite) TestImagesWorks(c *check.C) {
 	image, err := getImageInfo(apiClient, busyboxImage)
 	c.Assert(err, check.IsNil)
@@ -61,7 +61,7 @@ func (suite *PouchImagesSuite) TestImagesWorks(c *check.C) {
 	{
 		res := command.PouchRun("images", "--digest").Assert(c, icmd.Success)
 		items := imagesListToKV(res.Combined())[busyboxImage]
-		c.Assert(items[2], check.Equals, strings.TrimPrefix(image.RepoDigests[0], "registry.hub.docker.com/library/busybox@"))
+		c.Assert(items[2], check.Equals, strings.TrimPrefix(image.RepoDigests[0], environment.BusyboxRepo+"@"))
 	}
 }
 

--- a/test/cli_volume_test.go
+++ b/test/cli_volume_test.go
@@ -15,11 +15,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/icmd"
 )
 
-var (
-	// DefaultVolumeMountPath defines the default volume mount path.
-	DefaultVolumeMountPath = DefaultRootDir + "/volume"
-)
-
 // PouchVolumeSuite is the test suite for volume CLI.
 type PouchVolumeSuite struct{}
 

--- a/test/util_daemon.go
+++ b/test/util_daemon.go
@@ -6,16 +6,43 @@ import (
 	"os"
 	"strings"
 
+	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/daemon"
+	"github.com/alibaba/pouch/test/request"
 
 	"github.com/gotestyourself/gotestyourself/icmd"
 )
 
 var (
 	// DefaultRootDir defines the default root dir for pouchd.
-	DefaultRootDir = "/var/lib/pouch"
+	DefaultRootDir string
+	// DefaultVolumeMountPath defines the default volume mount path.
+	DefaultVolumeMountPath string
 )
+
+func init() {
+	GetRootDir(&DefaultRootDir)
+	// DefaultVolumeMountPath defines the default volume mount path.
+	DefaultVolumeMountPath = DefaultRootDir + "/volume"
+}
+
+// GetRootDir assign the root dir
+func GetRootDir(rootdir *string) error {
+	resp, err := request.Get("/info")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	got := types.SystemInfo{}
+	err = json.NewDecoder(resp.Body).Decode(&got)
+	if err != nil {
+		return err
+	}
+	*rootdir = got.PouchRootDir
+	return nil
+}
 
 // StartDefaultDaemonDebug starts a deamon with default configuration and debug on.
 func StartDefaultDaemonDebug(args ...string) (*daemon.Config, error) {


### PR DESCRIPTION
Signed-off-by: letty <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This PR mainly fixed some potential failure when tests run in no-travis-CI  environment.
For example:
* if the `homedir` of pouch daemon is not default value,  we need to get it dynamically.
* If there is legacy volumes, tests like `TestVolumeListOk ` may fail as it checks there are totally and exactly two volumes.
* If users set test images instead of using default ones, test `TestImagesWorks ` may fail.
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->



### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


