### PR TITLE
feature: update lock policy for container management

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -107,7 +107,7 @@ func (s *Server) removeImage(ctx context.Context, rw http.ResponseWriter, req *h
 
 	isForce := httputils.BoolValue(req, "force")
 	if !isForce && len(containers) > 0 {
-		return fmt.Errorf("Unable to remove the image %q (must force) - container %s is using this image", image.ID, containers[0].ID)
+		return fmt.Errorf("Unable to remove the image %q (must force) - container (%s, %s) is using this image", image.ID, containers[0].ID, containers[0].Name)
 	}
 
 	if err := s.ImageMgr.RemoveImage(ctx, name, isForce); err != nil {

--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -411,7 +411,7 @@ func (c *Client) createTask(ctx context.Context, id string, container containerd
 	// create task
 	task, err := container.NewTask(ctx, io)
 	if err != nil {
-		return pack, errors.Wrapf(err, "failed to create task, container id: %s", id)
+		return pack, errors.Wrapf(err, "failed to create task for container(%s)", id)
 	}
 
 	defer func() {
@@ -422,17 +422,17 @@ func (c *Client) createTask(ctx context.Context, id string, container containerd
 
 	statusCh, err := task.Wait(context.TODO())
 	if err != nil {
-		return pack, errors.Wrap(err, "failed to wait task")
+		return pack, errors.Wrapf(err, "failed to wait task in container", id)
 	}
 
-	logrus.Infof("success to new task, container id: %s, pid: %d", id, task.Pid())
+	logrus.Infof("success to create task(pid=%d) in container(%s)", task.Pid(), id)
 
 	// start task
 	if err := task.Start(ctx); err != nil {
-		return pack, errors.Wrapf(err, "failed to start task: %d, container id: %s", task.Pid(), id)
+		return pack, errors.Wrapf(err, "failed to start task(%d) in container(%s)", task.Pid(), id)
 	}
 
-	logrus.Infof("success to start task, container id: %s", id)
+	logrus.Infof("success to start task in container(%s)", id)
 
 	pack = &containerPack{
 		id:        id,

--- a/daemon/containerio/jsonfile.go
+++ b/daemon/containerio/jsonfile.go
@@ -22,7 +22,7 @@ func init() {
 
 var jsonFilePathName = "json.log"
 
-// TODO(fuwei): add compress/logrotate configure
+// TODO(fuwei): add compress/logrotate configuration
 type jsonFile struct {
 	closed bool
 

--- a/daemon/mgr/container_state.go
+++ b/daemon/mgr/container_state.go
@@ -1,0 +1,125 @@
+package mgr
+
+import (
+	"time"
+
+	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/pkg/utils"
+)
+
+// IsRunning returns container is running or not.
+func (c *Container) IsRunning() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.State.Status == types.StatusRunning
+}
+
+// IsStopped returns container is stopped or not.
+func (c *Container) IsStopped() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.State.Status == types.StatusStopped
+}
+
+// IsExited returns container is exited or not.
+func (c *Container) IsExited() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.State.Status == types.StatusExited
+}
+
+// IsCreated returns container is created or not.
+func (c *Container) IsCreated() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.State.Status == types.StatusCreated
+}
+
+// IsPaused returns container is paused or not.
+func (c *Container) IsPaused() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.State.Status == types.StatusPaused
+}
+
+// IsDead returns container is dead or not.
+func (c *Container) IsDead() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.State.Status == types.StatusDead
+}
+
+// IsRunningOrPaused returns true of container is running or paused.
+func (c *Container) IsRunningOrPaused() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.State.Status == types.StatusRunning || c.State.Status == types.StatusPaused
+}
+
+// IsRestarting returns container is restarting or not.
+func (c *Container) IsRestarting() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.State.Status == types.StatusRestarting
+}
+
+// ExitCode returns container's ExitCode.
+func (c *Container) ExitCode() int64 {
+	c.Lock()
+	defer c.Unlock()
+	return c.State.ExitCode
+}
+
+// SetStatusRunning sets a container to be status running.
+// When a container's status turns to StatusStopped, the following fields need updated:
+// Status -> StatusRunning
+// StartAt -> time.Now()
+// Pid -> input param
+// ExitCode -> 0
+func (c *Container) SetStatusRunning(pid int64) {
+	c.Lock()
+	defer c.Unlock()
+	c.State.Status = types.StatusRunning
+	c.State.StartedAt = time.Now().UTC().Format(utils.TimeLayout)
+	c.State.Pid = pid
+	c.State.ExitCode = 0
+}
+
+// SetStatusStopped sets a container to be status stopped.
+// When a container's status turns to StatusStopped, the following fields need updated:
+// Status -> StatusStopped
+// FinishedAt -> time.Now()
+// Pid -> -1
+// ExitCode -> input param
+// Error -> input param
+func (c *Container) SetStatusStopped(exitCode int64, errMsg string) {
+	c.Lock()
+	defer c.Unlock()
+	c.State.Status = types.StatusStopped
+	c.State.FinishedAt = time.Now().UTC().Format(utils.TimeLayout)
+	c.State.Pid = -1
+	c.State.ExitCode = exitCode
+	c.State.Error = errMsg
+}
+
+// SetStatusExited sets a container to be status exited.
+func (c *Container) SetStatusExited() {
+	c.Lock()
+	defer c.Unlock()
+	c.State.Status = types.StatusExited
+}
+
+// SetStatusPaused sets a container to be status paused.
+func (c *Container) SetStatusPaused() {
+	c.Lock()
+	defer c.Unlock()
+	c.State.Status = types.StatusPaused
+}
+
+// SetStatusUnpaused sets a container to be status running.
+// Unpaused is treated running.
+func (c *Container) SetStatusUnpaused() {
+	c.Lock()
+	defer c.Unlock()
+	c.State.Status = types.StatusRunning
+}

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -184,42 +184,9 @@ type Container struct {
 
 // Key returns container's id.
 func (c *Container) Key() string {
+	c.Lock()
+	defer c.Unlock()
 	return c.ID
-}
-
-// ExitCode returns container's ExitCode.
-func (c *Container) ExitCode() int64 {
-	return c.State.ExitCode
-}
-
-// IsRunning returns container is running or not.
-func (c *Container) IsRunning() bool {
-	return c.State.Status == types.StatusRunning
-}
-
-// IsStopped returns container is stopped or not.
-func (c *Container) IsStopped() bool {
-	return c.State.Status == types.StatusStopped
-}
-
-// IsExited returns container is exited or not.
-func (c *Container) IsExited() bool {
-	return c.State.Status == types.StatusExited
-}
-
-// IsCreated returns container is created or not.
-func (c *Container) IsCreated() bool {
-	return c.State.Status == types.StatusCreated
-}
-
-// IsPaused returns container is paused or not.
-func (c *Container) IsPaused() bool {
-	return c.State.Status == types.StatusPaused
-}
-
-// IsRestarting returns container is restarting or not.
-func (c *Container) IsRestarting() bool {
-	return c.State.Status == types.StatusRestarting
 }
 
 // Write writes container's meta data into meta store.
@@ -229,6 +196,8 @@ func (c *Container) Write(store *meta.Store) error {
 
 // StopTimeout returns the timeout (in seconds) used to stop the container.
 func (c *Container) StopTimeout() int64 {
+	c.Lock()
+	defer c.Unlock()
 	if c.Config.StopTimeout != nil {
 		return *c.Config.StopTimeout
 	}
@@ -236,6 +205,8 @@ func (c *Container) StopTimeout() int64 {
 }
 
 func (c *Container) merge(getconfig func() (v1.ImageConfig, error)) error {
+	c.Lock()
+	defer c.Unlock()
 	config, err := getconfig()
 	if err != nil {
 		return err
@@ -263,6 +234,8 @@ func (c *Container) merge(getconfig func() (v1.ImageConfig, error)) error {
 
 // FormatStatus format container status
 func (c *Container) FormatStatus() (string, error) {
+	c.Lock()
+	defer c.Unlock()
 	var status string
 
 	switch c.State.Status {

--- a/daemon/mgr/spec.go
+++ b/daemon/mgr/spec.go
@@ -20,8 +20,14 @@ type SpecWrapper struct {
 	argsArr [][]string
 }
 
+// All the functions related to the spec is lock-free for container instance,
+// so when calling functions here like createSpec, setupProcess, setupMounts,
+// setupUser and so on, caller should explicitly add lock for container instance.
+
 // createSpec create a runtime-spec.
 func createSpec(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
+	c.Lock()
+	defer c.Unlock()
 	// new a default spec from containerd.
 	s, err := ctrd.NewDefaultSpec(ctx, c.ID)
 	if err != nil {

--- a/test/api_container_logs_test.go
+++ b/test/api_container_logs_test.go
@@ -57,6 +57,8 @@ func (suite *APIContainerLogsSuite) TestNoShowStdoutAndShowStderr(c *check.C) {
 	resp, err := request.Get(fmt.Sprintf("/containers/%s/logs", name))
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, http.StatusBadRequest)
+
+	DelContainerForceOk(c, name)
 }
 
 // TestStdout tests stdout stream.

--- a/test/cli_pull_test.go
+++ b/test/cli_pull_test.go
@@ -37,7 +37,7 @@ func (suite *PouchPullSuite) TestPullWorks(c *check.C) {
 			c.Fatalf("unexpected output %s: should got image %s\n", out, expected)
 		}
 
-		command.PouchRun("rmi", expected).Assert(c, icmd.Success)
+		command.PouchRun("rmi", "-f", expected).Assert(c, icmd.Success)
 	}
 
 	busybox := "registry.hub.docker.com/library/busybox"

--- a/test/cli_top_test.go
+++ b/test/cli_top_test.go
@@ -43,7 +43,7 @@ func (suite *PouchTopSuite) TestTopStoppedContainer(c *check.C) {
 	res = command.PouchRun("top", name)
 	c.Assert(res.Stderr(), check.NotNil)
 
-	expectString := "container is not running, can not execute top command"
+	expectString := " is not running, cannot execute top command"
 	if out := res.Combined(); !strings.Contains(out, expectString) {
 		// FIXME(ziren): for debug top error info is empty
 		fmt.Printf("%+v", res)


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In the container manager, code usually use 

```
c.Lock()
defer c.Unlock()
```

to avoid race condition. While I think it is not so preferred since it does have serious affect on performance.

This PR dis three types of things:

* encapsulate all state management into a single file container_state.go;
* make container.Lock much more grained granularity.
* change log format to make it more explicit.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1244 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


