### PR TITLE
feature: add volume drivers info for system info

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1283,6 +1283,13 @@ definitions:
         description: |
           The logging driver to use as a default for new containers.
         type: "string"
+      VolumeDrivers:
+        description: |
+          The list of volume drivers which the pouchd supports
+        type: "array"
+        items:
+          type: "string"
+        example: ["local", "tmpfs"]
       CgroupDriver:
         description: |
           The driver to use for managing cgroups.

--- a/apis/types/system_info.go
+++ b/apis/types/system_info.go
@@ -207,6 +207,10 @@ type SystemInfo struct {
 	// Version string of the daemon.
 	//
 	ServerVersion string `json:"ServerVersion,omitempty"`
+
+	// The list of volume drivers which the pouchd supports
+	//
+	VolumeDrivers []string `json:"VolumeDrivers"`
 }
 
 /* polymorph SystemInfo Architecture false */
@@ -279,6 +283,8 @@ type SystemInfo struct {
 
 /* polymorph SystemInfo ServerVersion false */
 
+/* polymorph SystemInfo VolumeDrivers false */
+
 // Validate validates this system info
 func (m *SystemInfo) Validate(formats strfmt.Registry) error {
 	var res []error
@@ -324,6 +330,11 @@ func (m *SystemInfo) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateSecurityOptions(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateVolumeDrivers(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -475,6 +486,15 @@ func (m *SystemInfo) validateRuntimes(formats strfmt.Registry) error {
 func (m *SystemInfo) validateSecurityOptions(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.SecurityOptions) { // not required
+		return nil
+	}
+
+	return nil
+}
+
+func (m *SystemInfo) validateVolumeDrivers(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.VolumeDrivers) { // not required
 		return nil
 	}
 

--- a/cli/info.go
+++ b/cli/info.go
@@ -66,6 +66,7 @@ func prettyPrintInfo(cli *Cli, info *types.SystemInfo) error {
 	fmt.Fprintln(os.Stdout, "Storage Driver:", info.Driver)
 	fmt.Fprintln(os.Stdout, "Driver Status:", info.DriverStatus)
 	fmt.Fprintln(os.Stdout, "Logging Driver:", info.LoggingDriver)
+	fmt.Fprintln(os.Stdout, "Volume Drivers:", info.VolumeDrivers)
 	fmt.Fprintln(os.Stdout, "Cgroup Driver:", info.CgroupDriver)
 	if len(info.Runtimes) > 0 {
 		fmt.Fprintln(os.Stdout, "Runtimes:")

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alibaba/pouch/pkg/meta"
 	"github.com/alibaba/pouch/pkg/system"
 	"github.com/alibaba/pouch/registry"
+	volumedriver "github.com/alibaba/pouch/storage/volume/driver"
 	"github.com/alibaba/pouch/version"
 
 	"github.com/pkg/errors"
@@ -103,6 +104,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 	if err != nil {
 		logrus.Warnf("failed to get image info: %v", err)
 	}
+	volumeDrivers := volumedriver.AllDriversName()
 
 	info := types.SystemInfo{
 		Architecture: runtime.GOARCH,
@@ -128,6 +130,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		Labels:             mgr.config.Labels,
 		LiveRestoreEnabled: true,
 		LoggingDriver:      mgr.config.DefaultLogConfig.LogDriver,
+		VolumeDrivers:      volumeDrivers,
 		LxcfsEnabled:       mgr.config.IsLxcfsEnabled,
 		MemTotal:           totalMem,
 		Name:               hostname,

--- a/storage/volume/driver/driver.go
+++ b/storage/volume/driver/driver.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"sync"
 
 	"github.com/alibaba/pouch/plugins"
@@ -220,6 +221,9 @@ func Exist(name string) bool {
 
 // AllDriversName return all registered backend driver's name.
 func AllDriversName() []string {
+	// probing all volume plugins.
+	backendDrivers.GetAll()
+
 	backendDrivers.Lock()
 	defer backendDrivers.Unlock()
 
@@ -227,6 +231,9 @@ func AllDriversName() []string {
 	for n := range backendDrivers.drivers {
 		names = append(names, n)
 	}
+
+	// sort the names.
+	sort.Strings(names)
 
 	return names
 }

--- a/test/api_system_test.go
+++ b/test/api_system_test.go
@@ -51,6 +51,12 @@ func (suite *APISystemSuite) TestInfo(c *check.C) {
 	c.Assert(got.ServerVersion, check.Equals, version.Version)
 	c.Assert(got.Driver, check.Equals, "overlayfs")
 	c.Assert(got.NCPU, check.Equals, int64(runtime.NumCPU()))
+
+	// Check the volume drivers
+	c.Assert(len(got.VolumeDrivers), check.Equals, 3)
+	c.Assert(got.VolumeDrivers[0], check.Equals, "ceph")
+	c.Assert(got.VolumeDrivers[1], check.Equals, "local")
+	c.Assert(got.VolumeDrivers[2], check.Equals, "tmpfs")
 }
 
 // TestVersion tests /version API.


### PR DESCRIPTION
feature: add volume drivers info for system info

Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add volume drivers info when return system info


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it

```
~# pouch info
Containers: 17
 Running: 2
 Paused: 0
 Stopped: 15
Images:  4
ID: 
Name: ubuntu-1
Server Version: 0.4.0
Storage Driver: overlayfs
Driver Status: []
Logging Driver: 
Volume Drivers: [local-persist ceph tmpfs local]
Cgroup Driver: 
runc: <nil>
containerd: <nil>
Security Options: []
Kernel Version: 4.4.0-116-generic
Operating System: "Ubuntu 16.04.4 LTS"
OSType: linux
Architecture: amd64
HTTP Proxy: 
HTTPS Proxy: 
Registry: https://index.docker.io/v1/
Experimental: false
Debug: true
Labels:
  node_ip=127.0.1.1
  SN=0
CPUs: 1
Total Memory: 3.859 GiB
Pouch Root Dir: /var/lib/pouch
LiveRestoreEnabled: true
LxcfsEnabled: false
Daemon Listen Addresses: [unix:///var/run/pouchd.sock]
```


### Ⅴ. Special notes for reviews


