### PR TITLE
build: generate version information at build time

### DIFF
--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -159,7 +159,7 @@ func (mgr *SystemManager) Version() (types.SystemVersion, error) {
 		Arch:          runtime.GOARCH,
 		BuildTime:     version.BuildTime,
 		GitCommit:     version.GitCommit,
-		GoVersion:     version.GOVersion,
+		GoVersion:     runtime.Version(),
 		KernelVersion: kernelVersion,
 		Os:            runtime.GOOS,
 		Version:       version.Version,

--- a/hack/build
+++ b/hack/build
@@ -6,8 +6,15 @@ DIR="$( cd "$( dirname "$0" )/.." && pwd )"
 cd $DIR/
 GOPATH=$BUILDPATH:$BUILDPATH/src/github.com/docker/libnetwork/Godeps/_workspace
 
+
 # Go parameters
+VERSION="0.4.0"
+APIVERSION="1.24"
+GITCOMMIT=$(git describe --dirty --always --tags 2> /dev/null || true)
+BUILDTIME=$(date --rfc-3339 s 2> /dev/null | sed -e 's/ /T/')
+PKG=github.com/alibaba/pouch
 GOBUILD="go build"
+GOLDFLAGS="-X $PKG/version.GitCommit=${GITCOMMIT} -X $PKG/version.Version=${VERSION} -X $PKG/version.ApiVersion=${APIVERSION} -X $PKG/version.BuildTime=$BUILDTIME"
 
 # Binary name of CLI and Daemon
 BINARY_NAME=pouchd
@@ -30,7 +37,7 @@ function server()
 {
     cd $BUILDPATH/src/github.com/alibaba/pouch
     echo "GOOS=linux $GOBUILD -o $BINARY_NAME"
-    GOOS=linux $GOBUILD -o $BINARY_NAME -tags 'selinux'
+    GOOS=linux $GOBUILD -ldflags "${GOLDFLAGS}" -o $BINARY_NAME -tags 'selinux'
 }
 
 function client()

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func parseFlags(cmd *cobra.Command, flags []string) {
 func runDaemon() error {
 	//user specifies --version or -v, print version and return.
 	if printVersion {
-		fmt.Println(version.Version)
+		fmt.Printf("pouchd version: %s, build: %s, build at: %s\n", version.Version, version.GitCommit, version.BuildTime)
 		return nil
 	}
 

--- a/test/cli_version_test.go
+++ b/test/cli_version_test.go
@@ -32,7 +32,7 @@ func (suite *PouchVersionSuite) TestPouchVersion(c *check.C) {
 	res := command.PouchRun("version").Assert(c, icmd.Success)
 	kv := versionToKV(res.Combined())
 
-	c.Assert(kv["GoVersion"], check.Equals, version.GOVersion)
+	c.Assert(kv["GoVersion"], check.Equals, runtime.Version())
 	c.Assert(kv["APIVersion"], check.Equals, version.APIVersion)
 	c.Assert(kv["Arch"], check.Equals, runtime.GOARCH)
 	c.Assert(kv["Os"], check.Equals, runtime.GOOS)

--- a/version/version.go
+++ b/version/version.go
@@ -1,16 +1,16 @@
 package version
 
-// Version represents the version of pouchd.
-const Version = "0.4.0"
+// Version package values is auto-generated, the following values will be overwrited at build time.
+var (
+	// Version represents the version of pouchd.
+	Version = "0.4.0"
 
-// BuildTime is the time when this binary of daemon is built
-var BuildTime = "unknown"
+	// BuildTime is the time when pouch binary is built
+	BuildTime = "unknown"
 
-// APIVersion means the api version daemon serves
-var APIVersion = "1.24"
+	// APIVersion means the api version daemon serves
+	APIVersion = "1.24"
 
-// GOVersion is the go version to build Pouch
-var GOVersion = "go1.9.1"
-
-// GitCommit is the commit id to build Pouch
-var GitCommit = "unknown"
+	// GitCommit is the commit id to build Pouch
+	GitCommit = "unknown"
+)


### PR DESCRIPTION
auto-generate git commit, build time at build time,
    fix go-version hard code.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Make version infomation atuo-generated at build time.

Before this pr
```
$ sudo pouch version
Arch:            amd64
BuildTime:       unknown
GitCommit:       unknown
GoVersion:       go1.9.1
KernelVersion:   4.4.0-121-generic
Os:              linux
Version:         0.4.0
APIVersion:      1.24
```
With this pr
```
$ sudo pouch version
GoVersion:       go1.10.2
KernelVersion:   4.4.0-121-generic
Os:              linux
Version:         0.4.0
APIVersion:      1.24
Arch:            amd64
BuildTime:       2018-05-18T13:37:46+08:00
GitCommit:       0.4.0-258-gef3b5e9-dirty

```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


