### PR TITLE
test: enhance cli related tests

### DIFF
--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -40,14 +40,13 @@ func (suite *PouchCreateSuite) TearDownTest(c *check.C) {
 func (suite *PouchCreateSuite) TestCreateName(c *check.C) {
 	name := "create-normal"
 	res := command.PouchRun("create", "--name", name, busyboxImage)
-
+	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
 	// create command should add newline at the end of result
 	digStr := strings.TrimSpace(res.Combined())
 	c.Assert(res.Combined(), check.Equals, fmt.Sprintf("%s\n", digStr))
 
-	defer DelContainerForceMultyTime(c, name)
 }
 
 // TestCreateNameByImageID is to verify the correctness of creating contaier with specified name by image id.
@@ -59,14 +58,13 @@ func (suite *PouchCreateSuite) TestCreateNameByImageID(c *check.C) {
 	imageID := imagesListToKV(res.Combined())[busyboxImage][0]
 
 	res = command.PouchRun("create", "--name", name, imageID)
-
+	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
 	digHexStr := strings.TrimSpace(res.Combined())
 	_, err := digest.Parse(fmt.Sprintf("%s:%s", digest.SHA256, digHexStr))
 	c.Assert(err, check.IsNil)
 
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestCreateDuplicateContainerName is to verify duplicate container names.
@@ -74,12 +72,11 @@ func (suite *PouchCreateSuite) TestCreateDuplicateContainerName(c *check.C) {
 	name := "duplicate"
 
 	res := command.PouchRun("create", "--name", name, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
-	defer DelContainerForceMultyTime(c, name)
-
 	res = command.PouchRun("create", "--name", name, busyboxImage)
-	c.Assert(res.Error, check.NotNil)
+	c.Assert(res.Stderr(), check.NotNil)
 
 	if out := res.Combined(); !strings.Contains(out, "already exist") {
 		c.Fatalf("unexpected output %s expected already exist\n", out)
@@ -92,9 +89,9 @@ func (suite *PouchCreateSuite) TestCreateDuplicateContainerName(c *check.C) {
 func (suite *PouchCreateSuite) TestCreateWithArgs(c *check.C) {
 	name := "TestCreateWithArgs"
 	res := command.PouchRun("create", "--name", name, busyboxImage, "/bin/ls")
-	res.Assert(c, icmd.Success)
-
 	defer DelContainerForceMultyTime(c, name)
+
+	res.Assert(c, icmd.Success)
 }
 
 // TestCreateWithTTY is to verify tty flag.
@@ -103,9 +100,9 @@ func (suite *PouchCreateSuite) TestCreateWithArgs(c *check.C) {
 func (suite *PouchCreateSuite) TestCreateWithTTY(c *check.C) {
 	name := "TestCreateWithTTY"
 	res := command.PouchRun("create", "-t", "--name", name, busyboxImage)
-	res.Assert(c, icmd.Success)
-
 	defer DelContainerForceMultyTime(c, name)
+
+	res.Assert(c, icmd.Success)
 }
 
 // TestPouchCreateVolume is to verify volume flag.
@@ -120,9 +117,9 @@ func (suite *PouchCreateSuite) TestPouchCreateVolume(c *check.C) {
 	}
 
 	res := command.PouchRun("create", "-v /tmp:/tmp", "--name", funcname, busyboxImage)
-	res.Assert(c, icmd.Success)
-
 	defer DelContainerForceMultyTime(c, funcname)
+
+	res.Assert(c, icmd.Success)
 }
 
 // TestCreateInWrongWay tries to run create in wrong way.
@@ -137,7 +134,7 @@ func (suite *PouchCreateSuite) TestCreateInWrongWay(c *check.C) {
 		// {name: "missing image name", args: ""},
 	} {
 		res := command.PouchRun("create", tc.args)
-		c.Assert(res.Error, check.NotNil, check.Commentf(tc.name))
+		c.Assert(res.Stderr(), check.NotNil, check.Commentf(tc.name))
 	}
 }
 
@@ -147,8 +144,8 @@ func (suite *PouchCreateSuite) TestCreateWithLabels(c *check.C) {
 	name := "create-label"
 
 	res := command.PouchRun("create", "--name", name, "-l", label, busyboxImage)
-	res.Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 
@@ -169,8 +166,8 @@ func (suite *PouchCreateSuite) TestCreateWithSysctls(c *check.C) {
 	name := "create-sysctl"
 
 	res := command.PouchRun("create", "--name", name, "--sysctl", sysctl, busyboxImage)
-	res.Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 
@@ -191,8 +188,8 @@ func (suite *PouchCreateSuite) TestCreateWithAppArmor(c *check.C) {
 	name := "create-apparmor"
 
 	res := command.PouchRun("create", "--name", name, "--security-opt", appArmor, busyboxImage)
-	res.Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 
@@ -219,8 +216,8 @@ func (suite *PouchCreateSuite) TestCreateWithSeccomp(c *check.C) {
 	name := "create-seccomp"
 
 	res := command.PouchRun("create", "--name", name, "--security-opt", seccomp, busyboxImage)
-	res.Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 
@@ -247,8 +244,8 @@ func (suite *PouchCreateSuite) TestCreateWithCapability(c *check.C) {
 	name := "create-capability"
 
 	res := command.PouchRun("create", "--name", name, "--cap-add", capability, busyboxImage, "brctl", "addbr", "foobar")
-	res.Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 
@@ -274,8 +271,8 @@ func (suite *PouchCreateSuite) TestCreateWithPrivilege(c *check.C) {
 	name := "create-privilege"
 
 	res := command.PouchRun("create", "--name", name, "--privileged", busyboxImage, "brctl", "addbr", "foobar")
-	res.Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 
@@ -291,6 +288,7 @@ func (suite *PouchCreateSuite) TestCreateEnableLxcfs(c *check.C) {
 	name := "create-lxcfs"
 
 	res := command.PouchRun("create", "--name", name, "--enableLxcfs=true", busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
@@ -311,6 +309,8 @@ func (suite *PouchCreateSuite) TestCreateWithEnv(c *check.C) {
 	name := "TestCreateWithEnv"
 
 	res := command.PouchRun("create", "--name", name, "-e TEST=true", busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
@@ -334,6 +334,7 @@ func (suite *PouchCreateSuite) TestCreateWithWorkDir(c *check.C) {
 	name := "TestCreateWithWorkDir"
 
 	res := command.PouchRun("create", "--name", name, "-w /tmp/test", busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
@@ -353,6 +354,8 @@ func (suite *PouchCreateSuite) TestCreateWithUser(c *check.C) {
 	user := "1001"
 
 	res := command.PouchRun("create", "--name", name, "--user", user, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
@@ -370,6 +373,8 @@ func (suite *PouchCreateSuite) TestCreateWithIntelRdt(c *check.C) {
 	intelRdt := "L3:<cache_id0>=<cbm0>"
 
 	res := command.PouchRun("create", "--name", name, "--intel-rdt-l3-cbm", intelRdt, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
@@ -387,7 +392,11 @@ func (suite *PouchCreateSuite) TestCreateWithAliOSMemoryOptions(c *check.C) {
 	memoryWmarkRatio := "30"
 	memoryExtra := "50"
 
-	res := command.PouchRun("create", "--name", name, "--memory-wmark-ratio", memoryWmarkRatio, "--memory-extra", memoryExtra, "--memory-force-empty-ctl", "1", "--sche-lat-switch", "1", busyboxImage)
+	res := command.PouchRun("create", "--name", name, "--memory-wmark-ratio",
+		memoryWmarkRatio, "--memory-extra", memoryExtra, "--memory-force-empty-ctl", "1",
+		"--sche-lat-switch", "1", busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
@@ -407,7 +416,10 @@ func (suite *PouchCreateSuite) TestCreateWithOOMOption(c *check.C) {
 	name := "TestCreateWithOOMOption"
 	oomScore := "100"
 
-	res := command.PouchRun("create", "--name", name, "--oom-score-adj", oomScore, "--oom-kill-disable", busyboxImage)
+	res := command.PouchRun("create", "--name", name, "--oom-score-adj", oomScore,
+		"--oom-kill-disable", busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
@@ -423,7 +435,10 @@ func (suite *PouchCreateSuite) TestCreateWithOOMOption(c *check.C) {
 // TestCreateWithAnnotation tests creating container with annotation.
 func (suite *PouchCreateSuite) TestCreateWithAnnotation(c *check.C) {
 	cname := "TestCreateWithAnnotation"
-	command.PouchRun("create", "--annotation", "a=b", "--annotation", "foo=bar", "--name", cname, busyboxImage).Stdout()
+	res := command.PouchRun("create", "--annotation", "a=b", "--annotation", "foo=bar",
+		"--name", cname, busyboxImage)
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", cname).Stdout()
 	result := []types.ContainerJSON{}
@@ -445,7 +460,9 @@ func (suite *PouchCreateSuite) TestCreateWithAnnotation(c *check.C) {
 // TestCreateWithUlimit tests creating container with annotation.
 func (suite *PouchCreateSuite) TestCreateWithUlimit(c *check.C) {
 	cname := "TestCreateWithUlimit"
-	command.PouchRun("create", "--ulimit", "nproc=21", "--name", cname, busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("create", "--ulimit", "nproc=21", "--name", cname, busyboxImage)
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", cname).Stdout()
 	result := []types.ContainerJSON{}

--- a/test/cli_exec_test.go
+++ b/test/cli_exec_test.go
@@ -74,8 +74,9 @@ func (suite *PouchExecSuite) TestExecMultiCommands(c *check.C) {
 // TestExecEcho tests exec prints the output.
 func (suite *PouchExecSuite) TestExecEcho(c *check.C) {
 	name := "TestExecEcho"
-	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	out := command.PouchRun("exec", name, "echo", "test").Stdout()
 	if !strings.Contains(out, "test") {
@@ -86,8 +87,9 @@ func (suite *PouchExecSuite) TestExecEcho(c *check.C) {
 // TestExecStoppedContainer test exec in a stopped container fail.
 func (suite *PouchExecSuite) TestExecStoppedContainer(c *check.C) {
 	name := "TestExecStoppedContainer"
-	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("stop", name).Assert(c, icmd.Success)
 
@@ -105,8 +107,9 @@ func (suite *PouchExecSuite) TestExecInteractive(c *check.C) {
 // TestExecAfterContainerRestart test exec in a restart container should work.
 func (suite *PouchExecSuite) TestExecAfterContainerRestart(c *check.C) {
 	name := "TestExecAfterContainerRestart"
-	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("stop", name).Assert(c, icmd.Success)
 
@@ -121,8 +124,10 @@ func (suite *PouchExecSuite) TestExecAfterContainerRestart(c *check.C) {
 // TestExecUlimit test ulimit set container.
 func (suite *PouchExecSuite) TestExecUlimit(c *check.C) {
 	name := "TestExecUlimit"
-	command.PouchRun("run", "-d", "--name", name, "--ulimit", "nproc=256", busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", name, "--ulimit", "nproc=256",
+		busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	out := command.PouchRun("exec", name, "sh", "-c", "ulimit -p").Stdout()
 	c.Assert(out, check.Equals, "256\n")
@@ -131,8 +136,9 @@ func (suite *PouchExecSuite) TestExecUlimit(c *check.C) {
 // TestExecExitCode test exit code after exec process exit.
 func (suite *PouchExecSuite) TestExecExitCode(c *check.C) {
 	name := "TestExecExitCode"
-	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("exec", name, "sh", "-c", "exit 101").Assert(c, icmd.Expected{ExitCode: 101})
 	command.PouchRun("exec", name, "sh", "-c", "exit 0").Assert(c, icmd.Success)

--- a/test/cli_help_test.go
+++ b/test/cli_help_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alibaba/pouch/test/environment"
 
 	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
 )
 
 // PouchHelpSuite is the test suite for help CLI.
@@ -33,9 +34,9 @@ func (suite *PouchHelpSuite) TestHelpWorks(c *check.C) {
 	for arg, ok := range args {
 		res := command.PouchRun(arg)
 		if ok {
-			c.Assert(res.Error, check.IsNil)
+			res.Assert(c, icmd.Success)
 		} else {
-			c.Assert(res.Error, check.NotNil)
+			c.Assert(res.Stderr(), check.NotNil)
 		}
 	}
 }

--- a/test/cli_ps_test.go
+++ b/test/cli_ps_test.go
@@ -37,7 +37,7 @@ func (suite *PouchPsSuite) TearDownTest(c *check.C) {
 // TODO: check more value, like id/runtime.
 func (suite *PouchPsSuite) TestPsWorks(c *check.C) {
 	name := "ps-normal"
-
+	defer DelContainerForceMultyTime(c, name)
 	// create
 	{
 		command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
@@ -69,7 +69,6 @@ func (suite *PouchPsSuite) TestPsWorks(c *check.C) {
 		c.Assert(kv[name].status[0], check.Equals, "Stopped")
 	}
 
-	defer DelContainerForceMultyTime(c, name)
 }
 
 // TestPsAll tests "pouch ps -a" work

--- a/test/cli_pull_test.go
+++ b/test/cli_pull_test.go
@@ -75,12 +75,12 @@ func (suite *PouchPullSuite) TestPullInWrongWay(c *check.C) {
 	// pull unknown images
 	{
 		res := command.PouchRun("pull", "unknown")
-		c.Assert(res.Error, check.NotNil)
+		c.Assert(res.Stderr(), check.NotNil)
 	}
 
 	// pull with invalid flag
 	{
 		res := command.PouchRun("pull", busyboxImage, "-f")
-		c.Assert(res.Error, check.NotNil)
+		c.Assert(res.Stderr(), check.NotNil)
 	}
 }

--- a/test/cli_restart_test.go
+++ b/test/cli_restart_test.go
@@ -34,16 +34,16 @@ func (suite *PouchRestartSuite) TearDownTest(c *check.C) {
 func (suite *PouchRestartSuite) TestPouchRestart(c *check.C) {
 	name := "TestPouchRestart"
 
-	command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
-	res := command.PouchRun("restart", "-t", "1", name)
-	c.Assert(res.Error, check.IsNil)
+	res = command.PouchRun("restart", "-t", "1", name)
+	res.Assert(c, icmd.Success)
 
 	if out := res.Combined(); !strings.Contains(out, name) {
 		c.Fatalf("unexpected output: %s, expected: %s", out, name)
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestPouchRestartStoppedContainer is to verify the correctness of restarting a stopped container.
@@ -51,24 +51,23 @@ func (suite *PouchRestartSuite) TestPouchRestart(c *check.C) {
 func (suite *PouchRestartSuite) TestPouchRestartStoppedContainer(c *check.C) {
 	name := "TestPouchRestartStoppedContainer"
 
-	command.PouchRun("create", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("create", "--name", name, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
 
-	res := command.PouchRun("restart", "-t", "1", name)
-	c.Assert(res.Error, check.IsNil)
+	res.Assert(c, icmd.Success)
 
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
+	command.PouchRun("restart", "-t", "1", name).Assert(c, icmd.Success)
 }
 
 // TestPouchRestartPausedContainer is to verify restart paused container
 func (suite *PouchRestartSuite) TestPouchRestartPausedContainer(c *check.C) {
 	name := "TestPouchRestartPausedContainer"
 
-	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("pause", name).Assert(c, icmd.Success)
 
-	res := command.PouchRun("restart", name)
-	c.Assert(res.Error, check.IsNil)
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
+	command.PouchRun("restart", name).Assert(c, icmd.Success)
 }

--- a/test/cli_rich_container_test.go
+++ b/test/cli_rich_container_test.go
@@ -112,8 +112,10 @@ func (suite *PouchRichContainerSuite) TestRichContainerDumbInitWorks(c *check.C)
 		funcname = tmpname[i]
 	}
 
-	command.PouchRun("run", "-d", "--rich", "--rich-mode", "dumb-init", "--name", funcname,
-		busyboxImage, "sleep", "10000").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--rich", "--rich-mode", "dumb-init", "--name", funcname,
+		busyboxImage, "sleep", "10000")
+	defer DelContainerForceMultyTime(c, funcname)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", funcname).Stdout()
 	result := []types.ContainerJSON{}
@@ -134,8 +136,6 @@ func (suite *PouchRichContainerSuite) TestRichContainerDumbInitWorks(c *check.C)
 	command.PouchRun("pause", funcname).Assert(c, icmd.Success)
 	command.PouchRun("unpause", funcname).Assert(c, icmd.Success)
 	c.Assert(checkPidofProcessIsOne(funcname, "dumb-init"), check.Equals, true)
-
-	command.PouchRun("rm", "-f", funcname)
 }
 
 // TestRichContainerWrongArgs check the wrong args of rich container.
@@ -213,8 +213,10 @@ func (suite *PouchRichContainerSuite) TestRichContainerSystemdWorks(c *check.C) 
 		c.Skip("/usr/lib/systemd/systemd doesn't exist in test image")
 	}
 
-	command.PouchRun("run", "-d", "--privileged", "--rich", "--rich-mode", "systemd",
-		"--name", funcname, centosImage, "/usr/bin/sleep 1000").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--privileged", "--rich", "--rich-mode", "systemd",
+		"--name", funcname, centosImage, "/usr/bin/sleep 1000")
+	defer DelContainerForceMultyTime(c, funcname)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", funcname).Stdout()
 	result := []types.ContainerJSON{}
@@ -238,6 +240,4 @@ func (suite *PouchRichContainerSuite) TestRichContainerSystemdWorks(c *check.C) 
 	command.PouchRun("unpause", funcname).Assert(c, icmd.Success)
 	c.Assert(checkPidofProcessIsOne(funcname, "/usr/lib/systemd/systemdd"), check.Equals, true)
 	c.Assert(checkPPid(funcname, "sleep", "1"), check.Equals, true)
-
-	command.PouchRun("rm", "-f", funcname)
 }

--- a/test/cli_rm_test.go
+++ b/test/cli_rm_test.go
@@ -41,10 +41,13 @@ func (suite *PouchRmSuite) TestContainerRmWithVolume(c *check.C) {
 	expectVolumeNums := strings.Count(ret.Stdout(), "\n")
 
 	// run container with volume
-	command.PouchRun("run", "-d", "--name", containerName,
+	res := command.PouchRun("run", "-d", "--name", containerName,
 		"-v", volumeName+":/mnt",
 		"-v", "/home",
-		busyboxImage, "top").Assert(c, icmd.Success)
+		busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, containerName)
+
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("rm", "-vf", containerName).Assert(c, icmd.Success)
 

--- a/test/cli_rmi_test.go
+++ b/test/cli_rmi_test.go
@@ -99,6 +99,6 @@ func (suite *PouchRmiSuite) TestRmiInWrongWay(c *check.C) {
 		// {name: "missing image name", args: ""},
 	} {
 		res := command.PouchRun("rmi", tc.args)
-		c.Assert(res.Error, check.NotNil, check.Commentf(tc.name))
+		c.Assert(res.Stderr(), check.NotNil, check.Commentf(tc.name))
 	}
 }

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -42,13 +42,14 @@ func (suite *PouchRunSuite) TearDownTest(c *check.C) {
 func (suite *PouchRunSuite) TestRun(c *check.C) {
 	name := "test-run"
 
-	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
-	res := command.PouchRun("ps").Assert(c, icmd.Success)
+	res = command.PouchRun("ps").Assert(c, icmd.Success)
 	if out := res.Combined(); !strings.Contains(out, name) {
 		c.Fatalf("unexpected output %s: should contains container %s\n", out, name)
 	}
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunPrintHi is to verify run container with executing a command.
@@ -56,12 +57,12 @@ func (suite *PouchRunSuite) TestRunPrintHi(c *check.C) {
 	name := "test-run-print-hi"
 
 	res := command.PouchRun("run", "--name", name, busyboxImage, "echo", "hi")
+	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
 	if out := res.Combined(); !strings.Contains(out, "hi") {
 		c.Fatalf("unexpected output %s expected hi\n", out)
 	}
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunPrintHiByImageID is to verify run container with executing a command by image ID.
@@ -70,15 +71,16 @@ func (suite *PouchRunSuite) TestRunPrintHiByImageID(c *check.C) {
 
 	res := command.PouchRun("images")
 	res.Assert(c, icmd.Success)
+
 	imageID := imagesListToKV(res.Combined())[busyboxImage][0]
 
 	res = command.PouchRun("run", "--name", name, imageID, "echo", "hi")
+	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
 	if out := res.Combined(); !strings.Contains(out, "hi") {
 		c.Fatalf("unexpected output %s expected hi\n", out)
 	}
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunDeviceMapping is to verify --device param when running a container.
@@ -90,13 +92,14 @@ func (suite *PouchRunSuite) TestRunDeviceMapping(c *check.C) {
 	name := "test-run-device-mapping"
 	testDev := "/dev/testDev"
 
-	res := command.PouchRun("run", "--name", name, "--device", "/dev/zero:"+testDev, busyboxImage, "ls", testDev)
+	res := command.PouchRun("run", "--name", name, "--device", "/dev/zero:"+testDev,
+		busyboxImage, "ls", testDev)
+	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
 	if out := res.Combined(); !strings.Contains(out, testDev) {
 		c.Fatalf("unexpected output %s expected %s\n", out, testDev)
 	}
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunDevicePermissions is to verify --device permissions mode when running a container.
@@ -109,13 +112,15 @@ func (suite *PouchRunSuite) TestRunDevicePermissions(c *check.C) {
 	testDev := "/dev/testDev"
 	permissions := "crw-rw-rw-"
 
-	res := command.PouchRun("run", "--name", name, "--device", "/dev/zero:"+testDev+":rwm", busyboxImage, "ls", "-l", testDev)
+	res := command.PouchRun("run", "--name", name, "--device",
+		"/dev/zero:"+testDev+":rwm", busyboxImage, "ls", "-l", testDev)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
 
 	if out := res.Combined(); !strings.HasPrefix(out, permissions) {
 		c.Fatalf("Output should begin with %s, got %s\n", permissions, out)
 	}
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunDeviceInvalidMode is to verify --device wrong mode when running a container.
@@ -123,8 +128,11 @@ func (suite *PouchRunSuite) TestRunDeviceInvalidMode(c *check.C) {
 	name := "test-run-device-with-wrong-mode"
 	wrongMode := "rxm"
 
-	res := command.PouchRun("run", "--name", name, "--device", "/dev/zero:/dev/zero:"+wrongMode, busyboxImage, "ls", "/dev/zero")
-	c.Assert(res.Error, check.NotNil)
+	res := command.PouchRun("run", "--name", name, "--device",
+		"/dev/zero:/dev/zero:"+wrongMode, busyboxImage, "ls", "/dev/zero")
+	defer DelContainerForceMultyTime(c, name)
+
+	c.Assert(res.Stderr(), check.NotNil)
 
 	expected := "invalid device mode"
 	if out := res.Combined(); !strings.Contains(out, expected) {
@@ -141,7 +149,10 @@ func (suite *PouchRunSuite) TestRunDeviceDirectory(c *check.C) {
 	name := "test-run-with-directory-device"
 	srcDev := "/dev/snd"
 
-	res := command.PouchRun("run", "--name", name, "--device", srcDev+":/dev:rwm", busyboxImage, "ls", "-l", "/dev")
+	res := command.PouchRun("run", "--name", name, "--device",
+		srcDev+":/dev:rwm", busyboxImage, "ls", "-l", "/dev")
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
 
 	// /dev/snd contans two device: timer, seq
@@ -149,7 +160,6 @@ func (suite *PouchRunSuite) TestRunDeviceDirectory(c *check.C) {
 	if out := res.Combined(); !strings.Contains(out, expected) {
 		c.Fatalf("Output should contain %s, got %s\n", expected, out)
 	}
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithBadDevice is to verify --device with bad device dir when running a container.
@@ -157,7 +167,9 @@ func (suite *PouchRunSuite) TestRunDeviceWithBadDevice(c *check.C) {
 	name := "test-run-with-bad-device"
 
 	res := command.PouchRun("run", "--name", name, "--device", "/etc", busyboxImage, "ls", "/etc")
-	c.Assert(res.Error, check.NotNil)
+	defer DelContainerForceMultyTime(c, name)
+
+	c.Assert(res.Stderr(), check.NotNil)
 
 	expected := "not a device node"
 	if out := res.Combined(); !strings.Contains(out, expected) {
@@ -177,7 +189,7 @@ func (suite *PouchRunSuite) TestRunInWrongWay(c *check.C) {
 		// {name: "missing image name", args: ""},
 	} {
 		res := command.PouchRun("run", tc.args)
-		c.Assert(res.Error, check.NotNil, check.Commentf(tc.name))
+		c.Assert(res.Stderr(), check.NotNil, check.Commentf(tc.name))
 	}
 }
 
@@ -189,6 +201,7 @@ func (suite *PouchRunSuite) TestRunEnableLxcfs(c *check.C) {
 
 	command.PouchRun("run", "-d", "--name", name, "-m", "512M", "--enableLxcfs=true",
 		busyboxImage, "sleep", "10000").Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
 
 	res := command.PouchRun("exec", name, "head", "-n", "5", "/proc/meminfo")
 	res.Assert(c, icmd.Success)
@@ -197,7 +210,6 @@ func (suite *PouchRunSuite) TestRunEnableLxcfs(c *check.C) {
 	if out := res.Combined(); !strings.Contains(out, "524288 kB") {
 		c.Fatalf("upexpected output %v, expected %s\n", res, "524288 kB")
 	}
-	DelContainerForceMultyTime(c, name)
 }
 
 // Comment this flaky test.
@@ -222,16 +234,19 @@ func (suite *PouchRunSuite) TestRunEnableLxcfs(c *check.C) {
 func (suite *PouchRunSuite) TestRunRestartPolicyNone(c *check.C) {
 	name := "TestRunRestartPolicyNone"
 
-	command.PouchRun("run", "--name", name, "-d", "--restart=no", busyboxImage, "sh", "-c", "sleep 1").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "--name", name, "-d", "--restart=no", busyboxImage,
+		"sh", "-c", "sleep 1")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
+
 	time.Sleep(2000 * time.Millisecond)
 
-	res := command.PouchRun("ps")
+	res = command.PouchRun("ps")
 	res.Assert(c, icmd.Success)
 
 	if out := res.Combined(); strings.Contains(out, name) {
 		c.Fatalf("expect container %s to be exited: %s\n", name, out)
 	}
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithIPCMode is to verify --specific IPC mode when running a container.
@@ -240,8 +255,9 @@ func (suite *PouchRunSuite) TestRunWithIPCMode(c *check.C) {
 	name := "test-run-with-ipc-mode"
 
 	res := command.PouchRun("run", "-d", "--name", name, "--ipc", "host", busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithPIDMode is to verify --specific PID mode when running a container.
@@ -250,8 +266,9 @@ func (suite *PouchRunSuite) TestRunWithPIDMode(c *check.C) {
 	name := "test-run-with-pid-mode"
 
 	res := command.PouchRun("run", "-d", "--name", name, "--pid", "host", busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithUTSMode is to verify --specific UTS mode when running a container.
@@ -259,8 +276,9 @@ func (suite *PouchRunSuite) TestRunWithUTSMode(c *check.C) {
 	name := "test-run-with-uts-mode"
 
 	res := command.PouchRun("run", "-d", "--name", name, "--uts", "host", busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithSysctls is to verify run container with sysctls.
@@ -269,13 +287,14 @@ func (suite *PouchRunSuite) TestRunWithSysctls(c *check.C) {
 	name := "run-sysctl"
 
 	res := command.PouchRun("run", "-d", "--name", name, "--sysctl", sysctl, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("exec", name, "cat", "/proc/sys/net/ipv4/ip_forward").Stdout()
 	if !strings.Contains(output, "1") {
 		c.Fatalf("failed to run a container with sysctls: %s", output)
 	}
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithUser is to verify run container with user.
@@ -284,6 +303,7 @@ func (suite *PouchRunSuite) TestRunWithUser(c *check.C) {
 	name := "run-user"
 
 	res := command.PouchRun("run", "-d", "--name", name, "--user", user, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("exec", name, "id", "-u").Stdout()
@@ -307,11 +327,11 @@ func (suite *PouchRunSuite) TestRunWithAppArmor(c *check.C) {
 	name := "run-apparmor"
 
 	res := command.PouchRun("run", "-d", "--name", name, "--security-opt", appArmor, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
 
 	// TODO: do the test more strictly with effective AppArmor profile.
-
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithSeccomp is to verify run container with security option seccomp.
@@ -320,11 +340,12 @@ func (suite *PouchRunSuite) TestRunWithSeccomp(c *check.C) {
 	name := "run-seccomp"
 
 	res := command.PouchRun("run", "-d", "--name", name, "--security-opt", seccomp, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
 
 	// TODO: do the test more strictly with effective seccomp profile.
 
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithCapability is to verify run container with capability.
@@ -332,9 +353,11 @@ func (suite *PouchRunSuite) TestRunWithCapability(c *check.C) {
 	capability := "NET_ADMIN"
 	name := "run-capability"
 
-	res := command.PouchRun("run", "--name", name, "--cap-add", capability, busyboxImage, "brctl", "addbr", "foobar")
+	res := command.PouchRun("run", "--name", name, "--cap-add", capability,
+		busyboxImage, "brctl", "addbr", "foobar")
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithoutCapability tests running container with --cap-drop
@@ -344,17 +367,20 @@ func (suite *PouchRunSuite) TestRunWithoutCapability(c *check.C) {
 	expt := icmd.Expected{
 		Err: "Operation not permitted",
 	}
-	command.PouchRun("run", "--name", name, "--cap-drop", capability, busyboxImage, "chown", "755", "/tmp").Compare(expt)
-	DelContainerForceMultyTime(c, name)
+	command.PouchRun("run", "--name", name, "--cap-drop", capability,
+		busyboxImage, "chown", "755", "/tmp").Compare(expt)
+	defer DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithPrivilege is to verify run container with privilege.
 func (suite *PouchRunSuite) TestRunWithPrivilege(c *check.C) {
 	name := "run-privilege"
 
-	res := command.PouchRun("run", "--name", name, "--privileged", busyboxImage, "brctl", "addbr", "foobar")
+	res := command.PouchRun("run", "--name", name, "--privileged",
+		busyboxImage, "brctl", "addbr", "foobar")
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithBlkioWeight is to verify --specific Blkio Weight when running a container.
@@ -362,8 +388,9 @@ func (suite *PouchRunSuite) TestRunWithBlkioWeight(c *check.C) {
 	name := "test-run-with-blkio-weight"
 
 	res := command.PouchRun("run", "-d", "--name", name, "--blkio-weight", "500", busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+
 	res.Assert(c, icmd.Success)
-	DelContainerForceMultyTime(c, name)
 }
 
 // TestRunWithLocalVolume is to verify run container with -v volume works.
@@ -376,16 +403,20 @@ func (suite *PouchRunSuite) TestRunWithLocalVolume(c *check.C) {
 	}
 
 	name := funcname
+	{
+		res := command.PouchRun("volume", "create", "--name", funcname)
+		defer func() {
+			command.PouchRun("volume", "remove", funcname).Assert(c, icmd.Success)
+		}()
+		res.Assert(c, icmd.Success)
+	}
 
-	command.PouchRun("volume", "create", "--name", funcname).Assert(c, icmd.Success)
-	defer func() {
-		command.PouchRun("volume", "remove", funcname).Assert(c, icmd.Success)
-	}()
-
-	command.PouchRun("run", "--name", name, "-v", funcname+":/tmp", busyboxImage, "touch", "/tmp/test").Assert(c, icmd.Success)
-	defer func() {
-		DelContainerForceMultyTime(c, name)
-	}()
+	{
+		res := command.PouchRun("run", "--name", name, "-v", funcname+":/tmp",
+			busyboxImage, "touch", "/tmp/test")
+		defer DelContainerForceMultyTime(c, name)
+		res.Assert(c, icmd.Success)
+	}
 
 	// check the existence of /var/lib/pouch/volume/function/test
 	icmd.RunCommand("stat", DefaultVolumeMountPath+"/"+funcname+"/test").Assert(c, icmd.Success)
@@ -395,7 +426,7 @@ func (suite *PouchRunSuite) TestRunWithLocalVolume(c *check.C) {
 // checkFileContains checks the content of fname contains expt
 func checkFileContains(c *check.C, fname string, expt string) {
 	cmdResult := icmd.RunCommand("cat", fname)
-	c.Assert(cmdResult.Error, check.IsNil)
+	cmdResult.Assert(c, icmd.Success)
 	c.Assert(strings.Contains(string(cmdResult.Stdout()), expt), check.Equals, true)
 }
 
@@ -403,6 +434,7 @@ func checkFileContains(c *check.C, fname string, expt string) {
 func (suite *PouchRunSuite) TestRunWithLimitedMemory(c *check.C) {
 	cname := "TestRunWithLimitedMemory"
 	command.PouchRun("run", "-d", "-m", "100m", "--name", cname, busyboxImage, "top").Stdout()
+	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -417,9 +449,6 @@ func (suite *PouchRunSuite) TestRunWithLimitedMemory(c *check.C) {
 	path := fmt.Sprintf("/sys/fs/cgroup/memory/default/%s/memory.limit_in_bytes", containerID)
 
 	checkFileContains(c, path, "104857600")
-
-	// remove the container
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestRunWithMemoryswap is to verify the valid running container with --memory-swap
@@ -427,6 +456,7 @@ func (suite *PouchRunSuite) TestRunWithMemoryswap(c *check.C) {
 	cname := "TestRunWithMemoryswap"
 	command.PouchRun("run", "-d", "-m", "100m", "--memory-swap", "200m",
 		"--name", cname, busyboxImage, "sleep", "10000").Stdout()
+	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -440,9 +470,6 @@ func (suite *PouchRunSuite) TestRunWithMemoryswap(c *check.C) {
 	containerID := result[0].ID
 	path := fmt.Sprintf("/sys/fs/cgroup/memory/default/%s/memory.memsw.limit_in_bytes", containerID)
 	checkFileContains(c, path, "209715200")
-
-	// remove the container
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestRunWithMemoryswappiness is to verify the valid running container with memory-swappiness
@@ -450,6 +477,7 @@ func (suite *PouchRunSuite) TestRunWithMemoryswappiness(c *check.C) {
 	cname := "TestRunWithMemoryswappiness"
 	command.PouchRun("run", "-d", "-m", "100m", "--memory-swappiness", "70",
 		"--name", cname, busyboxImage, "sleep", "10000").Stdout()
+	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -463,8 +491,6 @@ func (suite *PouchRunSuite) TestRunWithMemoryswappiness(c *check.C) {
 	containerID := result[0].ID
 	path := fmt.Sprintf("/sys/fs/cgroup/memory/default/%s/memory.swappiness", containerID)
 	checkFileContains(c, path, "70")
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestRunWithCPULimit tests CPU related flags.
@@ -479,6 +505,7 @@ func (suite *PouchRunSuite) TestRunWithCPULimit(c *check.C) {
 		"--name", cname,
 		busyboxImage,
 		"sleep", "10000").Stdout()
+	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -516,8 +543,6 @@ func (suite *PouchRunSuite) TestRunWithCPULimit(c *check.C) {
 		path := fmt.Sprintf("/sys/fs/cgroup/cpu/default/%s/cpu.cfs_quota_us", containerID)
 		checkFileContains(c, path, "1000")
 	}
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestRunBlockIOWeight tests running container with --blkio-weight flag.
@@ -525,6 +550,7 @@ func (suite *PouchRunSuite) TestRunBlockIOWeight(c *check.C) {
 	cname := "TestRunBlockIOWeight"
 	command.PouchRun("run", "-d", "--blkio-weight", "100",
 		"--name", cname, busyboxImage, "sleep", "10000").Stdout()
+	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -541,7 +567,6 @@ func (suite *PouchRunSuite) TestRunBlockIOWeight(c *check.C) {
 		path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.weight", containerID)
 		checkFileContains(c, path, "100")
 	}
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestRunBlockIOWeightDevice tests running container with --blkio-weight-device flag.
@@ -554,6 +579,7 @@ func (suite *PouchRunSuite) TestRunBlockIOWeightDevice(c *check.C) {
 
 	command.PouchRun("run", "-d", "--blkio-weight-device", testDisk+":100",
 		"--name", cname, busyboxImage, "sleep", "10000").Stdout()
+	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -572,7 +598,6 @@ func (suite *PouchRunSuite) TestRunBlockIOWeightDevice(c *check.C) {
 	//	path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.weight_device", containerID)
 	//	checkFileContains(c, path, "100")
 	//}
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestRunDeviceReadBps tests running container with --device-read-bps flag.
@@ -585,6 +610,7 @@ func (suite *PouchRunSuite) TestRunDeviceReadBps(c *check.C) {
 
 	command.PouchRun("run", "-d", "--device-read-bps", testDisk+":1mb",
 		"--name", cname, busyboxImage, "sleep", "10000").Stdout()
+	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -603,7 +629,6 @@ func (suite *PouchRunSuite) TestRunDeviceReadBps(c *check.C) {
 		path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.throttle.read_bps_device", containerID)
 		checkFileContains(c, path, "1048576")
 	}
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestRunDeviceWriteBps tests running container with --device-write-bps flag.
@@ -616,6 +641,7 @@ func (suite *PouchRunSuite) TestRunDeviceWriteBps(c *check.C) {
 
 	command.PouchRun("run", "-d", "--device-write-bps", testDisk+":1mb",
 		"--name", cname, busyboxImage, "sleep", "10000").Stdout()
+	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -634,7 +660,6 @@ func (suite *PouchRunSuite) TestRunDeviceWriteBps(c *check.C) {
 		path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.throttle.write_bps_device", containerID)
 		checkFileContains(c, path, "1048576")
 	}
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestRunDeviceReadIops tests running container with --device-read-iops flag.
@@ -647,6 +672,7 @@ func (suite *PouchRunSuite) TestRunDeviceReadIops(c *check.C) {
 
 	command.PouchRun("run", "-d", "--device-read-iops", testDisk+":1000",
 		"--name", cname, busyboxImage, "sleep", "10000").Stdout()
+	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -665,7 +691,6 @@ func (suite *PouchRunSuite) TestRunDeviceReadIops(c *check.C) {
 		path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.throttle.read_iops_device", containerID)
 		checkFileContains(c, path, "1000")
 	}
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestRunDeviceWriteIops tests running container with --device-write-iops flag.
@@ -678,6 +703,7 @@ func (suite *PouchRunSuite) TestRunDeviceWriteIops(c *check.C) {
 
 	command.PouchRun("run", "-d", "--device-write-iops", testDisk+":1000",
 		"--name", cname, busyboxImage, "sleep", "10000").Stdout()
+	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
 	output := command.PouchRun("inspect", cname).Stdout()
@@ -696,7 +722,6 @@ func (suite *PouchRunSuite) TestRunDeviceWriteIops(c *check.C) {
 		path := fmt.Sprintf("/sys/fs/cgroup/blkio/default/%s/blkio.throttle.write_iops_device", containerID)
 		checkFileContains(c, path, "1000")
 	}
-	DelContainerForceMultyTime(c, cname)
 }
 
 //
@@ -731,9 +756,11 @@ func (suite *PouchRunSuite) TestRunWithHostFileVolume(c *check.C) {
 	icmd.RunCommand("touch", filepath).Assert(c, icmd.Success)
 
 	cname := "TestRunWithHostFileVolume"
-	command.PouchRun("run", "-d", "--name", cname, "-v", fmt.Sprintf("%s:%s", filepath, filepath), busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", cname, "-v",
+		fmt.Sprintf("%s:%s", filepath, filepath), busyboxImage)
 
-	DelContainerForceMultyTime(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
 }
 
 // TestRunWithCgroupParent tests running container with --cgroup-parent.
@@ -746,7 +773,11 @@ func (suite *PouchRunSuite) TestRunWithCgroupParent(c *check.C) {
 }
 
 func testRunWithCgroupParent(c *check.C, cgroupParent, name string) {
-	command.PouchRun("run", "-d", "-m", "300M", "--cgroup-parent", cgroupParent, "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "-m", "300M", "--cgroup-parent", cgroupParent,
+		"--name", name, busyboxImage, "top")
+
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}
@@ -782,9 +813,11 @@ func testRunWithCgroupParent(c *check.C, cgroupParent, name string) {
 
 // TestRunInvalidCgroupParent checks that a specially-crafted cgroup parent doesn't cause Docker to crash or start modifying /.
 func (suite *PouchRunSuite) TestRunInvalidCgroupParent(c *check.C) {
-	testRunInvalidCgroupParent(c, "../../../../../../../../SHOULD_NOT_EXIST", "SHOULD_NOT_EXIST", "cgroup-invalid-test")
+	testRunInvalidCgroupParent(c, "../../../../../../../../SHOULD_NOT_EXIST",
+		"SHOULD_NOT_EXIST", "cgroup-invalid-test")
 
-	testRunInvalidCgroupParent(c, "/../../../../../../../../SHOULD_NOT_EXIST", "/SHOULD_NOT_EXIST", "cgroup-absolute-invalid-test")
+	testRunInvalidCgroupParent(c, "/../../../../../../../../SHOULD_NOT_EXIST",
+		"/SHOULD_NOT_EXIST", "cgroup-absolute-invalid-test")
 }
 
 func testRunInvalidCgroupParent(c *check.C, cgroupParent, cleanCgroupParent, name string) {
@@ -802,11 +835,11 @@ func (suite *PouchRunSuite) TestRunWithDiskQuota(c *check.C) {
 		c.Skip("Host does not support disk quota")
 	}
 
-	ret := command.PouchRun("run", "--disk-quota", "2000m", "--name", "TestRunWithDiskQuota", busyboxImage, "df")
-	defer func() {
-		command.PouchRun("rm", "-f", "TestRunWithDiskQuota").Assert(c, icmd.Success)
-	}()
+	cname := "TestRunWithDiskQuota"
+	ret := command.PouchRun("run", "--disk-quota", "2000m",
+		"--name", cname, busyboxImage, "df")
 
+	defer DelContainerForceMultyTime(c, cname)
 	ret.Assert(c, icmd.Success)
 
 	out := ret.Combined()
@@ -825,7 +858,10 @@ func (suite *PouchRunSuite) TestRunWithDiskQuota(c *check.C) {
 // TestRunWithAnnotation is to verify the valid running container with annotation, and verify SpecAnnotation filed has been in inspect output.
 func (suite *PouchRunSuite) TestRunWithAnnotation(c *check.C) {
 	cname := "TestRunWithAnnotation"
-	command.PouchRun("run", "-d", "--annotation", "a=b", "--annotation", "foo=bar", "--name", cname, busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--annotation", "a=b", "--annotation", "foo=bar",
+		"--name", cname, busyboxImage).Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", cname).Stdout()
 	result := []types.ContainerJSON{}
@@ -848,6 +884,8 @@ func (suite *PouchRunSuite) TestRunWithAnnotation(c *check.C) {
 func (suite *PouchRunSuite) TestRunWithExitCode(c *check.C) {
 	cname := "TestRunWithExitCode"
 	ret := command.PouchRun("run", "--name", cname, busyboxImage, "sh", "-c", "exit 101")
+	defer DelContainerForceMultyTime(c, cname)
+
 	// test process exit code $? == 101
 	ret.Assert(c, icmd.Expected{ExitCode: 101})
 
@@ -869,7 +907,8 @@ func (suite *PouchRunSuite) TestRunWithDiskQuotaRegular(c *check.C) {
 	volumeName := "diskquota-volume"
 	containerName := "diskquota-regular"
 
-	ret := command.PouchRun("volume", "create", "-n", volumeName, "-o", "size=256m", "-o", "mount=/data/volume")
+	ret := command.PouchRun("volume", "create", "-n", volumeName,
+		"-o", "size=256m", "-o", "mount=/data/volume")
 	defer func() {
 		command.PouchRun("volume", "rm", volumeName).Assert(c, icmd.Success)
 	}()
@@ -883,9 +922,7 @@ func (suite *PouchRunSuite) TestRunWithDiskQuotaRegular(c *check.C) {
 		"-v", "/data/mount2:/mnt/mount2",
 		"-v", "diskquota-volume:/mnt/mount3",
 		"--name", containerName, busyboxImage, "df")
-	defer func() {
-		command.PouchRun("rm", "-f", containerName).Assert(c, icmd.Success)
-	}()
+	defer DelContainerForceMultyTime(c, containerName)
 	ret.Assert(c, icmd.Success)
 
 	out := ret.Stdout()
@@ -925,7 +962,9 @@ func (suite *PouchRunSuite) TestRunWithDiskQuotaRegular(c *check.C) {
 // TestRunWithRM is to verify the valid running container with rm flag
 func (suite *PouchRunSuite) TestRunWithRM(c *check.C) {
 	cname := "TestRunWithRM"
-	command.PouchRun("run", "--rm", "--name", cname, busyboxImage, "echo", "hello").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "--rm", "--name", cname, busyboxImage, "echo", "hello")
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", cname).Stderr()
 	c.Assert(util.PartialEqual(output, cname+": not found"), check.IsNil)
@@ -944,24 +983,22 @@ func (suite *PouchRunSuite) TestRunWithVolumesFrom(c *check.C) {
 	}()
 
 	// run container1
-	command.PouchRun("run", "-d",
+	res := command.PouchRun("run", "-d",
 		"-v", volumeName+":/mnt",
 		"-v", "/tmp:/tmp",
-		"--name", containerName1, busyboxImage, "top").Assert(c, icmd.Success)
-	defer func() {
-		command.PouchRun("rm", "-f", containerName1).Assert(c, icmd.Success)
-	}()
+		"--name", containerName1, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, containerName1)
+	res.Assert(c, icmd.Success)
 
 	// stop container1
 	command.PouchRun("stop", containerName1).Assert(c, icmd.Success)
 
 	// run container2
-	command.PouchRun("run", "-d",
+	res = command.PouchRun("run", "-d",
 		"--volumes-from", containerName1,
-		"--name", containerName2, busyboxImage, "top").Assert(c, icmd.Success)
-	defer func() {
-		command.PouchRun("rm", "-f", containerName2).Assert(c, icmd.Success)
-	}()
+		"--name", containerName2, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, containerName2)
+	res.Assert(c, icmd.Success)
 
 	// inspect container2
 	ret := command.PouchRun("inspect", containerName2)
@@ -992,25 +1029,23 @@ func (suite *PouchRunSuite) TestRunWithVolumesFromWithDupclicate(c *check.C) {
 	}()
 
 	// run container1
-	command.PouchRun("run", "-d",
+	res := command.PouchRun("run", "-d",
 		"-v", volumeName+":/mnt",
 		"-v", "/tmp:/tmp",
-		"--name", containerName1, busyboxImage, "top").Assert(c, icmd.Success)
-	defer func() {
-		command.PouchRun("rm", "-f", containerName1).Assert(c, icmd.Success)
-	}()
+		"--name", containerName1, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, containerName1)
+	res.Assert(c, icmd.Success)
 
 	// stop container1
 	command.PouchRun("stop", containerName1).Assert(c, icmd.Success)
 
 	// run container2
-	command.PouchRun("run", "-d",
+	res = command.PouchRun("run", "-d",
 		"-v", "/tmp:/tmp",
 		"--volumes-from", containerName1,
-		"--name", containerName2, busyboxImage, "top").Assert(c, icmd.Success)
-	defer func() {
-		command.PouchRun("rm", "-f", containerName2).Assert(c, icmd.Success)
-	}()
+		"--name", containerName2, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, containerName2)
+	res.Assert(c, icmd.Success)
 
 	// inspect container2
 	ret := command.PouchRun("inspect", containerName2)
@@ -1031,7 +1066,9 @@ func (suite *PouchRunSuite) TestRunWithVolumesFromWithDupclicate(c *check.C) {
 // TestRunWithUlimit tests running container with --ulimit flag.
 func (suite *PouchRunSuite) TestRunWithUlimit(c *check.C) {
 	cname := "TestRunWithUlimit"
-	res := command.PouchRun("run", "--ulimit", "nproc=256", "--name", cname, busyboxImage, "sh", "-c", "ulimit -p")
+	res := command.PouchRun("run", "--ulimit", "nproc=256", "--name",
+		cname, busyboxImage, "sh", "-c", "ulimit -p")
+	defer DelContainerForceMultyTime(c, cname)
 	res.Assert(c, icmd.Success)
 
 	out := res.Stdout()

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -96,7 +96,7 @@ func (suite *PouchStopSuite) TestStopInWrongWay(c *check.C) {
 		// {name: "missing container name", args: ""},
 	} {
 		res := command.PouchRun("stop", tc.args)
-		c.Assert(res.Error, check.NotNil, check.Commentf(tc.name))
+		c.Assert(res.Stderr(), check.NotNil, check.Commentf(tc.name))
 	}
 }
 

--- a/test/cli_top_test.go
+++ b/test/cli_top_test.go
@@ -36,10 +36,12 @@ func (suite *PouchTopSuite) TearDownTest(c *check.C) {
 func (suite *PouchTopSuite) TestTopStoppedContainer(c *check.C) {
 	name := "TestTopStoppedContainer"
 
-	command.PouchRun("create", "-m", "300M", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("create", "-m", "300M", "--name", name, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
-	res := command.PouchRun("top", name)
-	c.Assert(res.Error, check.NotNil)
+	res = command.PouchRun("top", name)
+	c.Assert(res.Stderr(), check.NotNil)
 
 	expectString := "container is not running, can not execute top command"
 	if out := res.Combined(); !strings.Contains(out, expectString) {
@@ -47,23 +49,21 @@ func (suite *PouchTopSuite) TestTopStoppedContainer(c *check.C) {
 		fmt.Printf("%+v", res)
 		c.Fatalf("unexpected output %s expected %s", out, expectString)
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestTopContainer is to verify the correctness of pouch top command.
 func (suite *PouchTopSuite) TestTopContainer(c *check.C) {
 	name := "TestTopContainer"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
-	res := command.PouchRun("top", name)
-	c.Assert(res.Error, check.IsNil)
+	res = command.PouchRun("top", name)
+	res.Assert(c, icmd.Success)
 
 	expectString := "UIDPIDPPID"
 	if out := util.TrimAllSpaceAndNewline(res.Combined()); !strings.Contains(out, expectString) {
 		c.Fatalf("unexpected output %s expected %s", out, expectString)
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }

--- a/test/cli_unpause_test.go
+++ b/test/cli_unpause_test.go
@@ -31,10 +31,9 @@ func (suite *PouchUnpauseSuite) TestUnpauseWorks(c *check.C) {
 	containernames := []string{"bar1", "bar2"}
 	for _, name := range containernames {
 		command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+		defer DelContainerForceMultyTime(c, name)
 
 		command.PouchRun("start", name).Assert(c, icmd.Success)
-
-		defer DelContainerForceMultyTime(c, name)
 	}
 
 	command.PouchRun("pause", containernames[0]).Assert(c, icmd.Success)
@@ -50,11 +49,11 @@ func (suite *PouchUnpauseSuite) TestUnpauseWorks(c *check.C) {
 
 	for arg, ok := range args {
 		res := command.PouchRun("unpause", arg)
-
-		expected := check.IsNil
 		if !ok {
-			expected = check.NotNil
+			c.Assert(res.Stderr(), check.NotNil)
+		} else {
+			res.Assert(c, icmd.Success)
 		}
-		c.Assert(res.Error, expected)
+
 	}
 }

--- a/test/cli_update_test.go
+++ b/test/cli_update_test.go
@@ -39,7 +39,9 @@ func (suite *PouchUpdateSuite) TearDownTest(c *check.C) {
 func (suite *PouchUpdateSuite) TestUpdateCpu(c *check.C) {
 	name := "update-container-cpu"
 
-	command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}
@@ -71,15 +73,15 @@ func (suite *PouchUpdateSuite) TestUpdateCpu(c *check.C) {
 	}
 
 	c.Assert(metaJSON[0].HostConfig.CPUShares, check.Equals, int64(40))
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestUpdateCpuPeriod is to verify the correctness of updating container cpu-period.
 func (suite *PouchUpdateSuite) TestUpdateCpuPeriod(c *check.C) {
 	name := "update-container-cpu-period"
 
-	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}
@@ -111,15 +113,15 @@ func (suite *PouchUpdateSuite) TestUpdateCpuPeriod(c *check.C) {
 	}
 
 	c.Assert(metaJSON[0].HostConfig.CPUPeriod, check.Equals, int64(2000))
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestUpdateRunningContainer is to verify the correctness of updating a running container.
 func (suite *PouchUpdateSuite) TestUpdateRunningContainer(c *check.C) {
 	name := "update-running-container"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}
@@ -151,15 +153,15 @@ func (suite *PouchUpdateSuite) TestUpdateRunningContainer(c *check.C) {
 	}
 
 	c.Assert(metaJSON[0].HostConfig.Memory, check.Equals, int64(524288000))
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestUpdateStoppedContainer is to verify the correctness of updating a stopped container.
 func (suite *PouchUpdateSuite) TestUpdateStoppedContainer(c *check.C) {
 	name := "update-stopped-container"
 
-	command.PouchRun("create", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("create", "-m", "300M", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}
@@ -193,43 +195,43 @@ func (suite *PouchUpdateSuite) TestUpdateStoppedContainer(c *check.C) {
 	}
 
 	c.Assert(metaJSON[0].HostConfig.Memory, check.Equals, int64(524288000))
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestUpdateContainerInvalidValue is to verify the correctness of updating a container with invalid value.
 func (suite *PouchUpdateSuite) TestUpdateContainerInvalidValue(c *check.C) {
 	name := "update-container-with-invalid-value"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
-	res := command.PouchRun("update", "--memory-swappiness", "-2", name)
-	c.Assert(res.Error, check.NotNil)
+	res = command.PouchRun("update", "--memory-swappiness", "-2", name)
+	c.Assert(res.Stderr(), check.NotNil)
 
 	expectString := "invalid memory swappiness: -2 (its range is -1 or 0-100)"
 	if out := res.Combined(); !strings.Contains(out, expectString) {
 		c.Fatalf("unexpected output %s expected %s", out, expectString)
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestUpdateContainerWithoutFlag is to verify the correctness of updating a container without any flag.
 func (suite *PouchUpdateSuite) TestUpdateContainerWithoutFlag(c *check.C) {
 	name := "update-container-without-flag"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("update", name).Assert(c, icmd.Success)
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestUpdateContainerEnv is to verify the correctness of updating env of container.
 func (suite *PouchUpdateSuite) TestUpdateContainerEnv(c *check.C) {
 	name := "update-container-env"
 
-	command.PouchRun("create", "-m", "300M", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("create", "-m", "300M", "--name", name, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("update", "--env", "foo=bar", name).Assert(c, icmd.Success)
 
@@ -242,15 +244,15 @@ func (suite *PouchUpdateSuite) TestUpdateContainerEnv(c *check.C) {
 	if !utils.StringInSlice(result[0].Config.Env, "foo=bar") {
 		c.Errorf("expect 'foo=bar' in container env, but got: %v", result[0].Config.Env)
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestUpdateRunningContainerEnv is to verify the correctness of updating env of an running container.
 func (suite *PouchUpdateSuite) TestUpdateRunningContainerEnv(c *check.C) {
 	name := "update-running-container-env"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("update", "--env", "foo=bar", name).Assert(c, icmd.Success)
 
@@ -268,16 +270,15 @@ func (suite *PouchUpdateSuite) TestUpdateRunningContainerEnv(c *check.C) {
 	if !strings.Contains(output, "foo=bar") {
 		c.Fatalf("Update running container env not worked")
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
-
 }
 
 // TestUpdateContainerLabel is to verify the correctness of updating label of container.
 func (suite *PouchUpdateSuite) TestUpdateContainerLabel(c *check.C) {
 	name := "update-container-label"
 
-	command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "-m", "300M", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("update", "--label", "foo=bar", name).Assert(c, icmd.Success)
 
@@ -290,6 +291,4 @@ func (suite *PouchUpdateSuite) TestUpdateContainerLabel(c *check.C) {
 	if v, ok := result[0].Config.Labels["foo"]; !ok || v != "bar" {
 		c.Errorf("expect 'foo=bar' in Labels, got: %v", result[0].Config.Labels)
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }

--- a/test/cli_upgrade_test.go
+++ b/test/cli_upgrade_test.go
@@ -41,60 +41,60 @@ func (suite *PouchUpgradeSuite) TeadDownTest(c *check.C) {
 func (suite *PouchUpgradeSuite) TestPouchUpgrade(c *check.C) {
 	name := "TestPouchUpgrade"
 
-	command.PouchRun("run", "-d", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
-	res := command.PouchRun("upgrade", "--name", name, busyboxImage125)
-	c.Assert(res.Error, check.IsNil)
+	res = command.PouchRun("upgrade", "--name", name, busyboxImage125)
+	res.Assert(c, icmd.Success)
 
 	if out := res.Combined(); !strings.Contains(out, name) {
 		c.Fatalf("unexpected output: %s, expected: %s", out, name)
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
-
 }
 
 // TestPouchUpgradeNoChange is to verify pouch upgrade command with same image.
 func (suite *PouchUpgradeSuite) TestPouchUpgradeNoChange(c *check.C) {
 	name := "TestPouchUpgradeNoChange"
 
-	command.PouchRun("run", "-d", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
-	res := command.PouchRun("upgrade", "--name", name, busyboxImage)
-	c.Assert(res.Error, check.NotNil)
+	res = command.PouchRun("upgrade", "--name", name, busyboxImage)
+	c.Assert(res.Stderr(), check.NotNil)
 
 	expectedStr := "failed to upgrade container: image not changed"
 	if out := res.Combined(); !strings.Contains(out, expectedStr) {
 		c.Fatalf("unexpected output: %s, expected: %s", out, expectedStr)
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
-
 }
 
 // TestPouchUpgradeStoppedContainer is to verify pouch upgrade a stopped command.
 func (suite *PouchUpgradeSuite) TestPouchUpgradeStoppedContainer(c *check.C) {
 	name := "TestPouchUpgradeStoppedContainer"
 
-	command.PouchRun("create", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("create", "--name", name, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
-	res := command.PouchRun("upgrade", "--name", name, busyboxImage125)
-	c.Assert(res.Error, check.IsNil)
+	res = command.PouchRun("upgrade", "--name", name, busyboxImage125)
+	res.Assert(c, icmd.Success)
 
 	if out := res.Combined(); !strings.Contains(out, name) {
 		c.Fatalf("unexpected output: %s, expected %s", out, name)
 	}
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestPouchUpgradeContainerMemCpu is to verify pouch upgrade container's memory
 func (suite *PouchUpgradeSuite) TestPouchUpgradeContainerMemCpu(c *check.C) {
 	name := "TestPouchUpgradeContainerMemCpu"
 
-	command.PouchRun("run", "-d", "-m", "300m", "--cpu-share", "20", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "-m", "300m", "--cpu-share", "20", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("upgrade", "-m", "500m", "--cpu-share", "40", "--name", name, busyboxImage125).Assert(c, icmd.Success)
 
@@ -137,15 +137,15 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeContainerMemCpu(c *check.C) {
 	if !strings.Contains(string(out), "40") {
 		c.Fatalf("unexpected output %s expected %s\n", string(out), "40")
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }
 
 // TestPouchUpgradeContainerLabels is to verify pouch upgrade container's labels
 func (suite *PouchUpgradeSuite) TestPouchUpgradeContainerLabels(c *check.C) {
 	name := "TestPouchUpgradeContainerLabels"
 
-	command.PouchRun("run", "-d", "--label", "test=foo", "--name", name, busyboxImage).Assert(c, icmd.Success)
+	res := command.PouchRun("run", "-d", "--label", "test=foo", "--name", name, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
 
 	command.PouchRun("upgrade", "--label", "test1=bar", "--name", name, busyboxImage125).Assert(c, icmd.Success)
 
@@ -163,6 +163,4 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeContainerLabels(c *check.C) {
 	if !reflect.DeepEqual(result[0].Config.Labels, labels) {
 		c.Errorf("unexpected output: %s, expected: %s", result[0].Config.Labels, labels)
 	}
-
-	command.PouchRun("rm", "-f", name).Assert(c, icmd.Success)
 }


### PR DESCRIPTION
Signed-off-by: letty <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This PR mainly enhances code in cli_xxx_test.go in the following two aspects: 

1. using `icmd.result.Stderr()` instead of `icmd.result.Error` to print readable error message when stderr is not nil. Please notice that, if you wanna check running CMD return success, please user icmd.result.Assert() instead of using check.Assert(icmd.result.Error, check.IsNil). Because the following usage will not print readable error message.

2. using defer to do cleanup work. When create a container or volume or network, following a `defer` to make sure the resource will always be deleted even if test failed.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix #1323
### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


