### PR TITLE
feature: allow use image by digest id

### DIFF
--- a/cri/src/cri.go
+++ b/cri/src/cri.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"time"
 
 	apitypes "github.com/alibaba/pouch/apis/types"
@@ -649,7 +648,7 @@ func (c *CriManager) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 	labels, annotations := extractLabels(container.Config.Labels)
 
 	imageRef := container.Image
-	imageInfo, err := c.ImageMgr.GetImage(ctx, strings.TrimPrefix(imageRef, "sha256:"))
+	imageInfo, err := c.ImageMgr.GetImage(ctx, imageRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image %s: %v", imageRef, err)
 	}
@@ -826,7 +825,7 @@ func (c *CriManager) ListImages(ctx context.Context, r *runtime.ListImagesReques
 			continue
 		}
 		// NOTE: we should query image cache to get the correct image info.
-		imageInfo, err := c.ImageMgr.GetImage(ctx, strings.TrimPrefix(i.ID, "sha256:"))
+		imageInfo, err := c.ImageMgr.GetImage(ctx, i.ID)
 		if err != nil {
 			continue
 		}
@@ -850,7 +849,7 @@ func (c *CriManager) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequ
 		return nil, err
 	}
 
-	imageInfo, err := c.ImageMgr.GetImage(ctx, strings.TrimPrefix(ref.String(), "sha256:"))
+	imageInfo, err := c.ImageMgr.GetImage(ctx, ref.String())
 	if err != nil {
 		// TODO: separate ErrImageNotFound with others.
 		// Now we just return empty if the error occurred.
@@ -894,7 +893,7 @@ func (c *CriManager) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 
 // RemoveImage removes the image.
 func (c *CriManager) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
-	imageRef := strings.TrimPrefix(r.GetImage().GetImage(), "sha256:")
+	imageRef := r.GetImage().GetImage()
 
 	if err := c.ImageMgr.RemoveImage(ctx, imageRef, false); err != nil {
 		if errtypes.IsNotfound(err) {

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -36,7 +36,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/imdario/mergo"
 	"github.com/magiconair/properties"
-	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -1919,7 +1918,7 @@ func (mgr *ContainerManager) getMountPointFromImage(ctx context.Context, meta *C
 	var err error
 
 	// parse volumes from image
-	image, err := mgr.ImageMgr.GetImage(ctx, strings.TrimPrefix(meta.Image, digest.Canonical.String()+":"))
+	image, err := mgr.ImageMgr.GetImage(ctx, meta.Image)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get image: %s", meta.Image)
 	}

--- a/daemon/mgr/image_store_test.go
+++ b/daemon/mgr/image_store_test.go
@@ -112,9 +112,24 @@ func TestSearch(t *testing.T) {
 
 	// search
 	{
-		// should return id if the reference is id
+		// should return id if the reference is id without algorithm header
 		{
 			namedStr := id.Hex()
+
+			namedRef, err := reference.Parse(namedStr)
+			if err != nil {
+				t.Fatalf("unexpected error during parse reference %v: %v", namedStr, err)
+			}
+
+			gotID, gotRef, err := store.Search(namedRef)
+			assert.Equal(t, err, nil)
+			assert.Equal(t, gotID.String(), id.String())
+			assert.Equal(t, gotRef.String(), namedRef.String())
+		}
+
+		// should return id if the reference is digest id
+		{
+			namedStr := id.String()
 
 			namedRef, err := reference.Parse(namedStr)
 			if err != nil {
@@ -202,7 +217,7 @@ func TestSearch(t *testing.T) {
 
 		// should return ErrTooMany if the reference is commonPart
 		{
-			namedStr := id.Hex()[:20]
+			namedStr := id.String()[:20]
 
 			namedRef, err := reference.Parse(namedStr)
 			if err != nil {

--- a/pkg/reference/parse_test.go
+++ b/pkg/reference/parse_test.go
@@ -43,9 +43,6 @@ func TestDefaultTagIfMissing(t *testing.T) {
 	assert.Equal(t, false, strings.Contains(named.String(), "latest"))
 }
 
-func TestIsNamedOnly(t *testing.T) {
-}
-
 func TestParse(t *testing.T) {
 	type tCase struct {
 		name     string
@@ -121,6 +118,14 @@ func TestParse(t *testing.T) {
 			input:    "busybox@sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac",
 			expected: nil,
 			err:      errors.New("invalid checksum digest length"),
+		}, {
+			name:  "Digest ID",
+			input: "sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac",
+			expected: taggedReference{
+				Named: namedReference{"sha256"},
+				tag:   "1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac",
+			},
+			err: nil,
 		},
 	} {
 		ref, err := Parse(tc.input)

--- a/test/api_image_inspect_test.go
+++ b/test/api_image_inspect_test.go
@@ -26,9 +26,11 @@ func (suite *APIImageInspectSuite) SetUpTest(c *check.C) {
 
 // TestImageInspectOk tests inspecting images is OK.
 func (suite *APIImageInspectSuite) TestImageInspectOk(c *check.C) {
+	repoID := environment.BusyboxID
 	repoTag, repoDigest := busyboxImage, fmt.Sprintf("%s@%s", environment.BusyboxRepo, environment.BusyboxDigest)
 
 	for _, image := range []string{
+		repoID,
 		repoTag,
 		repoDigest,
 		fmt.Sprintf("%s:whatever@%s", environment.BusyboxRepo, environment.BusyboxDigest),
@@ -43,7 +45,7 @@ func (suite *APIImageInspectSuite) TestImageInspectOk(c *check.C) {
 
 		// TODO: More specific check is needed
 		c.Assert(got.Config, check.NotNil)
-		c.Assert(got.ID, check.NotNil)
+		c.Assert(got.ID, check.Equals, repoID)
 		c.Assert(got.CreatedAt, check.NotNil)
 		c.Assert(got.Size, check.NotNil)
 		c.Assert(reflect.DeepEqual(got.RepoTags, []string{repoTag}), check.Equals, true)

--- a/test/cli_rmi_test.go
+++ b/test/cli_rmi_test.go
@@ -64,6 +64,22 @@ func (suite *PouchRmiSuite) TestRmiByImageID(c *check.C) {
 	}
 }
 
+// TestRmiByImageDigestID tests "pouch rmi sha256:xxx" work.
+func (suite *PouchRmiSuite) TestRmiByImageDigestID(c *check.C) {
+	command.PouchRun("pull", helloworldImage).Assert(c, icmd.Success)
+
+	res := command.PouchRun("images")
+	res.Assert(c, icmd.Success)
+	imageID := imagesListToKV(res.Combined())[helloworldImage][0]
+
+	command.PouchRun("rmi", "sha256:"+imageID).Assert(c, icmd.Success)
+
+	res = command.PouchRun("images").Assert(c, icmd.Success)
+	if out := res.Combined(); strings.Contains(out, helloworldImage) {
+		c.Fatalf("unexpected output %s: should rm image %s\n", out, helloworldImage)
+	}
+}
+
 // TestRmiByImageIDWithTwoPrimaryReferences tests "pouch rmi {ID}" work.
 func (suite *PouchRmiSuite) TestRmiByImageIDWithTwoPrimaryReferences(c *check.C) {
 	var (

--- a/test/environment/env.go
+++ b/test/environment/env.go
@@ -26,6 +26,9 @@ var (
 	// BusyboxRepo the repository of busybox image
 	BusyboxRepo = "registry.hub.docker.com/library/busybox"
 
+	// BusyboxID the digest ID used for busybox image
+	BusyboxID = "sha256:8ac48589692a53a9b8c2d1ceaa6b402665aa7fe667ba51ccc03002300856d8c7"
+
 	// BusyboxTag the tag used for busybox image
 	BusyboxTag = "1.28"
 


### PR DESCRIPTION
Basically, the user can use sha256:xyz to inspect image or run
container.

Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Enhance the Image Manager: Allow user to use image digest-type ID to consume pouch image.

For example, we pull busybox:1.28 by pouch. After pulled, the use can use the following method to inspect the image:

- pouch image inspect 8ac48589692a
- pouch image inspect sha256:8ac48589692a
- pouch image inspect busybox:1.28
- pouch image inspect busybox@sha256:58ac43b2cc92c687a32c8be6278e50a063579655fe3090125dcb2af0ff9e1a64


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Fixes #1348 

### Ⅲ. Describe how you did it

Update the imageStore search functionality. We add the `sha256:" If the refOrID miss.  

BTW, both the `Delete` and `Search` functionality should use the following method to check the reference is ID or not. 

```
reference.IsNamedOnly(ref) || strings.HasPrefix(id, ref)
```

### Ⅳ. Describe how to verify it

One of case is Use the Digest ID to run container

```
➜  pouch run -it sha256:8ac48589692a53a9b8c2d1ceaa6b402665aa7fe667ba51ccc03002300856d8c7 ls
bin   dev   etc   home  proc  root  run   sys   tmp   usr   var
```


### Ⅴ. Special notes for reviews


