### PR TITLE
enhance: replace the default sandbox image for pouchd with google-released image

### DIFF
--- a/hack/cri-test/test-utils.sh
+++ b/hack/cri-test/test-utils.sh
@@ -49,7 +49,7 @@ test_setup() {
   pouch_pid_command=`pgrep pouchd`
   pouch_pid=${pouch_pid_command}
   if [ ! -n "${pouch_pid}" ]; then
-    keepalive "pouchd --enable-cri ${POUCH_FLAGS}" \
+    keepalive "pouchd --enable-cri --sandbox-image=gcr.io/google_containers/pause-amd64:3.0 ${POUCH_FLAGS}" \
 	  ${RESTART_WAIT_PERIOD} &> ${report_dir}/pouch.log &
     pouch_pid=$!
   fi


### PR DESCRIPTION

Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Right now, cri-test will report flaky test from time to time, due to the default sandbox image is at home, while travis, which is located abroad, is used to run cri-test.

This pr changs the default sandbox image ```registry.cn-hangzhou.aliyuncs.com/google-containers/pause-amd64:3.0``` to ```gcr.io/google_containers/pause-amd64:3.0```, to reduce the possibility of random test errors caused by image pulling failure.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


