### PR TITLE
feature: Update CRI from v1alpha1 to v1alpha2

### DIFF
--- a/cri/service/cri.go
+++ b/cri/service/cri.go
@@ -9,7 +9,7 @@ import (
 	"github.com/alibaba/pouch/daemon/mgr"
 
 	"google.golang.org/grpc"
-	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
 // Service serves the kubelet runtime grpc api which will be consumed by kubelet.

--- a/cri/stream/server.go
+++ b/cri/stream/server.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gorilla/mux"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
 // Keep these constants consistent with the peers in official package:

--- a/daemon/containerio/cri_log_file.go
+++ b/daemon/containerio/cri_log_file.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
 const (

--- a/daemon/mgr/cri.go
+++ b/daemon/mgr/cri.go
@@ -23,7 +23,7 @@ import (
 	// NOTE: "golang.org/x/net/context" is compatible with standard "context" in golang1.7+.
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/sirupsen/logrus"
-	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
 const (
@@ -196,7 +196,7 @@ func (c *CriManager) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	// Step 4: Setup networking for the sandbox.
 	var netnsPath string
 	securityContext := config.GetLinux().GetSecurityContext()
-	hostNet := securityContext.GetNamespaceOptions().GetHostNetwork()
+	hostNet := securityContext.GetNamespaceOptions().GetNetwork() == runtime.NamespaceMode_NODE
 	// If it is in host network, no need to configure the network of sandbox.
 	if !hostNet {
 		container, err := c.ContainerMgr.Get(ctx, id)
@@ -268,7 +268,7 @@ func (c *CriManager) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandb
 	}
 
 	securityContext := sandboxMeta.Config.GetLinux().GetSecurityContext()
-	hostNet := securityContext.GetNamespaceOptions().GetHostNetwork()
+	hostNet := securityContext.GetNamespaceOptions().GetNetwork() == runtime.NamespaceMode_NODE
 
 	// Teardown network of the pod, if it is not in host network mode.
 	if !hostNet {
@@ -371,7 +371,7 @@ func (c *CriManager) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 	labels, annotations := extractLabels(sandbox.Config.Labels)
 
 	securityContext := sandboxMeta.Config.GetLinux().GetSecurityContext()
-	hostNet := securityContext.GetNamespaceOptions().GetHostNetwork()
+	hostNet := securityContext.GetNamespaceOptions().GetNetwork() == runtime.NamespaceMode_NODE
 
 	var ip string
 	// No need to get ip for host network mode.
@@ -482,22 +482,11 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	// Get container log.
 	if config.GetLogPath() != "" {
 		logPath := filepath.Join(sandboxConfig.GetLogDirectory(), config.GetLogPath())
-		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
+		err := c.attachLog(logPath, containerID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create container for opening log file failed: %v", err)
-		}
-		// Attach to the container to get log.
-		attachConfig := &AttachConfig{
-			Stdout:     true,
-			Stderr:     true,
-			CriLogFile: f,
-		}
-		err = c.ContainerMgr.Attach(context.Background(), containerID, attachConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach to container %q to get its log: %v", containerID, err)
+			return nil, err
 		}
 	}
-
 	return &runtime.CreateContainerResponse{ContainerId: containerID}, nil
 }
 
@@ -690,6 +679,31 @@ func (c *CriManager) ListContainerStats(ctx context.Context, r *runtime.ListCont
 // UpdateContainerResources updates ContainerConfig of the container.
 func (c *CriManager) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (*runtime.UpdateContainerResourcesResponse, error) {
 	return nil, fmt.Errorf("UpdateContainerResources Not Implemented Yet")
+}
+
+// ReopenContainerLog asks runtime to reopen the stdout/stderr log file
+// for the container. This is often called after the log file has been
+// rotated. If the container is not running, container runtime can choose
+// to either create a new log file and return nil, or return an error.
+// Once it returns error, new container log file MUST NOT be created.
+func (c *CriManager) ReopenContainerLog(ctx context.Context, r *runtime.ReopenContainerLogRequest) (*runtime.ReopenContainerLogResponse, error) {
+	containerID := r.GetContainerId()
+	container, err := c.ContainerMgr.Get(ctx, containerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container of %q: %v", containerID, err)
+	}
+	if container.State.Status != apitypes.StatusRunning {
+		return nil, fmt.Errorf("container %q is not running", containerID)
+	}
+	c.ContainerMgr.(*ContainerManager).IOs.Remove(containerID)
+	if container.LogPath != "" {
+		logPath := container.LogPath
+		err := c.attachLog(logPath, containerID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &runtime.ReopenContainerLogResponse{}, nil
 }
 
 // ExecSync executes a command in the container, and returns the stdout output.

--- a/daemon/mgr/cri_network.go
+++ b/daemon/mgr/cri_network.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/sirupsen/logrus"
-	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
 // CniMgr as an interface defines all operations against CNI.

--- a/daemon/mgr/cri_types.go
+++ b/daemon/mgr/cri_types.go
@@ -1,7 +1,7 @@
 package mgr
 
 import (
-	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
 // SandboxMeta represents the sandbox's meta data.

--- a/daemon/mgr/cri_utils_test.go
+++ b/daemon/mgr/cri_utils_test.go
@@ -9,7 +9,7 @@ import (
 	apitypes "github.com/alibaba/pouch/apis/types"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
 func Test_parseUint32(t *testing.T) {

--- a/hack/cri-test/test-cri.sh
+++ b/hack/cri-test/test-cri.sh
@@ -26,7 +26,7 @@ POUCH_SOCK="/var/run/pouchcri.sock"
 CRI_FOCUS=${CRI_FOCUS:-}
 
 # CRI_SKIP skips the test to skip.
-CRI_SKIP=${CRI_SKIP:-"RunAsUserName|seccomp localhost|should error on create with wrong options"}
+CRI_SKIP=${CRI_SKIP:-"RunAsUserName|seccomp localhost|should error on create with wrong options|runtime should support reopening container log"}
 # REPORT_DIR is the the directory to store test logs.
 REPORT_DIR=${REPORT_DIR:-"/tmp/test-cri"}
 
@@ -85,7 +85,7 @@ EOF'
 
 CRITEST=${GOPATH}/bin/critest
 CRITOOL_PKG=github.com/kubernetes-incubator/cri-tools
-
+GINKGO_PKG=github.com/onsi/ginkgo/ginkgo
 # Install critest
 if [ ! -x "$(command -v ${CRITEST})" ]; then
   go get -d ${CRITOOL_PKG}/...
@@ -100,7 +100,7 @@ mkdir -p ${REPORT_DIR}
 test_setup ${REPORT_DIR}
 
 # Run cri validation test
-sudo env PATH=${PATH} GOPATH=${GOPATH} ${CRITEST} --runtime-endpoint=${POUCH_SOCK} --focus="${CRI_FOCUS}" --ginkgo-flags="--skip=\"${CRI_SKIP}\"" validation
+sudo env PATH=${PATH} GOPATH=${GOPATH} ${CRITEST} --runtime-endpoint=${POUCH_SOCK} --ginkgo.focus="${CRI_FOCUS}" --ginkgo.skip="${CRI_SKIP}"
 test_exit_code=$?
 
 test_teardown

--- a/hack/cri-test/versions
+++ b/hack/cri-test/versions
@@ -1,2 +1,2 @@
-CRITOOL_VERSION=v1.0.0-alpha.0
+CRITOOL_VERSION=v1.0.0-beta.0
 

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/BUILD
@@ -1,0 +1,30 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["services.go"],
+    importpath = "k8s.io/kubernetes/pkg/kubelet/apis/cri",
+    deps = ["//pkg/kubelet/apis/cri/runtime/v1alpha2:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//pkg/kubelet/apis/cri/runtime/v1alpha2:all-srcs",
+        "//pkg/kubelet/apis/cri/testing:all-srcs",
+    ],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2/BUILD
@@ -11,7 +11,7 @@ go_library(
         "api.pb.go",
         "constants.go",
     ],
-    importpath = "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime",
+    importpath = "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2",
     deps = [
         "//vendor/github.com/gogo/protobuf/gogoproto:go_default_library",
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
@@ -37,5 +37,4 @@ filegroup(
 filegroup(
     name = "go_default_library_protos",
     srcs = ["api.proto"],
-    visibility = ["//visibility:public"],
 )

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2/api.proto
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2/api.proto
@@ -1,7 +1,8 @@
 // To regenerate api.pb.go run hack/update-generated-runtime.sh
 syntax = 'proto3';
 
-package runtime;
+package runtime.v1alpha2;
+option go_package = "v1alpha2";
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
@@ -14,7 +15,7 @@ option (gogoproto.unmarshaler_all) = true;
 option (gogoproto.goproto_unrecognized_all) = false;
 
 // Runtime service defines the public APIs for remote container runtimes
-service RuntimeService {
+  RuntimeService {
     // Version returns the runtime name, runtime version, and runtime API version.
     rpc Version(VersionRequest) returns (VersionResponse) {}
 
@@ -63,6 +64,12 @@ service RuntimeService {
     rpc ContainerStatus(ContainerStatusRequest) returns (ContainerStatusResponse) {}
     // UpdateContainerResources updates ContainerConfig of the container.
     rpc UpdateContainerResources(UpdateContainerResourcesRequest) returns (UpdateContainerResourcesResponse) {}
+    // ReopenContainerLog asks runtime to reopen the stdout/stderr log file
+    // for the container. This is often called after the log file has been
+    // rotated. If the container is not running, container runtime can choose
+    // to either create a new log file and return nil, or return an error.
+    // Once it returns error, new container log file MUST NOT be created.
+    rpc ReopenContainerLog(ReopenContainerLogRequest) returns (ReopenContainerLogResponse) {}
 
     // ExecSync runs a command in a container synchronously.
     rpc ExecSync(ExecSyncRequest) returns (ExecSyncResponse) {}
@@ -164,7 +171,9 @@ enum MountPropagation {
 message Mount {
     // Path of the mount within the container.
     string container_path = 1;
-    // Path of the mount on the host.
+    // Path of the mount on the host. If the hostPath doesn't exist, then runtimes
+    // should report error. If the hostpath is a symbolic link, runtimes should
+    // follow the symlink and mount the real destination to container.
     string host_path = 2;
     // If set, the mount is read-only.
     bool readonly = 3;
@@ -174,14 +183,39 @@ message Mount {
     MountPropagation propagation = 5;
 }
 
+// A NamespaceMode describes the intended namespace configuration for each
+// of the namespaces (Network, PID, IPC) in NamespaceOption. Runtimes should
+// map these modes as appropriate for the technology underlying the runtime.
+enum NamespaceMode {
+    // A POD namespace is common to all containers in a pod.
+    // For example, a container with a PID namespace of POD expects to view
+    // all of the processes in all of the containers in the pod.
+    POD       = 0;
+    // A CONTAINER namespace is restricted to a single container.
+    // For example, a container with a PID namespace of CONTAINER expects to
+    // view only the processes in that container.
+    CONTAINER = 1;
+    // A NODE namespace is the namespace of the Kubernetes node.
+    // For example, a container with a PID namespace of NODE expects to view
+    // all of the processes on the host running the kubelet.
+    NODE      = 2;
+}
+
 // NamespaceOption provides options for Linux namespaces.
 message NamespaceOption {
-    // If set, use the host's network namespace.
-    bool host_network = 1;
-    // If set, use the host's PID namespace.
-    bool host_pid = 2;
-    // If set, use the host's IPC namespace.
-    bool host_ipc = 3;
+    // Network namespace for this container/sandbox.
+    // Note: There is currently no way to set CONTAINER scoped network in the Kubernetes API.
+    // Namespaces currently set by the kubelet: POD, NODE
+    NamespaceMode network = 1;
+    // PID namespace for this container/sandbox.
+    // Note: The CRI default is POD, but the v1.PodSpec default is CONTAINER.
+    // The kubelet's runtime manager will set this to CONTAINER explicitly for v1 pods.
+    // Namespaces currently set by the kubelet: POD, CONTAINER, NODE
+    NamespaceMode pid = 2;
+    // IPC namespace for this container/sandbox.
+    // Note: There is currently no way to set CONTAINER scoped IPC in the Kubernetes API.
+    // Namespaces currently set by the kubelet: POD, NODE
+    NamespaceMode ipc = 3;
 }
 
 // Int64Value is the wrapper of int64.
@@ -203,6 +237,9 @@ message LinuxSandboxSecurityContext {
     SELinuxOption selinux_options = 2;
     // UID to run sandbox processes as, when applicable.
     Int64Value run_as_user = 3;
+    // GID to run sandbox processes as, when applicable. run_as_group should only
+    // be specified when run_as_user is specified; otherwise, the runtime MUST error.
+    Int64Value run_as_group = 8;
     // If set, the root filesystem of the sandbox is read-only.
     bool readonly_rootfs = 4;
     // List of groups applied to the first process run in the sandbox, in
@@ -215,7 +252,7 @@ message LinuxSandboxSecurityContext {
     // privileged containers are expected to be run.
     bool privileged = 6;
     // Seccomp profile for the sandbox, candidate values are:
-    // * docker/default: the default profile for the docker container runtime
+    // * runtime/default: the default profile for the container runtime
     // * unconfined: unconfined profile, ie, no seccomp sandboxing
     // * localhost/<full-path-to-profile>: the profile installed on the node.
     //   <full-path-to-profile> is the full path of the profile.
@@ -384,7 +421,7 @@ message PodSandboxStatus {
 message PodSandboxStatusResponse {
     // Status of the PodSandbox.
     PodSandboxStatus status = 1;
-    // Info is extra information of the PodSandbox. The key could be abitrary string, and
+    // Info is extra information of the PodSandbox. The key could be arbitrary string, and
     // value should be in json format. The information could include anything useful for
     // debug, e.g. network namespace for linux container based container runtime.
     // It should only be returned non-empty when Verbose is true.
@@ -519,6 +556,10 @@ message LinuxContainerSecurityContext {
     // UID to run the container process as. Only one of run_as_user and
     // run_as_username can be specified at a time.
     Int64Value run_as_user = 5;
+    // GID to run the container process as. run_as_group should only be specified
+    // when run_as_user or run_as_username is specified; otherwise, the runtime
+    // MUST error.
+    Int64Value run_as_group = 12;
     // User name to run the container process as. If specified, the user MUST
     // exist in the container image (i.e. in the /etc/passwd inside the image),
     // and be resolved there by the runtime; otherwise, the runtime MUST error.
@@ -536,7 +577,7 @@ message LinuxContainerSecurityContext {
     //    http://wiki.apparmor.net/index.php/AppArmor_Core_Policy_Reference
     string apparmor_profile = 9;
     // Seccomp profile for the container, candidate values are:
-    // * docker/default: the default profile for the docker container runtime
+    // * runtime/default: the default profile for the container runtime
     // * unconfined: unconfined profile, ie, no seccomp sandboxing
     // * localhost/<full-path-to-profile>: the profile installed on the node.
     //   <full-path-to-profile> is the full path of the profile.
@@ -554,6 +595,26 @@ message LinuxContainerConfig {
     LinuxContainerResources resources = 1;
     // LinuxContainerSecurityContext configuration for the container.
     LinuxContainerSecurityContext security_context = 2;
+}
+
+// WindowsContainerConfig contains platform-specific configuration for
+// Windows-based containers.
+message WindowsContainerConfig {
+    // Resources specification for the container.
+    WindowsContainerResources resources = 1;
+}
+
+// WindowsContainerResources specifies Windows specific configuration for
+// resources.
+message WindowsContainerResources {
+    // CPU shares (relative weight vs. other containers). Default: 0 (not specified).
+    int64 cpu_shares = 1;
+    // Number of CPUs available to the container. Default: 0 (not specified).
+    int64 cpu_count = 2;
+    // Specifies the portion of processor cycles that this container can use as a percentage times 100.
+    int64 cpu_maximum = 3;
+    // Memory limit in bytes. Default: 0 (not specified).
+    int64 memory_limit_in_bytes = 4;
 }
 
 // ContainerMetadata holds all necessary information for building the container
@@ -643,6 +704,8 @@ message ContainerConfig {
 
     // Configuration specific to Linux containers.
     LinuxContainerConfig linux = 15;
+   // Configuration specific to Windows containers.
+   WindowsContainerConfig windows = 16;
 }
 
 message CreateContainerRequest {
@@ -800,7 +863,7 @@ message ContainerStatus {
 message ContainerStatusResponse {
     // Status of the container.
     ContainerStatus status = 1;
-    // Info is extra information of the Container. The key could be abitrary string, and
+    // Info is extra information of the Container. The key could be arbitrary string, and
     // value should be in json format. The information could include anything useful for
     // debug, e.g. pid for linux container based container runtime.
     // It should only be returned non-empty when Verbose is true.
@@ -941,7 +1004,7 @@ message ImageStatusRequest {
 message ImageStatusResponse {
     // Status of the image.
     Image image = 1;
-    // Info is extra information of the Image. The key could be abitrary string, and
+    // Info is extra information of the Image. The key could be arbitrary string, and
     // value should be in json format. The information could include anything useful
     // for debug, e.g. image config for oci image based container runtime.
     // It should only be returned non-empty when Verbose is true.
@@ -1036,7 +1099,7 @@ message StatusRequest {
 message StatusResponse {
     // Status of the Runtime.
     RuntimeStatus status = 1;
-    // Info is extra information of the Runtime. The key could be abitrary string, and
+    // Info is extra information of the Runtime. The key could be arbitrary string, and
     // value should be in json format. The information could include anything useful for
     // debug, e.g. plugins used by the container runtime.
     // It should only be returned non-empty when Verbose is true.
@@ -1051,18 +1114,18 @@ message UInt64Value {
     uint64 value = 1;
 }
 
-// StorageIdentifier uniquely identify the storage..
-message StorageIdentifier{
-    // UUID of the device.
-    string uuid = 1;
+// FilesystemIdentifier uniquely identify the filesystem.
+message FilesystemIdentifier{
+    // Mountpoint of a filesystem.
+    string mountpoint = 1;
 }
 
 // FilesystemUsage provides the filesystem usage information.
 message FilesystemUsage {
     // Timestamp in nanoseconds at which the information were collected. Must be > 0.
     int64 timestamp = 1;
-    // The underlying storage of the filesystem.
-    StorageIdentifier storage_id = 2;
+    // The unique identifier of the filesystem.
+    FilesystemIdentifier fs_id = 2;
     // UsedBytes represents the bytes used for images on the filesystem.
     // This may differ from the total bytes used on the filesystem and may not
     // equal CapacityBytes - AvailableBytes.
@@ -1152,4 +1215,12 @@ message MemoryUsage {
     int64 timestamp = 1;
     // The amount of working set memory in bytes.
     UInt64Value working_set_bytes = 2;
+}
+
+message ReopenContainerLogRequest {
+    // ID of the container for which to reopen the log.
+    string container_id = 1;
+}
+
+message ReopenContainerLogResponse{
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2/constants.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2/constants.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package runtime
+package v1alpha2
 
 // This file contains all constants defined in CRI.
 
@@ -38,7 +38,7 @@ const (
 
 // LogTag is the tag of a log line in CRI container log.
 // Currently defined log tags:
-// * First tag: Partial/End - P/E.
+// * First tag: Partial/Full - P/F.
 // The field in the container log format can be extended to include multiple
 // tags by using a delimiter, but changes should be rare. If it becomes clear
 // that better extensibility is desired, a more extensible format (e.g., json)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/services.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/services.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cri
+
+import (
+	"time"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+// RuntimeVersioner contains methods for runtime name, version and API version.
+type RuntimeVersioner interface {
+	// Version returns the runtime name, runtime version and runtime API version
+	Version(apiVersion string) (*runtimeapi.VersionResponse, error)
+}
+
+// ContainerManager contains methods to manipulate containers managed by a
+// container runtime. The methods are thread-safe.
+type ContainerManager interface {
+	// CreateContainer creates a new container in specified PodSandbox.
+	CreateContainer(podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error)
+	// StartContainer starts the container.
+	StartContainer(containerID string) error
+	// StopContainer stops a running container with a grace period (i.e., timeout).
+	StopContainer(containerID string, timeout int64) error
+	// RemoveContainer removes the container.
+	RemoveContainer(containerID string) error
+	// ListContainers lists all containers by filters.
+	ListContainers(filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error)
+	// ContainerStatus returns the status of the container.
+	ContainerStatus(containerID string) (*runtimeapi.ContainerStatus, error)
+	// UpdateContainerResources updates the cgroup resources for the container.
+	UpdateContainerResources(containerID string, resources *runtimeapi.LinuxContainerResources) error
+	// ExecSync executes a command in the container, and returns the stdout output.
+	// If command exits with a non-zero exit code, an error is returned.
+	ExecSync(containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error)
+	// Exec prepares a streaming endpoint to execute a command in the container, and returns the address.
+	Exec(*runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error)
+	// Attach prepares a streaming endpoint to attach to a running container, and returns the address.
+	Attach(req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error)
+	// ReopenContainerLog asks runtime to reopen the stdout/stderr log file
+	// for the container. If it returns error, new container log file MUST NOT
+	// be created.
+	ReopenContainerLog(ContainerID string) error
+}
+
+// PodSandboxManager contains methods for operating on PodSandboxes. The methods
+// are thread-safe.
+type PodSandboxManager interface {
+	// RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
+	// the sandbox is in ready state.
+	RunPodSandbox(config *runtimeapi.PodSandboxConfig) (string, error)
+	// StopPodSandbox stops the sandbox. If there are any running containers in the
+	// sandbox, they should be force terminated.
+	StopPodSandbox(podSandboxID string) error
+	// RemovePodSandbox removes the sandbox. If there are running containers in the
+	// sandbox, they should be forcibly removed.
+	RemovePodSandbox(podSandboxID string) error
+	// PodSandboxStatus returns the Status of the PodSandbox.
+	PodSandboxStatus(podSandboxID string) (*runtimeapi.PodSandboxStatus, error)
+	// ListPodSandbox returns a list of Sandbox.
+	ListPodSandbox(filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error)
+	// PortForward prepares a streaming endpoint to forward ports from a PodSandbox, and returns the address.
+	PortForward(*runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error)
+}
+
+// ContainerStatsManager contains methods for retrieving the container
+// statistics.
+type ContainerStatsManager interface {
+	// ContainerStats returns stats of the container. If the container does not
+	// exist, the call returns an error.
+	ContainerStats(containerID string) (*runtimeapi.ContainerStats, error)
+	// ListContainerStats returns stats of all running containers.
+	ListContainerStats(filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error)
+}
+
+// RuntimeService interface should be implemented by a container runtime.
+// The methods should be thread-safe.
+type RuntimeService interface {
+	RuntimeVersioner
+	ContainerManager
+	PodSandboxManager
+	ContainerStatsManager
+
+	// UpdateRuntimeConfig updates runtime configuration if specified
+	UpdateRuntimeConfig(runtimeConfig *runtimeapi.RuntimeConfig) error
+	// Status returns the status of the runtime.
+	Status() (*runtimeapi.RuntimeStatus, error)
+}
+
+// ImageManagerService interface should be implemented by a container image
+// manager.
+// The methods should be thread-safe.
+type ImageManagerService interface {
+	// ListImages lists the existing images.
+	ListImages(filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error)
+	// ImageStatus returns the status of the image.
+	ImageStatus(image *runtimeapi.ImageSpec) (*runtimeapi.Image, error)
+	// PullImage pulls an image with the authentication config.
+	PullImage(image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig) (string, error)
+	// RemoveImage removes the image.
+	RemoveImage(image *runtimeapi.ImageSpec) error
+	// ImageFsInfo returns information of the filesystem that is used to store images.
+	ImageFsInfo() ([]*runtimeapi.FilesystemUsage, error)
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/testing/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/testing/BUILD
@@ -1,0 +1,34 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "fake_image_service.go",
+        "fake_runtime_service.go",
+        "utils.go",
+    ],
+    importpath = "k8s.io/kubernetes/pkg/kubelet/apis/cri/testing",
+    deps = [
+        "//pkg/kubelet/apis/cri/runtime/v1alpha2:go_default_library",
+        "//pkg/kubelet/util/sliceutils:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/testing/fake_image_service.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/testing/fake_image_service.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+	"k8s.io/kubernetes/pkg/kubelet/util/sliceutils"
+)
+
+type FakeImageService struct {
+	sync.Mutex
+
+	FakeImageSize uint64
+	Called        []string
+	Images        map[string]*runtimeapi.Image
+
+	pulledImages []*pulledImage
+
+	FakeFilesystemUsage []*runtimeapi.FilesystemUsage
+}
+
+func (r *FakeImageService) SetFakeImages(images []string) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Images = make(map[string]*runtimeapi.Image)
+	for _, image := range images {
+		r.Images[image] = r.makeFakeImage(image)
+	}
+}
+
+func (r *FakeImageService) SetFakeImageSize(size uint64) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.FakeImageSize = size
+}
+
+func (r *FakeImageService) SetFakeFilesystemUsage(usage []*runtimeapi.FilesystemUsage) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.FakeFilesystemUsage = usage
+}
+
+func NewFakeImageService() *FakeImageService {
+	return &FakeImageService{
+		Called: make([]string, 0),
+		Images: make(map[string]*runtimeapi.Image),
+	}
+}
+
+func (r *FakeImageService) makeFakeImage(image string) *runtimeapi.Image {
+	return &runtimeapi.Image{
+		Id:       image,
+		Size_:    r.FakeImageSize,
+		RepoTags: []string{image},
+	}
+}
+
+func (r *FakeImageService) ListImages(filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ListImages")
+
+	images := make([]*runtimeapi.Image, 0)
+	for _, img := range r.Images {
+		if filter != nil && filter.Image != nil {
+			if !sliceutils.StringInSlice(filter.Image.Image, img.RepoTags) {
+				continue
+			}
+		}
+
+		images = append(images, img)
+	}
+	return images, nil
+}
+
+func (r *FakeImageService) ImageStatus(image *runtimeapi.ImageSpec) (*runtimeapi.Image, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ImageStatus")
+
+	return r.Images[image.Image], nil
+}
+
+func (r *FakeImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig) (string, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "PullImage")
+
+	r.pulledImages = append(r.pulledImages, &pulledImage{imageSpec: image, authConfig: auth})
+	// ImageID should be randomized for real container runtime, but here just use
+	// image's name for easily making fake images.
+	imageID := image.Image
+	if _, ok := r.Images[imageID]; !ok {
+		r.Images[imageID] = r.makeFakeImage(image.Image)
+	}
+
+	return imageID, nil
+}
+
+func (r *FakeImageService) RemoveImage(image *runtimeapi.ImageSpec) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "RemoveImage")
+
+	// Remove the image
+	delete(r.Images, image.Image)
+
+	return nil
+}
+
+// ImageFsInfo returns information of the filesystem that is used to store images.
+func (r *FakeImageService) ImageFsInfo() ([]*runtimeapi.FilesystemUsage, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ImageFsInfo")
+
+	return r.FakeFilesystemUsage, nil
+}
+
+func (r *FakeImageService) AssertImagePulledWithAuth(t *testing.T, image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, failMsg string) {
+	r.Lock()
+	defer r.Unlock()
+	expected := &pulledImage{imageSpec: image, authConfig: auth}
+	assert.Contains(t, r.pulledImages, expected, failMsg)
+}
+
+type pulledImage struct {
+	imageSpec  *runtimeapi.ImageSpec
+	authConfig *runtimeapi.AuthConfig
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/testing/fake_runtime_service.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/testing/fake_runtime_service.go
@@ -1,0 +1,495 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+var (
+	FakeVersion = "0.1.0"
+
+	FakeRuntimeName  = "fakeRuntime"
+	FakePodSandboxIP = "192.168.192.168"
+)
+
+type FakePodSandbox struct {
+	// PodSandboxStatus contains the runtime information for a sandbox.
+	runtimeapi.PodSandboxStatus
+}
+
+type FakeContainer struct {
+	// ContainerStatus contains the runtime information for a container.
+	runtimeapi.ContainerStatus
+
+	// the sandbox id of this container
+	SandboxID string
+}
+
+type FakeRuntimeService struct {
+	sync.Mutex
+
+	Called []string
+	Errors map[string][]error
+
+	FakeStatus         *runtimeapi.RuntimeStatus
+	Containers         map[string]*FakeContainer
+	Sandboxes          map[string]*FakePodSandbox
+	FakeContainerStats map[string]*runtimeapi.ContainerStats
+}
+
+func (r *FakeRuntimeService) GetContainerID(sandboxID, name string, attempt uint32) (string, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	for id, c := range r.Containers {
+		if c.SandboxID == sandboxID && c.Metadata.Name == name && c.Metadata.Attempt == attempt {
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("container (name, attempt, sandboxID)=(%q, %d, %q) not found", name, attempt, sandboxID)
+}
+
+func (r *FakeRuntimeService) SetFakeSandboxes(sandboxes []*FakePodSandbox) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Sandboxes = make(map[string]*FakePodSandbox)
+	for _, sandbox := range sandboxes {
+		sandboxID := sandbox.Id
+		r.Sandboxes[sandboxID] = sandbox
+	}
+}
+
+func (r *FakeRuntimeService) SetFakeContainers(containers []*FakeContainer) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Containers = make(map[string]*FakeContainer)
+	for _, c := range containers {
+		containerID := c.Id
+		r.Containers[containerID] = c
+	}
+
+}
+
+func (r *FakeRuntimeService) AssertCalls(calls []string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	if !reflect.DeepEqual(calls, r.Called) {
+		return fmt.Errorf("expected %#v, got %#v", calls, r.Called)
+	}
+	return nil
+}
+
+func (r *FakeRuntimeService) InjectError(f string, err error) {
+	r.Lock()
+	defer r.Unlock()
+	r.Errors[f] = append(r.Errors[f], err)
+}
+
+// caller of popError must grab a lock.
+func (r *FakeRuntimeService) popError(f string) error {
+	if r.Errors == nil {
+		return nil
+	}
+	errs := r.Errors[f]
+	if len(errs) == 0 {
+		return nil
+	}
+	err, errs := errs[0], errs[1:]
+	return err
+}
+
+func NewFakeRuntimeService() *FakeRuntimeService {
+	return &FakeRuntimeService{
+		Called:             make([]string, 0),
+		Errors:             make(map[string][]error),
+		Containers:         make(map[string]*FakeContainer),
+		Sandboxes:          make(map[string]*FakePodSandbox),
+		FakeContainerStats: make(map[string]*runtimeapi.ContainerStats),
+	}
+}
+
+func (r *FakeRuntimeService) Version(apiVersion string) (*runtimeapi.VersionResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Version")
+
+	return &runtimeapi.VersionResponse{
+		Version:           FakeVersion,
+		RuntimeName:       FakeRuntimeName,
+		RuntimeVersion:    FakeVersion,
+		RuntimeApiVersion: FakeVersion,
+	}, nil
+}
+
+func (r *FakeRuntimeService) Status() (*runtimeapi.RuntimeStatus, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Status")
+
+	return r.FakeStatus, nil
+}
+
+func (r *FakeRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig) (string, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "RunPodSandbox")
+
+	// PodSandboxID should be randomized for real container runtime, but here just use
+	// fixed name from BuildSandboxName() for easily making fake sandboxes.
+	podSandboxID := BuildSandboxName(config.Metadata)
+	createdAt := time.Now().UnixNano()
+	r.Sandboxes[podSandboxID] = &FakePodSandbox{
+		PodSandboxStatus: runtimeapi.PodSandboxStatus{
+			Id:        podSandboxID,
+			Metadata:  config.Metadata,
+			State:     runtimeapi.PodSandboxState_SANDBOX_READY,
+			CreatedAt: createdAt,
+			Network: &runtimeapi.PodSandboxNetworkStatus{
+				Ip: FakePodSandboxIP,
+			},
+			Labels:      config.Labels,
+			Annotations: config.Annotations,
+		},
+	}
+
+	return podSandboxID, nil
+}
+
+func (r *FakeRuntimeService) StopPodSandbox(podSandboxID string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "StopPodSandbox")
+
+	if s, ok := r.Sandboxes[podSandboxID]; ok {
+		s.State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+	} else {
+		return fmt.Errorf("pod sandbox %s not found", podSandboxID)
+	}
+
+	return nil
+}
+
+func (r *FakeRuntimeService) RemovePodSandbox(podSandboxID string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "RemovePodSandbox")
+
+	// Remove the pod sandbox
+	delete(r.Sandboxes, podSandboxID)
+
+	return nil
+}
+
+func (r *FakeRuntimeService) PodSandboxStatus(podSandboxID string) (*runtimeapi.PodSandboxStatus, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "PodSandboxStatus")
+
+	s, ok := r.Sandboxes[podSandboxID]
+	if !ok {
+		return nil, fmt.Errorf("pod sandbox %q not found", podSandboxID)
+	}
+
+	status := s.PodSandboxStatus
+	return &status, nil
+}
+
+func (r *FakeRuntimeService) ListPodSandbox(filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ListPodSandbox")
+
+	result := make([]*runtimeapi.PodSandbox, 0)
+	for id, s := range r.Sandboxes {
+		if filter != nil {
+			if filter.Id != "" && filter.Id != id {
+				continue
+			}
+			if filter.State != nil && filter.GetState().State != s.State {
+				continue
+			}
+			if filter.LabelSelector != nil && !filterInLabels(filter.LabelSelector, s.GetLabels()) {
+				continue
+			}
+		}
+
+		result = append(result, &runtimeapi.PodSandbox{
+			Id:          s.Id,
+			Metadata:    s.Metadata,
+			State:       s.State,
+			CreatedAt:   s.CreatedAt,
+			Labels:      s.Labels,
+			Annotations: s.Annotations,
+		})
+	}
+
+	return result, nil
+}
+
+func (r *FakeRuntimeService) PortForward(*runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "PortForward")
+	return &runtimeapi.PortForwardResponse{}, nil
+}
+
+func (r *FakeRuntimeService) CreateContainer(podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "CreateContainer")
+
+	// ContainerID should be randomized for real container runtime, but here just use
+	// fixed BuildContainerName() for easily making fake containers.
+	containerID := BuildContainerName(config.Metadata, podSandboxID)
+	createdAt := time.Now().UnixNano()
+	createdState := runtimeapi.ContainerState_CONTAINER_CREATED
+	imageRef := config.Image.Image
+	r.Containers[containerID] = &FakeContainer{
+		ContainerStatus: runtimeapi.ContainerStatus{
+			Id:          containerID,
+			Metadata:    config.Metadata,
+			Image:       config.Image,
+			ImageRef:    imageRef,
+			CreatedAt:   createdAt,
+			State:       createdState,
+			Labels:      config.Labels,
+			Annotations: config.Annotations,
+		},
+		SandboxID: podSandboxID,
+	}
+
+	return containerID, nil
+}
+
+func (r *FakeRuntimeService) StartContainer(containerID string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "StartContainer")
+
+	c, ok := r.Containers[containerID]
+	if !ok {
+		return fmt.Errorf("container %s not found", containerID)
+	}
+
+	// Set container to running.
+	c.State = runtimeapi.ContainerState_CONTAINER_RUNNING
+	c.StartedAt = time.Now().UnixNano()
+
+	return nil
+}
+
+func (r *FakeRuntimeService) StopContainer(containerID string, timeout int64) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "StopContainer")
+
+	c, ok := r.Containers[containerID]
+	if !ok {
+		return fmt.Errorf("container %q not found", containerID)
+	}
+
+	// Set container to exited state.
+	finishedAt := time.Now().UnixNano()
+	exitedState := runtimeapi.ContainerState_CONTAINER_EXITED
+	c.State = exitedState
+	c.FinishedAt = finishedAt
+
+	return nil
+}
+
+func (r *FakeRuntimeService) RemoveContainer(containerID string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "RemoveContainer")
+
+	// Remove the container
+	delete(r.Containers, containerID)
+
+	return nil
+}
+
+func (r *FakeRuntimeService) ListContainers(filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ListContainers")
+
+	result := make([]*runtimeapi.Container, 0)
+	for _, s := range r.Containers {
+		if filter != nil {
+			if filter.Id != "" && filter.Id != s.Id {
+				continue
+			}
+			if filter.PodSandboxId != "" && filter.PodSandboxId != s.SandboxID {
+				continue
+			}
+			if filter.State != nil && filter.GetState().State != s.State {
+				continue
+			}
+			if filter.LabelSelector != nil && !filterInLabels(filter.LabelSelector, s.GetLabels()) {
+				continue
+			}
+		}
+
+		result = append(result, &runtimeapi.Container{
+			Id:           s.Id,
+			CreatedAt:    s.CreatedAt,
+			PodSandboxId: s.SandboxID,
+			Metadata:     s.Metadata,
+			State:        s.State,
+			Image:        s.Image,
+			ImageRef:     s.ImageRef,
+			Labels:       s.Labels,
+			Annotations:  s.Annotations,
+		})
+	}
+
+	return result, nil
+}
+
+func (r *FakeRuntimeService) ContainerStatus(containerID string) (*runtimeapi.ContainerStatus, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ContainerStatus")
+
+	c, ok := r.Containers[containerID]
+	if !ok {
+		return nil, fmt.Errorf("container %q not found", containerID)
+	}
+
+	status := c.ContainerStatus
+	return &status, nil
+}
+
+func (r *FakeRuntimeService) UpdateContainerResources(string, *runtimeapi.LinuxContainerResources) error {
+	return nil
+}
+
+func (r *FakeRuntimeService) ExecSync(containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ExecSync")
+	return nil, nil, nil
+}
+
+func (r *FakeRuntimeService) Exec(*runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Exec")
+	return &runtimeapi.ExecResponse{}, nil
+}
+
+func (r *FakeRuntimeService) Attach(req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "Attach")
+	return &runtimeapi.AttachResponse{}, nil
+}
+
+func (r *FakeRuntimeService) UpdateRuntimeConfig(runtimeCOnfig *runtimeapi.RuntimeConfig) error {
+	return nil
+}
+
+func (r *FakeRuntimeService) SetFakeContainerStats(containerStats []*runtimeapi.ContainerStats) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.FakeContainerStats = make(map[string]*runtimeapi.ContainerStats)
+	for _, s := range containerStats {
+		r.FakeContainerStats[s.Attributes.Id] = s
+	}
+}
+
+func (r *FakeRuntimeService) ContainerStats(containerID string) (*runtimeapi.ContainerStats, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ContainerStats")
+
+	s, found := r.FakeContainerStats[containerID]
+	if !found {
+		return nil, fmt.Errorf("no stats for container %q", containerID)
+	}
+	return s, nil
+}
+
+func (r *FakeRuntimeService) ListContainerStats(filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ListContainerStats")
+
+	var result []*runtimeapi.ContainerStats
+	for _, c := range r.Containers {
+		if filter != nil {
+			if filter.Id != "" && filter.Id != c.Id {
+				continue
+			}
+			if filter.PodSandboxId != "" && filter.PodSandboxId != c.SandboxID {
+				continue
+			}
+			if filter.LabelSelector != nil && !filterInLabels(filter.LabelSelector, c.GetLabels()) {
+				continue
+			}
+		}
+		s, found := r.FakeContainerStats[c.Id]
+		if !found {
+			continue
+		}
+		result = append(result, s)
+	}
+
+	return result, nil
+}
+
+func (r *FakeRuntimeService) ReopenContainerLog(containerID string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Called = append(r.Called, "ReopenContainerLog")
+
+	if err := r.popError("ReopenContainerLog"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/testing/utils.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/testing/utils.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+func BuildContainerName(metadata *runtimeapi.ContainerMetadata, sandboxID string) string {
+	// include the sandbox ID to make the container ID unique.
+	return fmt.Sprintf("%s_%s_%d", sandboxID, metadata.Name, metadata.Attempt)
+}
+
+func BuildSandboxName(metadata *runtimeapi.PodSandboxMetadata) string {
+	return fmt.Sprintf("%s_%s_%s_%d", metadata.Name, metadata.Namespace, metadata.Uid, metadata.Attempt)
+}
+
+func filterInLabels(filter, labels map[string]string) bool {
+	for k, v := range filter {
+		if value, ok := labels[k]; ok {
+			if value != v {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Update cri from v1alpha1 to v1alpha2，deploying with released Kubernetes 1.10.0 will be successful.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how you did it
1. update package from cri/v1alpha1/runtime to cri/runtime/v1alpha2
2. fix: convert GetHostNetwork() to GetNetwork(),etc
3. add ReopenContainerLog function definition
4. nothing should be configured when PidMode equals NamespaceMode_CONTAINER 
5. update the scripts of hack/cri-test/*.sh

### Ⅳ. Describe how to verify it
It has passed CRI validation tests.
Deploying with released Kubernetes 1.10.0 will be successful.

### Ⅴ. Special notes for reviews
ReopenContainerLog is not supported for now.

