### PR TITLE
feature: init pouch tag functionality

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -117,3 +117,20 @@ func (s *Server) removeImage(ctx context.Context, rw http.ResponseWriter, req *h
 	rw.WriteHeader(http.StatusNoContent)
 	return nil
 }
+
+// postImageTag adds tag for the existing image.
+func (s *Server) postImageTag(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+	name := mux.Vars(req)["name"]
+
+	targetRef := req.FormValue("repo")
+	if tag := req.FormValue("tag"); tag != "" {
+		targetRef = fmt.Sprintf("%s:%s", targetRef, tag)
+	}
+
+	if err := s.ImageMgr.AddTag(ctx, name, targetRef); err != nil {
+		return err
+	}
+
+	rw.WriteHeader(http.StatusCreated)
+	return nil
+}

--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -60,6 +60,7 @@ func initRoute(s *Server) http.Handler {
 	s.addRoute(r, http.MethodGet, "/images/json", s.listImages)
 	s.addRoute(r, http.MethodDelete, "/images/{name:.*}", s.removeImage)
 	s.addRoute(r, http.MethodGet, "/images/{name:.*}/json", s.getImage)
+	s.addRoute(r, http.MethodPost, "/images/{name:.*}/tag", s.postImageTag)
 
 	// volume
 	s.addRoute(r, http.MethodGet, "/volumes", s.listVolume)

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -265,6 +265,34 @@ paths:
         500:
           $ref: "#/responses/500ErrorResponse"
 
+  /images/{imageid}/tag:
+    post:
+      summary: "Tag an image"
+      description: "Add tag reference to the existing image"
+      parameters:
+        - $ref: "#/parameters/imageid"
+        - name: "repo"
+          in: "query"
+          description: "The repository to tag in. For example, `someuser/someimage`."
+          type: "string"
+        - name: "tag"
+          in: "query"
+          description: "The name of the new tag."
+          type: "string"
+      responses:
+        201:
+          description: "No error"
+        400:
+          description: "Bad parameter"
+          schema:
+            $ref: "#/definitions/Error"
+        404:
+          description: "no such image"
+          schema:
+            $ref: "#/definitions/Error"
+        500:
+          $ref: "#/responses/500ErrorResponse"
+
   /images/{imageid}:
     delete:
       summary: "Remove an image"

--- a/cli/main.go
+++ b/cli/main.go
@@ -29,6 +29,7 @@ func main() {
 	cli.AddCommand(base, &RmiCommand{})
 	cli.AddCommand(base, &VolumeCommand{})
 	cli.AddCommand(base, &NetworkCommand{})
+	cli.AddCommand(base, &TagCommand{})
 
 	cli.AddCommand(base, &InspectCommand{})
 	cli.AddCommand(base, &RenameCommand{})

--- a/cli/tag.go
+++ b/cli/tag.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+// tagDescription
+var tagDescription = "tag command is to add tag reference for the existing image."
+
+// TagCommand use to implement 'tag' command.
+type TagCommand struct {
+	baseCommand
+	args []string
+}
+
+// Init initialize tag command.
+func (tag *TagCommand) Init(c *Cli) {
+	tag.cli = c
+	tag.cmd = &cobra.Command{
+		Use:   "tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]",
+		Short: "Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE",
+		Long:  tagDescription,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return tag.runTag(args)
+		},
+		Example: tagExamples(),
+	}
+}
+
+// runTag is the entry of tag command.
+func (tag *TagCommand) runTag(args []string) error {
+	ctx := context.Background()
+	apiClient := tag.cli.Client()
+
+	source, target := args[0], args[1]
+	return apiClient.ImageTag(ctx, source, target)
+}
+
+// tagExamples shows examples in tag command, and is used in auto-generated cli docs.
+func tagExamples() string {
+	return `$ pouch tag registry.hub.docker.com/library/busybox:1.28 busybox:latest`
+}

--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/alibaba/pouch/pkg/reference"
+)
+
+// ImageTag creates tag for the image.
+func (client *APIClient) ImageTag(ctx context.Context, image string, tag string) error {
+	if _, err := reference.Parse(image); err != nil {
+		return fmt.Errorf("the image reference (%s) is not valid reference", image)
+	}
+
+	ref, err := reference.Parse(tag)
+	if err != nil {
+		return fmt.Errorf("the tag reference (%s) is not valid reference", tag)
+	}
+
+	if _, ok := ref.(reference.Digested); ok {
+		return fmt.Errorf("refusing to create a tag with a digest reference")
+	}
+
+	q := url.Values{}
+	q.Set("repo", ref.Name())
+	if tagRef, ok := ref.(reference.Tagged); ok {
+		q.Set("tag", tagRef.Tag())
+	}
+
+	resp, err := client.post(ctx, fmt.Sprintf("/images/%s/tag", image), q, nil, nil)
+	ensureCloseReader(resp)
+	return err
+}

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestImageTagNotFoundError(t *testing.T) {
+	client := &APIClient{
+		HTTPCli: newMockClient(errorMockResponse(http.StatusNotFound, "Not Found")),
+	}
+
+	err := client.ImageTag(context.Background(), "oops", "whatever")
+	if err == nil || !strings.Contains(err.Error(), "Not Found") {
+		t.Fatalf("expected a not found error, got %v", err)
+	}
+}
+
+func TestImageTagOK(t *testing.T) {
+	expectedURL := "/images/imagetagok/tag"
+
+	expectedRepo, expectedTag := "pouch", "0.5.0"
+
+	httpClient := newMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+
+		if got := req.FormValue("repo"); got != expectedRepo {
+			return nil, fmt.Errorf("expected repo is %s, got %s", expectedRepo, got)
+		}
+
+		if got := req.FormValue("tag"); got != expectedTag {
+			return nil, fmt.Errorf("expected tag is %s, got %s", expectedTag, got)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	})
+
+	client := &APIClient{
+		HTTPCli: httpClient,
+	}
+
+	err := client.ImageTag(context.Background(), "imagetagok", fmt.Sprintf("%s:%s", expectedRepo, expectedTag))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -47,6 +47,7 @@ type ImageAPIClient interface {
 	ImageInspect(ctx context.Context, name string) (types.ImageInfo, error)
 	ImagePull(ctx context.Context, name, tag, encodedAuth string) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, name string, force bool) error
