### PR TITLE
bugfix: make the PullImage test util work

### DIFF
--- a/test/main_test.go
+++ b/test/main_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/alibaba/pouch/client"
-	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
 	"github.com/go-check/check"
 )
@@ -26,8 +25,6 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	apiClient = commonAPIClient.(*client.APIClient)
-
-	command.PouchRun("pull", busyboxImage)
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

The post method of pullImage will hijack the connection so that the HTTP header always contains 200. It means that we cannot just check the HTTP status. We should read all the data bytes from server.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

Read the bytes from server and check the error in the jsonstream.

### Ⅳ. Describe how to verify it

Remove the `command.PouchRun("pull", busyboxImage)` in the beginning of test so that we can make sure the `PullImage` works well or not.

### Ⅴ. Special notes for reviews

It is very important to make CI happy
