### PR TITLE
bugfix: move IO part behind to ensure execConfig result assignment before IO closes

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -95,7 +95,7 @@ type ContainerMgr interface {
 	// Remove removes a container, it may be running or stopped and so on.
 	Remove(ctx context.Context, name string, option *types.ContainerRemoveOptions) error
 
-	// 2. The following five functions is related to containr exec.
+	// 2. The following five functions is related to container exec.
 
 	// CreateExec creates exec process's environment.
 	CreateExec(ctx context.Context, name string, config *types.ExecCreateConfig) (string, error)
@@ -1674,16 +1674,6 @@ func (mgr *ContainerManager) exitedAndRelease(id string, m *ctrd.Message) error 
 // execExitedAndRelease be register into ctrd as a callback function, when the exec process in a container
 // exited, "ctrd" will call it to release resource and so on.
 func (mgr *ContainerManager) execExitedAndRelease(id string, m *ctrd.Message) error {
-	if io := mgr.IOs.Get(id); io != nil {
-		if err := m.RawError(); err != nil {
-			fmt.Fprintf(io.Stdout, "%v\n", err)
-		}
-
-		// close io
-		io.Close()
-		mgr.IOs.Remove(id)
-	}
-
 	v, ok := mgr.ExecProcesses.Get(id).Result()
 	if !ok {
 		return errors.Wrap(errtypes.ErrNotfound, "to be exec process: "+id)
@@ -1696,7 +1686,16 @@ func (mgr *ContainerManager) execExitedAndRelease(id string, m *ctrd.Message) er
 	execConfig.Running = false
 	execConfig.Error = m.RawError()
 
-	// TODO: GC invalid mgr.ExecProcess.
+	if io := mgr.IOs.Get(id); io != nil {
+		if err := m.RawError(); err != nil {
+			fmt.Fprintf(io.Stdout, "%v\n", err)
+		}
+
+		// close io
+		io.Close()
+		mgr.IOs.Remove(id)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Right now flaky test happens once in a while because ```getExecConfig``` does not always get the execConfig result before IO is pipe closed.
This pr changed the sequence inside ```execExitedAndRelease```, which pouchd will call to execute ```exit```.  By moving IO close operation behind the execConfig value assignment, the result getting is ensured.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1337


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