+	ImageTag(ctx context.Context, image string, tag string) error
 }
 
 // VolumeAPIClient defines methods of Volume client.

--- a/ctrd/interface.go
+++ b/ctrd/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alibaba/pouch/pkg/jsonstream"
 
 	"github.com/containerd/containerd"
+	ctrdmetaimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
 )
@@ -56,6 +57,8 @@ type ContainerAPIClient interface {
 
 // ImageAPIClient provides access to containerd image features.
 type ImageAPIClient interface {
+	// CreateImageReference creates the image data into meta data in the containerd.
+	CreateImageReference(ctx context.Context, img ctrdmetaimages.Image) (ctrdmetaimages.Image, error)
 	// GetImage returns containerd.Image by the given reference.
 	GetImage(ctx context.Context, ref string) (containerd.Image, error)
 	// ListImages returns the list of containerd.Image filtered by the given conditions.

--- a/test/api_image_tag_test.go
+++ b/test/api_image_tag_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/test/request"
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// APIImageTagSuite is the test suite for image tag API.
+type APIImageTagSuite struct{}
+
+func init() {
+	check.Suite(&APIImageTagSuite{})
+}
+
+// SetUpTest does common setup in the beginning of each test.
+func (suite *APIImageTagSuite) SetUpTest(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	PullImage(c, busyboxImage)
+}
+
+// TestImageTagCreateWithTagOK tests OK.
+func (suite *APIImageTagSuite) TestImageTagCreateWithTagOK(c *check.C) {
+	repo, tag := "localhost:5000/testimagetagok/pouch", "0.5.0"
+	resp, err := suite.sendRequest(busyboxImage, repo, tag)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 201)
+
+	tagRef := fmt.Sprintf("%s:%s", repo, tag)
+	defer forceDeleteImage(c, tagRef)
+	suite.checkTagReferenceExisting(c, tagRef, true)
+}
+
+// TestImageTagCreateUsingDefaultTagOK tests OK.
+func (suite *APIImageTagSuite) TestImageTagCreateUsingDefaultTagOK(c *check.C) {
+	repo, tag := "localhost:5000/testimagetagok/pouch", "latest"
+	resp, err := suite.sendRequest(busyboxImage, repo, tag)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 201)
+
+	tagRef := fmt.Sprintf("%s:%s", repo, tag)
+	defer forceDeleteImage(c, tagRef)
+	suite.checkTagReferenceExisting(c, tagRef, true)
+}
+
+// TestImageTagUsingNoFoundSourceImage tests fail.
+func (suite *APIImageTagSuite) TestImageTagUsingNoFoundSourceImage(c *check.C) {
+	repo, tag := "image_test_using_no_found_source_image", "latest"
+	resp, err := suite.sendRequest("image_test_ghost_image", repo, tag)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 404)
+}
+
+// TestImageTagFailToOverrideExistingPrimaryReference tests fail.
+func (suite *APIImageTagSuite) TestImageTagFailToOverrideExistingPrimaryReference(c *check.C) {
+	repo, tag := "registry.hub.docker.com/library/busybox", "1.25"
+	tagRef := fmt.Sprintf("%s:%s", repo, tag)
+	command.PouchRun("pull", tagRef).Assert(c, icmd.Success)
+	defer forceDeleteImage(c, tagRef)
+
+	resp, err := suite.sendRequest(busyboxImage, repo, tag)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 400)
+}
+
+// TestImageTagFailToOverrideExistingTag tests fail.
+func (suite *APIImageTagSuite) TestImageTagFailToOverrideExistingTag(c *check.C) {
+	repo, tag := "registry.hub.docker.com/library/busybox", "1.25"
+	tagRef := fmt.Sprintf("%s:%s", repo, tag)
+	command.PouchRun("pull", tagRef).Assert(c, icmd.Success)
+	defer forceDeleteImage(c, tagRef)
+
+	resp, err := suite.sendRequest(busyboxImage, repo, tag)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 400)
+}
+
+// TestImageTagFailToUseSha256AsName tests fail.
+func (suite *APIImageTagSuite) TestImageTagFailToUseSha256AsName(c *check.C) {
+	repo, tag := "localhost:5000/sha256", "1.25"
+
+	resp, err := suite.sendRequest(busyboxImage, repo, tag)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 400)
+}
+
+func (suite *APIImageTagSuite) sendRequest(source, repo, tag string) (*http.Response, error) {
+	q := url.Values{}
+	q.Set("repo", repo)
+	q.Set("tag", tag)
+
+	return request.Post(fmt.Sprintf("/images/%s/tag", source), request.WithQuery(q))
+}
+
+func (suite *APIImageTagSuite) checkTagReferenceExisting(c *check.C, tagRef string, ok bool) {
+	resp, err := request.Get(fmt.Sprintf("/images/%s/json", tagRef))
+	c.Assert(err, check.IsNil)
+
+	status := http.StatusOK
+	if !ok {
+		status = http.StatusNotFound
+	}
+	CheckRespStatus(c, resp, status)
+}
+
+func forceDeleteImage(c *check.C, idOrRef string) {
+	q := url.Values{}
+	q.Set("force", "1")
+
+	resp, err := request.Delete(fmt.Sprintf("/images/%s", idOrRef), request.WithQuery(q))
+	c.Assert(err, check.IsNil)
+
+	CheckRespStatus(c, resp, 204)
+}

