### PR TITLE
cli: add instruction for blkio-weight-device

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2166,7 +2166,7 @@ definitions:
         description: "Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist."
         type: "string"
       BlkioWeight:
-        description: "Block IO weight (relative weight)."
+        description: "Block IO weight (relative weight), need CFQ IO Scheduler enable."
         type: "integer"
         format: "uint16"
         x-nullable: false

--- a/apis/types/resources.go
+++ b/apis/types/resources.go
@@ -36,7 +36,7 @@ type Resources struct {
 	//
 	BlkioDeviceWriteIOps []*ThrottleDevice `json:"BlkioDeviceWriteIOps"`
 
-	// Block IO weight (relative weight).
+	// Block IO weight (relative weight), need CFQ IO Scheduler enable.
 	// Maximum: 1000
 	// Minimum: 0
 	BlkioWeight uint16 `json:"BlkioWeight,omitempty"`

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -10,7 +10,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	// please add the following flag by name in alphabetical order
 	// blkio
 	flagSet.Uint16Var(&c.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable")
-	flagSet.Var(&c.blkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
+	flagSet.Var(&c.blkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight), need CFQ IO Scheduler enable")
 	flagSet.Var(&c.blkioDeviceReadBps, "device-read-bps", "Limit read rate (bytes per second) from a device")
 	flagSet.Var(&c.blkioDeviceReadIOps, "device-read-iops", "Limit read rate (IO per second) from a device")
 	flagSet.Var(&c.blkioDeviceWriteBps, "device-write-bps", "Limit write rate (bytes per second) from a device")

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -576,6 +577,14 @@ func (suite *PouchRunSuite) TestRunBlockIOWeightDevice(c *check.C) {
 	if !found {
 		c.Skip("fail to find available disk for blkio test")
 	}
+
+	SkipIfFalse(c, func() bool {
+		file := fmt.Sprintf("/sys/block/%s/queue/scheduler", strings.Trim(testDisk, "/dev/"))
+		if data, err := ioutil.ReadFile(file); err == nil {
+			return strings.Contains(string(data), "[cfq]")
+		}
+		return false
+	})
 
 	command.PouchRun("run", "-d", "--blkio-weight-device", testDisk+":100",
 		"--name", cname, busyboxImage, "sleep", "10000").Stdout()


### PR DESCRIPTION
blkio.weight_device need cfq io scheduler enable, add this
instruction for blkio-weight-device

add condition check for ci test TestRunBlockIOWeightDevice

Same problem also exist in #1346.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

```
[root@r10d08216.sqa.zmf /root]
#pouch run -ti --blkio-weight-device "/dev/sda:1000" reg.docker.alibaba-inc.com/sunyuan/ubuntu:14.04 bash
Error: failed to run container 143a0e: {"message":"failed to create task, container id: 143a0e09b0d0d3905a6c56f66aa55576c0801fd50d1dc5072d6578eefc182231: OCI runtime create failed: container_linux.go:265: starting container process caused \"process_linux.go:348: container init caused \\\"process_linux.go:320: setting cgroup config for procHooks process caused \\\\\\\"failed to write 8:0 1000 to blkio.weight_device: write /sys/fs/cgroup/blkio/default/143a0e09b0d0d3905a6c56f66aa55576c0801fd50d1dc5072d6578eefc182231/blkio.weight_device: operation not supported\\\\\\\"\\\"\": unknown"}
```

Container fails to start, because sda's io scheduler is deadline, but blkio.weight_device need cfq,
```
[root@r10d08216.sqa.zmf /sys/fs/cgroup/blkio]
#cat /sys/block/sda/queue/scheduler 
noop [deadline] cfq 
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


