### PR TITLE
test: add missing removal of container

### DIFF
--- a/test/api_container_restart_test.go
+++ b/test/api_container_restart_test.go
@@ -74,4 +74,6 @@ func (suite *APIContainerRestartSuite) TestAPIRestartPausedContainer(c *check.C)
 	resp, err := request.Post("/containers/"+cname+"/restart", query)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 204)
+
+	DelContainerForceOk(c, cname)
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This pull request adds missing removal of container.

cc @Letty5411 

Otherwise I will get CI failure like:

```
FAIL: /go/src/github.com/alibaba/pouch/test/cli_ps_test.go:76: PouchPsSuite.TestPsAll
/go/src/github.com/alibaba/pouch/test/cli_ps_test.go:86:
    // show running containers default
    c.Assert(lines[1], check.Equals, "")
... obtained string = "TestAPIRestartPauseContainer   4b8795   Up 1 minute   1 minute ago   registry.hub.docker.com/library/busybox:1.28   runc"
... expected string = ""
```
 


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


