### PR TITLE
bugfix: fix cgroup-parent can not set from config

### DIFF
--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -91,7 +91,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringVar(&c.initScript, "initscript", "", "Initial script executed in container")
 
 	// cgroup
-	flagSet.StringVarP(&c.cgroupParent, "cgroup-parent", "", "default", "Optional parent cgroup for the container")
+	flagSet.StringVarP(&c.cgroupParent, "cgroup-parent", "", "", "Optional parent cgroup for the container")
 
 	// disk quota
 	flagSet.StringSliceVar(&c.diskQuota, "disk-quota", nil, "Set disk quota for container")


### PR DESCRIPTION
remove initial value in cgroup-parent flag, or this flag
can never be set from config file when create container
with pouch cli.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

```
func (mgr *ContainerManager) createContainerdContainer(ctx context.Context, c *Container) error {
    // CgroupParent from HostConfig will be first priority to use,
    // then will be value from mgr.Config.CgroupParent
    if c.HostConfig.CgroupParent == "" { 
        c.HostConfig.CgroupParent = mgr.Config.CgroupParent
    }    
```
If pouch cli give cgroup-parent a default value, the `c.HostConfig.CgroupParent ` will  never be empty, and it can never use `CgroupParent ` set from daemon config file.

The default cgroup parent we already set in 
```
    // same with containerd use. or make it a variable
    cgroupsParent := "default"
    if c.HostConfig.CgroupParent != "" {
        cgroupsParent = c.HostConfig.CgroupParent
    }   
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


