### PR TITLE
bugfix: make the jsonfile log friendly

### DIFF
--- a/daemon/containerio/jsonfile.go
+++ b/daemon/containerio/jsonfile.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/alibaba/pouch/daemon/logger"
@@ -130,6 +131,10 @@ func (jf *jsonFile) copy(source string, reader io.ReadCloser) {
 			Line:      bs,
 			Timestamp: createdTime,
 		}); err != nil {
+			if strings.Contains(err.Error(), os.ErrClosed.Error()) {
+				logrus.Warnf("failed to copy %v message into jsonfile: the container may be stopped: %v", source, err)
+				return
+			}
 			logrus.Errorf("failed to copy %v message into jsonfile: %v", source, err)
 			return
 		}

--- a/daemon/logger/jsonfile/jsonfile_read_test.go
+++ b/daemon/logger/jsonfile/jsonfile_read_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestReadLogMessagesWithRemoveFileInFollowMode(t *testing.T) {
-	f, err := ioutil.TempFile("/root", "tail-file")
+	f, err := ioutil.TempFile("", "tail-file")
 	if err != nil {
 		t.Fatalf("unexpected error during create tempfile: %v", err)
 	}


### PR DESCRIPTION
The file related error may be os.ErrClosed. If so, we can show the
container has been stopped.

Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Make the jsonfile log friendly.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Fixes #1325 

### Ⅲ. Describe how you did it

Since the error has been wrapped by the Write function, we should use the `strings.Contain` to check the error if it contains the `file already closed`.


### Ⅳ. Describe how to verify it

Basically, it's hard to verify it without change the logic, because it causes by the concurrent issue:

Before jsonfile writes the data into the file, the container manager has been stopped it and closed it.

In order to make it happen, we can add the `time.Sleep` before `Write`. It will show up.


### Ⅴ. Special notes for reviews


