### PR TITLE
refactor: eliminate containerMeta in daemon manager

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -98,8 +98,8 @@ func (s *Server) removeImage(ctx context.Context, rw http.ResponseWriter, req *h
 		return err
 	}
 
-	containers, err := s.ContainerMgr.List(ctx, func(meta *mgr.ContainerMeta) bool {
-		return meta.Image == image.ID
+	containers, err := s.ContainerMgr.List(ctx, func(c *mgr.Container) bool {
+		return c.Image == image.ID
 	}, &mgr.ContainerListOption{All: true})
 	if err != nil {
 		return err

--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -349,12 +349,12 @@ func (c *Client) createContainer(ctx context.Context, ref, id string, container 
 	img, err := wrapperCli.client.GetImage(ctx, ref)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
-			return errors.Wrap(errtypes.ErrNotfound, "image")
+			return errors.Wrapf(errtypes.ErrNotfound, "image %s", ref)
 		}
-		return errors.Wrapf(err, "failed to get image: %s", ref)
+		return errors.Wrapf(err, "failed to get image %s", ref)
 	}
 
-	logrus.Infof("success to get image: %s, container id: %s", img.Name(), id)
+	logrus.Infof("success to get image %s, container id %s", img.Name(), id)
 
 	// create container
 	specOptions := []oci.SpecOpts{
@@ -375,13 +375,13 @@ func (c *Client) createContainer(ctx context.Context, ref, id string, container 
 
 	// check snapshot exist or not.
 	if _, err := c.GetSnapshot(ctx, id); err != nil {
-		return errors.Wrapf(err, "failed to create container, id: %s", id)
+		return errors.Wrapf(err, "failed to create container %s", id)
 	}
 	options = append(options, containerd.WithSnapshot(id))
 
 	nc, err := wrapperCli.client.NewContainer(ctx, id, options...)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create container, id: %s", id)
+		return errors.Wrapf(err, "failed to create container %s", id)
 	}
 
 	defer func() {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -54,7 +54,7 @@ func NewDaemon(cfg *config.Config) *Daemon {
 		Buckets: []meta.Bucket{
 			{
 				Name: meta.MetaJSONFile,
-				Type: reflect.TypeOf(mgr.ContainerMeta{}),
+				Type: reflect.TypeOf(mgr.Container{}),
 			},
 		},
 	})

--- a/daemon/mgr/container_exec.go
+++ b/daemon/mgr/container_exec.go
@@ -21,14 +21,14 @@ func (mgr *ContainerManager) CreateExec(ctx context.Context, name string, config
 	}
 
 	if !c.IsRunning() {
-		return "", fmt.Errorf("container %s is not running", c.ID())
+		return "", fmt.Errorf("container %s is not running", c.ID)
 	}
 
 	execid := randomid.Generate()
 	execConfig := &ContainerExecConfig{
 		ExecID:           execid,
 		ExecCreateConfig: *config,
-		ContainerID:      c.ID(),
+		ContainerID:      c.ID,
 	}
 
 	mgr.ExecProcesses.Put(execid, execConfig)
@@ -65,19 +65,19 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, confi
 		Args:     execConfig.Cmd,
 		Terminal: execConfig.Tty,
 		Cwd:      "/",
-		Env:      c.Config().Env,
+		Env:      c.Config.Env,
 	}
 
 	if execConfig.User != "" {
-		c.meta.Config.User = execConfig.User
+		c.Config.User = execConfig.User
 	}
 
-	if err = setupUser(ctx, c.meta, &specs.Spec{Process: process}); err != nil {
+	if err = setupUser(ctx, c, &specs.Spec{Process: process}); err != nil {
 		return err
 	}
 
 	// set exec process ulimit
-	if err := setupRlimits(ctx, c.meta.HostConfig, &specs.Spec{Process: process}); err != nil {
+	if err := setupRlimits(ctx, c.HostConfig, &specs.Spec{Process: process}); err != nil {
 		return err
 	}
 

--- a/daemon/mgr/container_monitor.go
+++ b/daemon/mgr/container_monitor.go
@@ -24,7 +24,7 @@ type ContainerEvent struct {
 func (e *ContainerEvent) String() string {
 	switch e.Kind {
 	case EvExit:
-		return fmt.Sprintf("%s exit", e.c.ID())
+		return fmt.Sprintf("%s exit", e.c.ID)
 	default:
 		return "none"
 	}

--- a/daemon/mgr/container_rich_mode.go
+++ b/daemon/mgr/container_rich_mode.go
@@ -14,7 +14,7 @@ const (
 	interRichModeEnv = "ali_run_mode=common_vm"
 )
 
-func richContainerModeEnv(c *ContainerMeta) []string {
+func richContainerModeEnv(c *Container) []string {
 	var (
 		ret         = []string{}
 		setRichMode = false

--- a/daemon/mgr/container_rich_mode_test.go
+++ b/daemon/mgr/container_rich_mode_test.go
@@ -22,7 +22,7 @@ func convertEnvArrayToMap(envs []string) map[string]string {
 }
 
 func TestRichModeSet(t *testing.T) {
-	c := &ContainerMeta{
+	c := &Container{
 		Config: &types.ContainerConfig{
 			Rich: true,
 		},
@@ -35,7 +35,7 @@ func TestRichModeSet(t *testing.T) {
 	assert.Equal(t, types.ContainerConfigRichModeDumbInit, mEnvs1[richModeLaunchEnv])
 
 	//test not set rich mode
-	c = &ContainerMeta{
+	c = &Container{
 		Config: &types.ContainerConfig{
 			Rich: false,
 		},
@@ -44,7 +44,7 @@ func TestRichModeSet(t *testing.T) {
 	assert.Equal(t, 0, len(envs2))
 
 	//test set rich mode manner, not set rich mode
-	c = &ContainerMeta{
+	c = &Container{
 		Config: &types.ContainerConfig{
 			Rich:     false,
 			RichMode: types.ContainerConfigRichModeSystemd,
@@ -54,7 +54,7 @@ func TestRichModeSet(t *testing.T) {
 	assert.Equal(t, 0, len(envs3))
 
 	//test set rich mode manner
-	c = &ContainerMeta{
+	c = &Container{
 		Config: &types.ContainerConfig{
 			Rich:     true,
 			RichMode: types.ContainerConfigRichModeSystemd,
@@ -66,7 +66,7 @@ func TestRichModeSet(t *testing.T) {
 	assert.Equal(t, types.ContainerConfigRichModeSystemd, mEnvs4[richModeLaunchEnv])
 
 	//test set rich mode by env
-	c = &ContainerMeta{
+	c = &Container{
 		Config: &types.ContainerConfig{
 			Env: []string{
 				interRichModeEnv,

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -29,7 +29,7 @@ const (
 
 // ContainerFilter defines a function to filter
 // container in the store.
-type ContainerFilter func(*ContainerMeta) bool
+type ContainerFilter func(*Container) bool
 
 // ContainerExecConfig is the config a process exec.
 type ContainerExecConfig struct {
@@ -86,8 +86,9 @@ type ContainerListOption struct {
 	All bool
 }
 
-// ContainerMeta represents the container's meta data.
-type ContainerMeta struct {
+// Container represents the container's meta data.
+type Container struct {
+	sync.Mutex
 
 	// app armor profile
 	AppArmorProfile string `json:"AppArmorProfile,omitempty"`
@@ -176,14 +177,60 @@ type ContainerMeta struct {
 
 	// BaseFS
 	BaseFS string `json:"BaseFS, omitempty"`
+
+	// Escape keys for detach
+	DetachKeys string
 }
 
 // Key returns container's id.
-func (meta *ContainerMeta) Key() string {
-	return meta.ID
+func (c *Container) Key() string {
+	return c.ID
 }
 
-func (meta *ContainerMeta) merge(getconfig func() (v1.ImageConfig, error)) error {
+// IsRunning returns container is running or not.
+func (c *Container) IsRunning() bool {
+	return c.State.Status == types.StatusRunning
+}
+
+// IsStopped returns container is stopped or not.
+func (c *Container) IsStopped() bool {
+	return c.State.Status == types.StatusStopped
+}
+
+// IsExited returns container is exited or not.
+func (c *Container) IsExited() bool {
+	return c.State.Status == types.StatusExited
+}
+
+// IsCreated returns container is created or not.
+func (c *Container) IsCreated() bool {
+	return c.State.Status == types.StatusCreated
+}
+
+// IsPaused returns container is paused or not.
+func (c *Container) IsPaused() bool {
+	return c.State.Status == types.StatusPaused
+}
+
+// IsRestarting returns container is restarting or not.
+func (c *Container) IsRestarting() bool {
+	return c.State.Status == types.StatusRestarting
+}
+
+// Write writes container's meta data into meta store.
+func (c *Container) Write(store *meta.Store) error {
+	return store.Put(c)
+}
+
+// StopTimeout returns the timeout (in seconds) used to stop the container.
+func (c *Container) StopTimeout() int64 {
+	if c.Config.StopTimeout != nil {
+		return *c.Config.StopTimeout
+	}
+	return DefaultStopTimeout
+}
+
+func (c *Container) merge(getconfig func() (v1.ImageConfig, error)) error {
 	config, err := getconfig()
 	if err != nil {
 		return err
@@ -191,31 +238,31 @@ func (meta *ContainerMeta) merge(getconfig func() (v1.ImageConfig, error)) error
 
 	// If user specify the Entrypoint, no need to merge image's configuration.
 	// Otherwise use the image's configuration to fill it.
-	if len(meta.Config.Entrypoint) == 0 {
-		if len(meta.Config.Cmd) == 0 {
-			meta.Config.Cmd = config.Cmd
+	if len(c.Config.Entrypoint) == 0 {
+		if len(c.Config.Cmd) == 0 {
+			c.Config.Cmd = config.Cmd
 		}
-		meta.Config.Entrypoint = config.Entrypoint
+		c.Config.Entrypoint = config.Entrypoint
 	}
-	if meta.Config.Env == nil {
-		meta.Config.Env = config.Env
+	if c.Config.Env == nil {
+		c.Config.Env = config.Env
 	} else {
-		meta.Config.Env = append(meta.Config.Env, config.Env...)
+		c.Config.Env = append(c.Config.Env, config.Env...)
 	}
-	if meta.Config.WorkingDir == "" {
-		meta.Config.WorkingDir = config.WorkingDir
+	if c.Config.WorkingDir == "" {
+		c.Config.WorkingDir = config.WorkingDir
 	}
 
 	return nil
 }
 
 // FormatStatus format container status
-func (meta *ContainerMeta) FormatStatus() (string, error) {
+func (c *Container) FormatStatus() (string, error) {
 	var status string
 
-	switch meta.State.Status {
+	switch c.State.Status {
 	case types.StatusRunning, types.StatusPaused:
-		start, err := time.Parse(utils.TimeLayout, meta.State.StartedAt)
+		start, err := time.Parse(utils.TimeLayout, c.State.StartedAt)
 		if err != nil {
 			return "", err
 		}
@@ -226,12 +273,12 @@ func (meta *ContainerMeta) FormatStatus() (string, error) {
 		}
 
 		status = "Up " + startAt
-		if meta.State.Status == types.StatusPaused {
+		if c.State.Status == types.StatusPaused {
 			status += "(paused)"
 		}
 
 	case types.StatusStopped, types.StatusExited:
-		finish, err := time.Parse(utils.TimeLayout, meta.State.FinishedAt)
+		finish, err := time.Parse(utils.TimeLayout, c.State.FinishedAt)
 		if err != nil {
 			return "", err
 		}
@@ -242,100 +289,20 @@ func (meta *ContainerMeta) FormatStatus() (string, error) {
 		}
 
 		//FIXME: if stop status is needed ?
-		exitCode := meta.State.ExitCode
-		if meta.State.Status == types.StatusStopped {
+		exitCode := c.State.ExitCode
+		if c.State.Status == types.StatusStopped {
 			status = fmt.Sprintf("Stopped (%d) %s", exitCode, finishAt)
 		}
-		if meta.State.Status == types.StatusExited {
+		if c.State.Status == types.StatusExited {
 			status = fmt.Sprintf("Exited (%d) %s", exitCode, finishAt)
 		}
 	}
 
 	if status == "" {
-		return string(meta.State.Status), nil
+		return string(c.State.Status), nil
 	}
 
 	return status, nil
-}
-
-// Container represents the container instance in runtime.
-type Container struct {
-	sync.Mutex
-	meta       *ContainerMeta
-	DetachKeys string
-}
-
-// Key returns container's id.
-func (c *Container) Key() string {
-	return c.meta.ID
-}
-
-// ID returns container's id.
-func (c *Container) ID() string {
-	return c.meta.ID
-}
-
-// Image returns container's image name.
-func (c *Container) Image() string {
-	return c.meta.Config.Image
-}
-
-// Name returns container's name.
-func (c *Container) Name() string {
-	return c.meta.Name
-}
-
-// Config returns container's config.
-func (c *Container) Config() *types.ContainerConfig {
-	return c.meta.Config
-}
-
-// HostConfig returns container's hostconfig.
-func (c *Container) HostConfig() *types.HostConfig {
-	return c.meta.HostConfig
-}
-
-// IsRunning returns container is running or not.
-func (c *Container) IsRunning() bool {
-	return c.meta.State.Status == types.StatusRunning
-}
-
-// IsStopped returns container is stopped or not.
-func (c *Container) IsStopped() bool {
-	return c.meta.State.Status == types.StatusStopped
-}
-
-// IsExited returns container is exited or not.
-func (c *Container) IsExited() bool {
-	return c.meta.State.Status == types.StatusExited
-}
-
-// IsCreated returns container is created or not.
-func (c *Container) IsCreated() bool {
-	return c.meta.State.Status == types.StatusCreated
-}
-
-// IsPaused returns container is paused or not.
-func (c *Container) IsPaused() bool {
-	return c.meta.State.Status == types.StatusPaused
-}
-
-// IsRestarting returns container is restarting or not.
-func (c *Container) IsRestarting() bool {
-	return c.meta.State.Status == types.StatusRestarting
-}
-
-// Write writes container's meta data into meta store.
-func (c *Container) Write(store *meta.Store) error {
-	return store.Put(c.meta)
-}
-
-// StopTimeout returns the timeout (in seconds) used to stop the container.
-func (c *Container) StopTimeout() int64 {
-	if c.meta.Config.StopTimeout != nil {
-		return *c.meta.Config.StopTimeout
-	}
-	return DefaultStopTimeout
 }
 
 // ContainerRestartPolicy represents the policy is used to manage container.

--- a/daemon/mgr/container_types_test.go
+++ b/daemon/mgr/container_types_test.go
@@ -12,17 +12,17 @@ import (
 
 type tCase struct {
 	name     string
-	input    *ContainerMeta
+	input    *Container
 	expected string
 	err      error
 }
 
-func TestContainerMeta_FormatStatus(t *testing.T) {
+func TestContainer_FormatStatus(t *testing.T) {
 	// TODO: add more cases
 	for _, tc := range []tCase{
 		{
 			name: "Created",
-			input: &ContainerMeta{
+			input: &Container{
 				State: &types.ContainerState{
 					Status: types.StatusCreated,
 				},
@@ -32,7 +32,7 @@ func TestContainerMeta_FormatStatus(t *testing.T) {
 		},
 		{
 			name: "Exited",
-			input: &ContainerMeta{
+			input: &Container{
 				State: &types.ContainerState{
 					Status:     types.StatusExited,
 					FinishedAt: time.Now().Add(0 - utils.Hour).UTC().Format(utils.TimeLayout),
@@ -44,7 +44,7 @@ func TestContainerMeta_FormatStatus(t *testing.T) {
 		},
 		{
 			name: "Stopped",
-			input: &ContainerMeta{
+			input: &Container{
 				State: &types.ContainerState{
 					Status:     types.StatusStopped,
 					FinishedAt: time.Now().Add(0 - utils.Minute).UTC().Format(utils.TimeLayout),
@@ -56,7 +56,7 @@ func TestContainerMeta_FormatStatus(t *testing.T) {
 		},
 		{
 			name: "Running",
-			input: &ContainerMeta{
+			input: &Container{
 				State: &types.ContainerState{
 					Status:    types.StatusRunning,
 					StartedAt: time.Now().Add(0 - utils.Minute).UTC().Format(utils.TimeLayout),
@@ -67,7 +67,7 @@ func TestContainerMeta_FormatStatus(t *testing.T) {
 		},
 		{
 			name: "Paused",
-			input: &ContainerMeta{
+			input: &Container{
 				State: &types.ContainerState{
 					Status:    types.StatusPaused,
 					StartedAt: time.Now().Add(0 - utils.Minute*2).UTC().Format(utils.TimeLayout),

--- a/daemon/mgr/container_utils.go
+++ b/daemon/mgr/container_utils.go
@@ -38,12 +38,12 @@ func (mgr *ContainerManager) containerID(nameOrPrefix string) (string, error) {
 	}
 	obj = objs[0]
 
-	containerMeta, ok := obj.(*ContainerMeta)
+	con, ok := obj.(*Container)
 	if !ok {
 		return "", fmt.Errorf("failed to get container info, invalid meta's type")
 	}
 
-	return containerMeta.ID, nil
+	return con.ID, nil
 }
 
 func (mgr *ContainerManager) container(nameOrPrefix string) (*Container, error) {
@@ -103,14 +103,14 @@ func (mgr *ContainerManager) generateName(id string) string {
 	return name
 }
 
-func parseSecurityOpts(meta *ContainerMeta, securityOpts []string) error {
+func parseSecurityOpts(c *Container, securityOpts []string) error {
 	var (
 		labelOpts []string
 		err       error
 	)
 	for _, securityOpt := range securityOpts {
 		if securityOpt == "no-new-privileges" {
-			meta.NoNewPrivileges = true
+			c.NoNewPrivileges = true
 			continue
 		}
 		fields := strings.SplitN(securityOpt, "=", 2)
@@ -121,15 +121,15 @@ func parseSecurityOpts(meta *ContainerMeta, securityOpts []string) error {
 		switch key {
 		// TODO: handle other security options.
 		case "apparmor":
-			meta.AppArmorProfile = value
+			c.AppArmorProfile = value
 		case "seccomp":
-			meta.SeccompProfile = value
+			c.SeccompProfile = value
 		case "no-new-privileges":
 			noNewPrivileges, err := strconv.ParseBool(value)
 			if err != nil {
 				return fmt.Errorf("invalid --security-opt: %q", securityOpt)
 			}
-			meta.NoNewPrivileges = noNewPrivileges
+			c.NoNewPrivileges = noNewPrivileges
 		case "label":
 			labelOpts = append(labelOpts, value)
 		default:
@@ -140,7 +140,7 @@ func parseSecurityOpts(meta *ContainerMeta, securityOpts []string) error {
 	if len(labelOpts) == 0 {
 		return nil
 	}
-	meta.ProcessLabel, meta.MountLabel, err = label.InitLabels(labelOpts)
+	c.ProcessLabel, c.MountLabel, err = label.InitLabels(labelOpts)
 	if err != nil {
 		return fmt.Errorf("failed to init labels: %v", err)
 	}

--- a/daemon/mgr/container_utils_test.go
+++ b/daemon/mgr/container_utils_test.go
@@ -19,7 +19,7 @@ func TestContainerManager_generateID(t *testing.T) {
 		Buckets: []meta.Bucket{
 			{
 				Name: meta.MetaJSONFile,
-				Type: reflect.TypeOf(ContainerMeta{}),
+				Type: reflect.TypeOf(Container{}),
 			},
 		},
 	})
@@ -80,7 +80,7 @@ func TestContainerManager_generateName(t *testing.T) {
 
 func Test_parseSecurityOpt(t *testing.T) {
 	type args struct {
-		meta        *ContainerMeta
+		meta        *Container
 		securityOpt string
 	}
 	tests := []struct {
@@ -91,7 +91,7 @@ func Test_parseSecurityOpt(t *testing.T) {
 		{
 			name: "invalid security option",
 			args: args{
-				meta:        &ContainerMeta{},
+				meta:        &Container{},
 				securityOpt: "",
 			},
 			wantErr: true,
@@ -99,7 +99,7 @@ func Test_parseSecurityOpt(t *testing.T) {
 		{
 			name: "invalid security option",
 			args: args{
-				meta:        &ContainerMeta{},
+				meta:        &Container{},
 				securityOpt: "apparmor:/tmp/file",
 			},
 			wantErr: true,
@@ -107,7 +107,7 @@ func Test_parseSecurityOpt(t *testing.T) {
 		{
 			name: "invalid security option",
 			args: args{
-				meta:        &ContainerMeta{},
+				meta:        &Container{},
 				securityOpt: "apparmor2=/tmp/file",
 			},
 			wantErr: true,
@@ -115,7 +115,7 @@ func Test_parseSecurityOpt(t *testing.T) {
 		{
 			name: "valid security option",
 			args: args{
-				meta:        &ContainerMeta{},
+				meta:        &Container{},
 				securityOpt: "apparmor=/tmp/file",
 			},
 			wantErr: false,
@@ -123,7 +123,7 @@ func Test_parseSecurityOpt(t *testing.T) {
 		{
 			name: "valid security option",
 			args: args{
-				meta:        &ContainerMeta{},
+				meta:        &Container{},
 				securityOpt: "seccomp=asdfghjkl",
 			},
 			wantErr: false,

--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -241,7 +241,7 @@ func (c *CriManager) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandb
 	sandboxMeta := res.(*SandboxMeta)
 
 	opts := &ContainerListOption{All: true}
-	filter := func(c *ContainerMeta) bool {
+	filter := func(c *Container) bool {
 		return c.Config.Labels[sandboxIDLabelKey] == podSandboxID
 	}
 
@@ -299,7 +299,7 @@ func (c *CriManager) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 	podSandboxID := r.GetPodSandboxId()
 
 	opts := &ContainerListOption{All: true}
-	filter := func(c *ContainerMeta) bool {
+	filter := func(c *Container) bool {
 		return c.Config.Labels[sandboxIDLabelKey] == podSandboxID
 	}
 
@@ -400,7 +400,7 @@ func (c *CriManager) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 // ListPodSandbox returns a list of Sandbox.
 func (c *CriManager) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (*runtime.ListPodSandboxResponse, error) {
 	opts := &ContainerListOption{All: true}
-	filter := func(c *ContainerMeta) bool {
+	filter := func(c *Container) bool {
 		return c.Config.Labels[containerTypeLabelKey] == containerTypeLabelSandbox
 	}
 
@@ -540,7 +540,7 @@ func (c *CriManager) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 // ListContainers lists all containers matching the filter.
 func (c *CriManager) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (*runtime.ListContainersResponse, error) {
 	opts := &ContainerListOption{All: true}
-	filter := func(c *ContainerMeta) bool {
+	filter := func(c *Container) bool {
 		return c.Config.Labels[containerTypeLabelKey] == containerTypeLabelContainer
 	}
 

--- a/daemon/mgr/cri_utils.go
+++ b/daemon/mgr/cri_utils.go
@@ -266,7 +266,7 @@ func toCriSandboxState(status apitypes.Status) runtime.PodSandboxState {
 	}
 }
 
-func toCriSandbox(c *ContainerMeta) (*runtime.PodSandbox, error) {
+func toCriSandbox(c *Container) (*runtime.PodSandbox, error) {
 	state := toCriSandboxState(c.State.Status)
 	metadata, err := parseSandboxName(c.Name)
 	if err != nil {
@@ -630,7 +630,7 @@ func toCriContainerState(status apitypes.Status) runtime.ContainerState {
 	}
 }
 
-func toCriContainer(c *ContainerMeta) (*runtime.Container, error) {
+func toCriContainer(c *Container) (*runtime.Container, error) {
 	state := toCriContainerState(c.State.Status)
 	metadata, err := parseContainerName(c.Name)
 	if err != nil {
@@ -688,7 +688,7 @@ func filterCRIContainers(containers []*runtime.Container, filter *runtime.Contai
 }
 
 // containerNetns returns the network namespace of the given container.
-func containerNetns(container *ContainerMeta) string {
+func containerNetns(container *Container) string {
 	pid := container.State.Pid
 	if pid == -1 {
 		// Pouch reports pid -1 for an exited container.

--- a/daemon/mgr/cri_utils_test.go
+++ b/daemon/mgr/cri_utils_test.go
@@ -332,7 +332,7 @@ func Test_toCriSandboxState(t *testing.T) {
 
 func Test_toCriSandbox(t *testing.T) {
 	type args struct {
-		c *ContainerMeta
+		c *Container
 	}
 	tests := []struct {
 		name    string
@@ -643,7 +643,7 @@ func TestCriManager_updateCreateConfig(t *testing.T) {
 
 func Test_toCriContainer(t *testing.T) {
 	type args struct {
-		c *ContainerMeta
+		c *Container
 	}
 	tests := []struct {
 		name    string

--- a/daemon/mgr/spec.go
+++ b/daemon/mgr/spec.go
@@ -21,7 +21,7 @@ type SpecWrapper struct {
 }
 
 // createSpec create a runtime-spec.
-func createSpec(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) error {
+func createSpec(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
 	// new a default spec from containerd.
 	s, err := ctrd.NewDefaultSpec(ctx, c.ID)
 	if err != nil {

--- a/daemon/mgr/spec_annotations.go
+++ b/daemon/mgr/spec_annotations.go
@@ -9,7 +9,7 @@ import (
 )
 
 // setupAnnotations extracts other related options from HostConfig and locate them in spec's annotations which will be dealt by vendored runc.
-func setupAnnotations(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
+func setupAnnotations(ctx context.Context, c *Container, s *specs.Spec) error {
 	if s.Annotations == nil {
 		s.Annotations = make(map[string]string)
 	}

--- a/daemon/mgr/spec_hook.go
+++ b/daemon/mgr/spec_hook.go
@@ -17,7 +17,7 @@ import (
 )
 
 //setup hooks specified by user via plugins, if set rich mode and init-script exists set init-script
-func setupHook(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) error {
+func setupHook(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
 	s := specWrapper.s
 	if s.Hooks == nil {
 		s.Hooks = &specs.Hooks{
@@ -83,7 +83,7 @@ func setupHook(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) 
 	return nil
 }
 
-func setMountTab(ctx context.Context, c *ContainerMeta, spec *SpecWrapper) error {
+func setMountTab(ctx context.Context, c *Container, spec *SpecWrapper) error {
 	if len(c.BaseFS) == 0 {
 		return nil
 	}

--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -35,7 +35,7 @@ const (
 )
 
 // Setup linux-platform-sepecific specification.
-func populatePlatform(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) error {
+func populatePlatform(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
 	s := specWrapper.s
 	if s.Linux == nil {
 		s.Linux = &specs.Linux{}
@@ -90,7 +90,7 @@ func populatePlatform(ctx context.Context, c *ContainerMeta, specWrapper *SpecWr
 }
 
 // setupSeccomp creates seccomp security settings spec.
-func setupSeccomp(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
+func setupSeccomp(ctx context.Context, c *Container, s *specs.Spec) error {
 	if c.HostConfig.Privileged {
 		return nil
 	}
@@ -121,7 +121,7 @@ func setupSeccomp(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
 }
 
 // setupResource creates linux resource spec.
-func setupResource(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
+func setupResource(ctx context.Context, c *Container, s *specs.Spec) error {
 	if s.Linux.Resources == nil {
 		s.Linux.Resources = &specs.LinuxResources{}
 	}
@@ -272,7 +272,7 @@ func setupMemory(ctx context.Context, r types.Resources, s *specs.Spec) {
 }
 
 // setupResource creates linux device resource spec.
-func setupDevices(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
+func setupDevices(ctx context.Context, c *Container, s *specs.Spec) error {
 	var devs []specs.LinuxDevice
 	devPermissions := s.Linux.Resources.Devices
 	if c.HostConfig.Privileged {
@@ -384,7 +384,7 @@ func devicesFromPath(pathOnHost, pathInContainer, cgroupPermissions string) (dev
 }
 
 // setupNamespaces creates linux namespaces spec.
-func setupNamespaces(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) error {
+func setupNamespaces(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
 	// create user namespace spec
 	if err := setupUserNamespace(ctx, c, specWrapper); err != nil {
 		return err
@@ -461,7 +461,7 @@ func connectedContainer(mode string) string {
 	return ""
 }
 
-func getIpcContainer(ctx context.Context, mgr ContainerMgr, id string) (*ContainerMeta, error) {
+func getIpcContainer(ctx context.Context, mgr ContainerMgr, id string) (*Container, error) {
 	// Check whether the container exists.
 	c, err := mgr.Get(ctx, id)
 	if err != nil {
@@ -475,7 +475,7 @@ func getIpcContainer(ctx context.Context, mgr ContainerMgr, id string) (*Contain
 	return c, nil
 }
 
-func getPidContainer(ctx context.Context, mgr ContainerMgr, id string) (*ContainerMeta, error) {
+func getPidContainer(ctx context.Context, mgr ContainerMgr, id string) (*Container, error) {
 	// Check the container exists.
 	c, err := mgr.Get(ctx, id)
 	if err != nil {
@@ -488,11 +488,11 @@ func getPidContainer(ctx context.Context, mgr ContainerMgr, id string) (*Contain
 }
 
 // TODO
-func setupUserNamespace(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) error {
+func setupUserNamespace(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
 	return nil
 }
 
-func setupNetworkNamespace(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) error {
+func setupNetworkNamespace(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
 	if c.Config.NetworkDisabled {
 		return nil
 	}
@@ -535,7 +535,7 @@ func setupNetworkNamespace(ctx context.Context, c *ContainerMeta, specWrapper *S
 	return nil
 }
 
-func setupIpcNamespace(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) error {
+func setupIpcNamespace(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
 	s := specWrapper.s
 	ipcMode := c.HostConfig.IpcMode
 	switch {
@@ -556,7 +556,7 @@ func setupIpcNamespace(ctx context.Context, c *ContainerMeta, specWrapper *SpecW
 	return nil
 }
 
-func setupPidNamespace(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) error {
+func setupPidNamespace(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
 	s := specWrapper.s
 	pidMode := c.HostConfig.PidMode
 	switch {
@@ -577,7 +577,7 @@ func setupPidNamespace(ctx context.Context, c *ContainerMeta, specWrapper *SpecW
 	return nil
 }
 
-func setupUtsNamespace(ctx context.Context, c *ContainerMeta, specWrapper *SpecWrapper) error {
+func setupUtsNamespace(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
 	s := specWrapper.s
 	utsMode := c.HostConfig.UTSMode
 	switch {

--- a/daemon/mgr/spec_mount.go
+++ b/daemon/mgr/spec_mount.go
@@ -18,7 +18,7 @@ func clearReadonly(m *specs.Mount) {
 }
 
 // setupMounts create mount spec.
-func setupMounts(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
+func setupMounts(ctx context.Context, c *Container, s *specs.Spec) error {
 	mounts := s.Mounts
 	if c.HostConfig == nil {
 		return nil

--- a/daemon/mgr/spec_process.go
+++ b/daemon/mgr/spec_process.go
@@ -15,7 +15,7 @@ import (
 )
 
 // setupProcess setups spec process.
-func setupProcess(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
+func setupProcess(ctx context.Context, c *Container, s *specs.Spec) error {
 	if s.Process == nil {
 		s.Process = &specs.Process{}
 	}
@@ -65,14 +65,14 @@ func setupProcess(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
 	return nil
 }
 
-func createEnvironment(c *ContainerMeta) []string {
+func createEnvironment(c *Container) []string {
 	env := c.Config.Env
 	env = append(env, richContainerModeEnv(c)...)
 
 	return env
 }
 
-func setupUser(ctx context.Context, c *ContainerMeta, s *specs.Spec) (err error) {
+func setupUser(ctx context.Context, c *Container, s *specs.Spec) (err error) {
 	// container rootfs is created by containerd, pouch just creates a snapshot
 	// id and keeps it in memory. If container is in start process, we can not
 	// find if user if exist in container image, so we do some simple check.
@@ -137,7 +137,7 @@ func isAppArmorEnabled() bool {
 	return false
 }
 
-func setupAppArmor(ctx context.Context, c *ContainerMeta, s *specs.Spec) error {
+func setupAppArmor(ctx context.Context, c *Container, s *specs.Spec) error {
 	if !isAppArmorEnabled() {
 		// Return if the apparmor is disabled.
 		return nil

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -61,11 +61,11 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 
 	var cRunning, cPaused, cStopped int64
 	_ = mgr.store.ForEach(func(obj meta.Object) error {
-		containerMeta, ok := obj.(*ContainerMeta)
+		c, ok := obj.(*Container)
 		if !ok {
 			return nil
 		}
-		status := containerMeta.State.Status
+		status := c.State.Status
 		switch status {
 		case types.StatusRunning:
 			atomic.AddInt64(&cRunning, 1)


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

### Ⅰ. Describe what this PR did

In the ContainerMgr of original code, we have two structs which describe container instance, one is Container, and the other is ContainerMeta. While we have the following relationship between them:

```golang
type ContainerMeta struct {
    sync.Mutex
    *Container
    Detachkeys string
}
```

So, we can find that ContainerMeta has a very similar construction of Container. So we could only make use of Container to eliminate one to make code and data structure much more simplified.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Describe how you did it
none


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none


