### PR TITLE
feature: add misspell tool to check English words

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,29 +3,19 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
-  markdown-lint-docs:
+  misspell-and-markdown-lint:
     docker:
-      # specify the version
-      - image: allencloud/mdl:v0.4
-    
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
-    #### TEMPLATE_NOTE: go expects specific checkout path representing url
-    #### expecting it in the form of
-    ####   /go/src/github.com/circleci/go-tool
-    ####   /go/src/bitbucket.org/circleci/go-tool
+      - image: allencloud/mdlmisspell:v0.1
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     steps:
       - checkout
-
-      # specify any bash command here prefixed with `run: `
       - run:
           name: use markdownlint v0.4.0 to lint markdown file (https://github.com/markdownlint/markdownlint)
           command: |
             find  ./ -name  "*.md" | grep -v vendor | grep -v extra |  grep -v commandline |  grep -v .github |  grep -v swagger |  grep -v api |  xargs mdl -r ~MD010,~MD013,~MD024,~MD029,~MD033,~MD036
+      - run:
+          name: use opensource tool client9/misspell to correct commonly misspelled English words 
+          command: find  ./* -name  "*"  | grep -v extra | grep -v vendor | xargs misspell -error 
 
   code-check:
     docker: 
@@ -62,6 +52,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - markdown-lint-docs
+      - misspell-and-markdown-lint
       - code-check
       - unit-test

--- a/pkg/errtypes/errors.go
+++ b/pkg/errtypes/errors.go
@@ -29,7 +29,7 @@ var (
 	// ErrNotImplemented represents that the function is not implemented.
 	ErrNotImplemented = errorType{codeNotImplemented, "not implemented"}
 
-	// ErrUsingbyContainers represents that object is useing by containers
+	// ErrUsingbyContainers represents that object is used by containers
 	ErrUsingbyContainers = errorType{codeInUse, "using by containers"}
 )
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

I add tool [misspell](https://github.com/client9/misspell) to check incorrect English words spelling in this project.

I combined this feature in CI with test type of markdownlint.

In addition I use a new Dockerfile to construct new image `allencloud/mdlmisspell:v0.1`:

```
FROM ubuntu:16.04

RUN apt-get update \
    && apt-get install -y rubygems git curl \
    && gem install rake \
    && gem install bundler \
    && apt-get clean

RUN git clone https://github.com/markdownlint/markdownlint.git \
    && cd markdownlint && git checkout v0.4.0 && rake install

RUN git clone https://github.com/client9/misspell.git \
    && cd misspell && curl -L -o ./install-misspell.sh https://git.io/misspell && sh ./install-misspell.sh

RUN mv misspell/bin/misspell /usr/local/bin/
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none

### Ⅲ. Describe how you did it



### Ⅳ. Describe how to verify it
This addition would checkout one typo.

### Ⅴ. Special notes for reviews
none

