### PR TITLE
test: fix cli_ps_test failed

### DIFF
--- a/test/cli_ps_test.go
+++ b/test/cli_ps_test.go
@@ -76,7 +76,7 @@ func (suite *PouchPsSuite) TestPsWorks(c *check.C) {
 func (suite *PouchPsSuite) TestPsAll(c *check.C) {
 	name := "ps-all"
 
-	command.PouchRun("create", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
 	res := command.PouchRun("ps").Assert(c, icmd.Success)
@@ -95,7 +95,7 @@ func (suite *PouchPsSuite) TestPsAll(c *check.C) {
 func (suite *PouchPsSuite) TestPsQuiet(c *check.C) {
 	name := "ps-quiet"
 
-	command.PouchRun("create", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
 	res := command.PouchRun("ps", "-q", "-a").Assert(c, icmd.Success)
@@ -113,7 +113,7 @@ func (suite *PouchPsSuite) TestPsQuiet(c *check.C) {
 func (suite *PouchPsSuite) TestPsNoTrunc(c *check.C) {
 	name := "ps-noTrunc"
 
-	command.PouchRun("create", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>


### Ⅰ. Describe what this PR did

```
----------------------------------------------------------------------
FAIL: /go/src/github.com/alibaba/pouch/test/cli_ps_test.go:113: PouchPsSuite.TestPsNoTrunc
/go/src/github.com/alibaba/pouch/test/cli_ps_test.go:131:
    c.Assert(kv[name].id, check.HasLen, 64)
... obtained string = ""
... n int = 64
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