--- a/test/cli_tag_test.go
+++ b/test/cli_tag_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// PouchTagSuite is the test suite for pouch tag.
+type PouchTagSuite struct{}
+
+func init() {
+	check.Suite(&PouchTagSuite{})
+}
+
+// SetUpTest does common setup in the beginning of each test.
+func (suite *PouchTagSuite) SetUpTest(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	PullImage(c, busyboxImage)
+}
+
+// TestImageTagOKWithSourceImageName tests OK.
+func (suite *PouchTagSuite) TestImageTagOKWithSourceImageName(c *check.C) {
+	repo, tag := "localhost:5000/testimagetagok/pouch", "source.name"
+	tagRef := fmt.Sprintf("%s:%s", repo, tag)
+	command.PouchRun("tag", busyboxImage, tagRef).Assert(c, icmd.Success)
+	defer forceDeleteImage(c, tagRef)
+
+	command.PouchRun("image", "inspect", tagRef).Assert(c, icmd.Success)
+}
+
+// TestImageTagOKWithSourceImageID tests OK.
+func (suite *PouchTagSuite) TestImageTagOKWithSourceImageID(c *check.C) {
+	repo, tag := "localhost:5000/testimagetagok/pouch", "source.id"
+	tagRef := fmt.Sprintf("%s:%s", repo, tag)
+
+	command.PouchRun("tag", environment.BusyboxID, tagRef).Assert(c, icmd.Success)
+	defer forceDeleteImage(c, tagRef)
+
+	command.PouchRun("image", "inspect", tagRef).Assert(c, icmd.Success)
+}
+
+// TestImageTagOKTargetWithoutTag tests fail.
+func (suite *PouchTagSuite) TestImageTagOKTargetWithoutTag(c *check.C) {
+	repo, tag := "localhost:5000/testimagetagok/pouch", "latest"
+	tagRef := fmt.Sprintf("%s:%s", repo, tag)
+
+	command.PouchRun("tag", busyboxImage, repo).Assert(c, icmd.Success)
+	defer forceDeleteImage(c, tagRef)
+
+	command.PouchRun("image", "inspect", tagRef).Assert(c, icmd.Success)
+}
+
+// TestImageTagFailToUseDigest tests fail.
+func (suite *PouchTagSuite) TestImageTagFailToUseDigest(c *check.C) {
+	repo, tag := "localhost:5000/testimagetagfail/pouch", "1.25"
+	dig := "sha256:1ac48589692a53a9b8c2d1ceaa6b402665aa7fe667ba51ccc03002300856d8c7"
+
+	tagRef := fmt.Sprintf("%s:%s@%s", repo, tag, dig)
+	got := command.PouchRun("tag", busyboxImage, tagRef).Stderr()
+	c.Assert(got, check.NotNil)
+
+	expectedErr := "refusing to create a tag with a digest reference"
+	if !strings.Contains(got, expectedErr) {
+		c.Errorf("expected to contains %s, but got %v", expectedErr, got)
+	}
+}
+
+// TestImageTagFailToUseSha256AsName tests fail.
+func (suite *PouchTagSuite) TestImageTagFailToUseSha256AsName(c *check.C) {
+	repo, tag := "localhost:5000/testimagetagfail/sha256", "1.25"
+
+	tagRef := fmt.Sprintf("%s:%s", repo, tag)
+	got := command.PouchRun("tag", busyboxImage, tagRef).Stderr()
+	c.Assert(got, check.NotNil)
+
+	expectedErr := "refusing to create an reference using digest algorithm as name"
+	if !strings.Contains(got, expectedErr) {
+		c.Errorf("expected to contains %s, but got %v", expectedErr, got)
+	}
+}


