### PR TITLE
feature: support update and delete env

### DIFF
--- a/apis/opts/env.go
+++ b/apis/opts/env.go
@@ -1,0 +1,27 @@
+package opts
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseEnv parses the env param of container.
+func ParseEnv(env []string) (map[string]string, error) {
+	results := make(map[string]string)
+	for _, e := range env {
+		fields := strings.SplitN(e, "=", 2)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("invalid env %s: env must be in format of key=value", e)
+		}
+		results[fields[0]] = fields[1]
+	}
+
+	return results, nil
+}
+
+// ValidateEnv verifies the correct of env
+func ValidateEnv(map[string]string) error {
+	// TODO
+
+	return nil
+}

--- a/apis/opts/env_test.go
+++ b/apis/opts/env_test.go
@@ -1,0 +1,34 @@
+package opts
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseEnv(t *testing.T) {
+	type args struct {
+		env []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{name: "test1", args: args{env: []string{"foo=bar"}}, want: map[string]string{"foo": "bar"}, wantErr: false},
+		{name: "test2", args: args{env: []string{"ErrorInfo"}}, want: nil, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseEnv(tt.args.env)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseEnv() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

when we use `update` command to update container's env, we not only support add or update env, but also delete env

  1. Check container's `env`:
```
root@osboxes:test (zr/update-env) -> pouch exec -it for-test env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOME=/
```

  2. add `foo=bar` env
```
root@osboxes:test (zr/update-env) -> pouch update --env "foo=bar" for-test
root@osboxes:test (zr/update-env) -> pouch exec -it for-test env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
foo=bar
HOME=/
```

  3. change `foo=bar` to `foo=bar1`
```
root@osboxes:test (zr/update-env) -> pouch update --env "foo=bar1" for-test
root@osboxes:test (zr/update-env) -> pouch exec -it for-test env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
foo=bar1
HOME=/
```

  4. remove `foo` env
```
root@osboxes:test (zr/update-env) -> pouch update --env "foo=" for-test
root@osboxes:test (zr/update-env) -> pouch exec -it for-test env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOME=/
```

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