### PR DESCRIPTION
Since the containerd provides the ImageService to modify the boltdb
data, we can add tag reference into the containerd. Just in case that
the client removes the source image.

Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Use containerd's ImageService to implement `pouch tag` functionality. Allow user to create tag reference to existing image.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE.

### Ⅲ. Describe how you did it

The containerd stores the image name as key in the `boltdb`. `pouch run/image inspect/rmi` will use the primary reference as name to handle image information.

If we don't use the `boltdb` provided by containerd.ImageService, we will loss the tag reference when we remove the source image.

Therefore, when user adds tag reference to the existing image, I will do the following things:
* get the image from containerd
* use the tag reference as primary name and update boltdb by containerd.ImageService

The update action will add the reference count for the image content. That is the key to implement this functionality.

### Ⅳ. Describe how to verify it

First one is the help:

```
➜  pouch git:(feature_image_tag) pouch tag -h
tag command is to add tag reference for the existing image.

Usage:
  pouch tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]

Examples:
$ pouch tag registry.hub.docker.com/library/busybox:1.28 busybox:latest

Flags:
  -h, --help   help for tag

Global Flags:
  -D, --debug              Switch client log level to DEBUG mode
  -H, --host string        Specify connecting address of Pouch CLI (default "unix:///var/run/pouchd.sock")
      --tlscacert string   Specify CA file of TLS
      --tlscert string     Specify cert file of TLS
      --tlskey string      Specify key file of TLS
      --tlsverify          Use TLS and verify remote
```

Use Tag:

```
➜  pouch git:(feature_image_tag) pouch images
IMAGE ID       IMAGE NAME                                     SIZE
8ac48589692a   registry.hub.docker.com/library/busybox:1.28   710.83 KB
➜  pouch git:(feature_image_tag) pouch tag busybox:1.28 busybox:test
➜  pouch git:(feature_image_tag) pouch images --digest
IMAGE ID       IMAGE NAME                                     DIGEST                                                                    SIZE
8ac48589692a   registry.hub.docker.com/library/busybox:1.28   sha256:58ac43b2cc92c687a32c8be6278e50a063579655fe3090125dcb2af0ff9e1a64   710.83 KB
8ac48589692a   registry.hub.docker.com/library/busybox:test   sha256:58ac43b2cc92c687a32c8be6278e50a063579655fe3090125dcb2af0ff9e1a64   710.83 KB
```

We can use the tag reference to run container like:

```
➜  pouch git:(feature_image_tag) pouch run busybox:test ls
bin
dev
etc
home
proc
root
run
sys
tmp
usr
var
```

But we don't allow to use `sha256` as name, because it will confuse with searching by imageID.

```
➜  pouch git:(feature_image_tag) pouch tag busybox:1.28 sha256:oops
Error: {"message":"refusing to create an reference using digest algorithm as name: invalid param"}
```

However, it doesn't act like `docker` right now. We don't allow user to override the existing primary reference, like: 

```
➜  pouch git:(feature_image_tag) pouch images
IMAGE ID       IMAGE NAME                                     SIZE
e02e811dd08f   registry.hub.docker.com/library/busybox:1.25   654.44 KB
8ac48589692a   registry.hub.docker.com/library/busybox:1.28   710.83 KB
8ac48589692a   registry.hub.docker.com/library/busybox:test   710.83 KB
➜  pouch git:(feature_image_tag) pouch tag e02e811dd08f busybox:test # even if the busybox:test is created by tag
Error: {"message":"the tag reference (registry.hub.docker.com/library/busybox:test) has been used as reference: invalid param"}
```


### Ⅴ. Special notes for reviews


