### PR TITLE
feature: add pouch load functionality

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -134,3 +134,18 @@ func (s *Server) postImageTag(ctx context.Context, rw http.ResponseWriter, req *
 	rw.WriteHeader(http.StatusCreated)
 	return nil
 }
+
+// loadImage loads an image by http tar stream.
+func (s *Server) loadImage(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+	imageName := req.FormValue("name")
+	if imageName == "" {
+		imageName = "unknown/unknown"
+	}
+
+	if err := s.ImageMgr.LoadImage(ctx, imageName, req.Body); err != nil {
+		return err
+	}
+
+	rw.WriteHeader(http.StatusOK)
+	return nil
+}

--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -61,6 +61,7 @@ func initRoute(s *Server) http.Handler {
 	s.addRoute(r, http.MethodDelete, "/images/{name:.*}", s.removeImage)
 	s.addRoute(r, http.MethodGet, "/images/{name:.*}/json", s.getImage)
 	s.addRoute(r, http.MethodPost, "/images/{name:.*}/tag", s.postImageTag)
+	s.addRoute(r, http.MethodPost, "/images/load", withCancelHandler(s.loadImage))
 
 	// volume
 	s.addRoute(r, http.MethodGet, "/volumes", s.listVolume)

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -152,6 +152,32 @@ paths:
           description: "A base64-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
           type: "string"
 
+  /images/load:
+     post:
+      summary: "Import images"
+      description: |
+        Load a set of images by oci.v1 format tar stream
+      consumes:
+        - application/x-tar
+      responses:
+        200:
+          description: "no error"
+        500:
+          description: "server error"
+          schema:
+            $ref: "#/responses/500ErrorResponse"
+      parameters:
+        - name: "imageTarStream"
+          in: "body"
+          description: "tar stream containing images"
+          schema:
+            type: "string"
+            format: "binary"
+        - name: "name"
+          in: "query"
+          description: "set the image name for the tar stream, default unknown/unknown"
+          type: "string"
+
   /images/{imageid}/json:
     get:
       summary: "Inspect a image"

--- a/cli/load.go
+++ b/cli/load.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// loadDescription is used to describe load command in detail and auto generate command doc.
+var loadDescription = "load a set of images by tar stream"
+
+// LoadCommand use to implement 'load' command.
+type LoadCommand struct {
+	baseCommand
+	input string
+}
+
+// Init initialize load command.
+func (l *LoadCommand) Init(c *Cli) {
+	l.cli = c
+	l.cmd = &cobra.Command{
+		Use:   "load [OPTIONS] [IMAGE_NAME]",
+		Short: "load a set of images from a tar archive or STDIN",
+		Long:  loadDescription,
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return l.runLoad(args)
+		},
+		Example: loadExample(),
+	}
+	l.addFlags()
+}
+
+// addFlags adds flags for specific command.
+func (l *LoadCommand) addFlags() {
+	flagSet := l.cmd.Flags()
+	flagSet.StringVarP(&l.input, "input", "i", "", "Read from tar archive file, instead of STDIN")
+}
+
+// runLoad is the entry of load command.
+func (l *LoadCommand) runLoad(args []string) error {
+	ctx := context.Background()
+	apiClient := l.cli.Client()
+
+	var (
+		in        io.Reader = os.Stdin
+		imageName           = ""
+	)
+
+	if l.input != "" {
+		file, err := os.Open(l.input)
+		if err != nil {
+			return err
+		}
+
+		defer file.Close()
+		in = file
+	}
+
+	if len(args) > 0 {
+		imageName = args[0]
+	}
+	return apiClient.ImageLoad(ctx, imageName, in)
+}
+
+// loadExample shows examples in load command, and is used in auto-generated cli docs.
+func loadExample() string {
+	return `$ pouch load -i busybox.tar busybox`
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -30,6 +30,7 @@ func main() {
 	cli.AddCommand(base, &VolumeCommand{})
 	cli.AddCommand(base, &NetworkCommand{})
 	cli.AddCommand(base, &TagCommand{})
+	cli.AddCommand(base, &LoadCommand{})
 
 	cli.AddCommand(base, &InspectCommand{})
 	cli.AddCommand(base, &RenameCommand{})

--- a/client/image_load.go
+++ b/client/image_load.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"context"
+	"io"
+	"net/url"
+)
+
+// ImageLoad requests daemon to load an image from tarstream.
+func (client *APIClient) ImageLoad(ctx context.Context, imageName string, reader io.Reader) error {
+	q := url.Values{}
+	if imageName != "" {
+		q.Set("name", imageName)
+	}
+
+	headers := map[string][]string{}
+	headers["Content-Type"] = []string{"application/x-tar"}
+
+	resp, err := client.postRawData(ctx, "/images/load", q, reader, headers)
+	if err != nil {
+		return err
+	}
+
+	ensureCloseReader(resp)
+	return nil
+}

--- a/client/image_load_test.go
+++ b/client/image_load_test.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestImageLoadServerError(t *testing.T) {
+	expectedError := "Server error"
+
+	client := &APIClient{
+		HTTPCli: newMockClient(errorMockResponse(http.StatusInternalServerError, expectedError)),
+	}
+
+	err := client.ImageLoad(context.Background(), "test_image_load_500", nil)
+	if err == nil || !strings.Contains(err.Error(), expectedError) {
+		t.Fatalf("expected (%v), got (%v)", expectedError, err)
+	}
+}
+
+func TestImageLoadOK(t *testing.T) {
+	expectedURL := "/images/load"
+	expectedImageName := "test_image_load_ok"
+
+	httpClient := newMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+
+		if req.Method != "POST" {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+
+		if got := req.FormValue("name"); got != expectedImageName {
+			return nil, fmt.Errorf("expected (%s), got %s", expectedImageName, got)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	})
+
+	client := &APIClient{
+		HTTPCli: httpClient,
+	}
+
+	if err := client.ImageLoad(context.Background(), expectedImageName, nil); err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -48,6 +48,7 @@ type ImageAPIClient interface {
 	ImagePull(ctx context.Context, name, tag, encodedAuth string) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, name string, force bool) error
 	ImageTag(ctx context.Context, image string, tag string) error
+	ImageLoad(ctx context.Context, name string, r io.Reader) error
 }
 
 // VolumeAPIClient defines methods of Volume client.

--- a/client/request.go
+++ b/client/request.go
@@ -37,7 +37,16 @@ func (client *APIClient) get(ctx context.Context, path string, query url.Values,
 }
 
 func (client *APIClient) post(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (*Response, error) {
-	return client.sendRequest(ctx, "POST", path, query, obj, headers)
+	body, err := objectToJSONStream(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.sendRequest(ctx, "POST", path, query, body, headers)
+}
+
+func (client *APIClient) postRawData(ctx context.Context, path string, query url.Values, data io.Reader, headers map[string][]string) (*Response, error) {
+	return client.sendRequest(ctx, "POST", path, query, data, headers)
 }
 
 func (client *APIClient) delete(ctx context.Context, path string, query url.Values, headers map[string][]string) (*Response, error) {
@@ -45,7 +54,12 @@ func (client *APIClient) delete(ctx context.Context, path string, query url.Valu
 }
 
 func (client *APIClient) hijack(ctx context.Context, path string, query url.Values, obj interface{}, header map[string][]string) (net.Conn, *bufio.Reader, error) {
-	req, err := client.newRequest("POST", path, query, obj, header)
+	body, err := objectToJSONStream(obj)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := client.newRequest("POST", path, query, body, header)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,20 +90,7 @@ func (client *APIClient) hijack(ctx context.Context, path string, query url.Valu
 	return rwc, br, nil
 }
 
-func (client *APIClient) newRequest(method, path string, query url.Values, obj interface{}, header map[string][]string) (*http.Request, error) {
-	var body io.Reader
-	if method == "POST" {
-		if obj != nil {
-			b, err := json.Marshal(obj)
-			if err != nil {
-				return nil, err
-			}
-			body = bytes.NewReader(b)
-		} else {
-			body = bytes.NewReader([]byte{})
-		}
-	}
-
+func (client *APIClient) newRequest(method, path string, query url.Values, body io.Reader, header map[string][]string) (*http.Request, error) {
 	fullPath := client.baseURL + client.GetAPIPath(path, query)
 	req, err := http.NewRequest(method, fullPath, body)
 	if err != nil {
@@ -105,8 +106,8 @@ func (client *APIClient) newRequest(method, path string, query url.Values, obj i
 	return req, err
 }
 
-func (client *APIClient) sendRequest(ctx context.Context, method, path string, query url.Values, obj interface{}, headers map[string][]string) (*Response, error) {
-	req, err := client.newRequest(method, path, query, obj, headers)
+func (client *APIClient) sendRequest(ctx context.Context, method, path string, query url.Values, body io.Reader, headers map[string][]string) (*Response, error) {
+	req, err := client.newRequest(method, path, query, body, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -158,4 +159,16 @@ func cancellableDo(ctx context.Context, client *http.Client, req *http.Request) 
 	case resp := <-ctxResp:
 		return resp.response, resp.err
 	}
+}
+
+func objectToJSONStream(obj interface{}) (io.Reader, error) {
+	if obj != nil {
+		b, err := json.Marshal(obj)
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewReader(b), nil
+	}
+
+	return nil, nil
 }

--- a/ctrd/interface.go
+++ b/ctrd/interface.go
@@ -2,6 +2,7 @@ package ctrd
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/alibaba/pouch/apis/types"
@@ -67,6 +68,8 @@ type ImageAPIClient interface {
 	PullImage(ctx context.Context, ref string, authConfig *types.AuthConfig, stream *jsonstream.JSONStream) (containerd.Image, error)
 	// RemoveImage removes the image by the given reference.
 	RemoveImage(ctx context.Context, ref string) error
+	// ImportImage creates a set of images by tarstream.
+	ImportImage(ctx context.Context, importer ctrdmetaimages.Importer, reader io.Reader) ([]containerd.Image, error)
 }
 
 // SnapshotAPIClient provides access to containerd snapshot features

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -46,6 +46,9 @@ type ImageMgr interface {
 
 	// CheckReference returns imageID, actual reference and primary reference.
 	CheckReference(ctx context.Context, idOrRef string) (digest.Digest, reference.Named, reference.Named, error)
+
+	// LoadImage creates a set of images by tarstream.
+	LoadImage(ctx context.Context, imageName string, tarstream io.ReadCloser) error
 }
 
 // ImageManager is an implementation of interface ImageMgr.
@@ -345,7 +348,7 @@ func (mgr *ImageManager) updateLocalStore() error {
 
 	for _, img := range imgs {
 		if err := mgr.storeImageReference(ctx, img); err != nil {
-			return err
+			logrus.Warnf("failed to load the image reference into local store: %v", err)
 		}
 	}
 	return nil

--- a/daemon/mgr/image_load.go
+++ b/daemon/mgr/image_load.go
@@ -1,0 +1,56 @@
+package mgr
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/alibaba/pouch/pkg/multierror"
+	"github.com/alibaba/pouch/pkg/reference"
+
+	ociimage "github.com/containerd/containerd/images/oci"
+	pkgerrors "github.com/pkg/errors"
+)
+
+// LoadImage loads images by the oci.v1 format tarstream.
+func (mgr *ImageManager) LoadImage(ctx context.Context, imageName string, tarstream io.ReadCloser) error {
+	defer tarstream.Close()
+
+	namedRef, err := reference.Parse(imageName)
+	if err != nil {
+		return pkgerrors.Wrapf(err, "failed to parse image name %s", imageName)
+	}
+
+	// NOTE: in the image ocispec.v1, the org.opencontainers.image.ref.name
+	// annotation represents a "tag" for image. For example, an image may
+	// have a tag for different versions or builds of the software.
+	// And containerd.importer will append ":" and annotation to the name
+	// so that we don't allow imageName to contains any digest or tag
+	// information, like foo/bar:latest:v1.2.
+	if !reference.IsNamedOnly(namedRef) {
+		return fmt.Errorf("the image name should not contains any digest or tag information")
+	}
+
+	importer := &ociimage.V1Importer{
+		ImageName: imageName,
+	}
+
+	imgs, err := mgr.client.ImportImage(ctx, importer, tarstream)
+	if err != nil {
+		return pkgerrors.Wrap(err, "failed to import image into containerd by tarstream")
+	}
+
+	// FIXME(fuwei): if the store fails to update reference cache, the daemon
+	// may fails to load after restart.
+	merrs := new(multierror.Multierrors)
+	for _, img := range imgs {
+		if err := mgr.storeImageReference(ctx, img); err != nil {
+			merrs.Append(fmt.Errorf("fail to store reference: %s: %v", img.Name(), err))
+		}
+	}
+
+	if merrs.Size() != 0 {
+		return fmt.Errorf("fails to load image: %v", merrs.Error())
+	}
+	return nil
+}

--- a/pkg/multierror/def.go
+++ b/pkg/multierror/def.go
@@ -1,0 +1,38 @@
+package multierror
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Multierrors contains a slice of errors.
+type Multierrors struct {
+	errs []error
+}
+
+// Append adds the errors into the list.
+func (m *Multierrors) Append(errs ...error) {
+	m.errs = append(m.errs, errs...)
+}
+
+// Size returns the count of list of errors.
+func (m *Multierrors) Size() int {
+	return len(m.errs)
+}
+
+// Error returns the combined error messages.
+func (m *Multierrors) Error() string {
+	if len(m.errs) == 0 {
+		return fmt.Sprintf("no error")
+	}
+
+	if len(m.errs) == 1 {
+		return fmt.Sprintf("%s", m.errs[0])
+	}
+
+	serrs := make([]string, len(m.errs))
+	for i, err := range m.errs {
+		serrs[i] = fmt.Sprintf("* %s", err)
+	}
+	return fmt.Sprintf("%d errors:\n\n%s", len(m.errs), strings.Join(serrs, "\n"))
+}

--- a/pkg/multierror/def_test.go
+++ b/pkg/multierror/def_test.go
@@ -1,0 +1,46 @@
+package multierror
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMultiErrors(t *testing.T) {
+	type tCase struct {
+		name string
+		errs []error
+
+		expectedSize  int
+		expectedError string
+	}
+
+	for _, tc := range []tCase{
+		{
+			name:          "no error",
+			errs:          nil,
+			expectedSize:  0,
+			expectedError: "no error",
+		}, {
+			name:          "one error",
+			errs:          []error{fmt.Errorf("oops1")},
+			expectedSize:  1,
+			expectedError: "oops1",
+		}, {
+			name:          "two errors",
+			errs:          []error{fmt.Errorf("oops1"), fmt.Errorf("oops2")},
+			expectedSize:  2,
+			expectedError: "2 errors:\n\n* oops1\n* oops2",
+		},
+	} {
+		merrs := new(Multierrors)
+		merrs.Append(tc.errs...)
+
+		if got := merrs.Size(); got != tc.expectedSize {
+			t.Fatalf("%s: want %d, but got %d", tc.name, tc.expectedSize, got)
+		}
+
+		if got := merrs.Error(); got != tc.expectedError {
+			t.Fatalf("%s: want %s, but got %s", tc.name, tc.expectedError, got)
+		}
+	}
+}

--- a/test/api_image_load_test.go
+++ b/test/api_image_load_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/alibaba/pouch/test/environment"
+
+	"github.com/go-check/check"
+)
+
+// APIImageLoadSuite is the test suite for image load API.
+type APIImageLoadSuite struct{}
+
+func init() {
+	check.Suite(&APIImageLoadSuite{})
+}
+
+// SetUpTest does common setup in the beginning of each test.
+func (suite *APIImageLoadSuite) SetUpTest(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+}
+
+// TODO(fuwei): We cannot upload the oci.v1 format tar into repo because it will
+// increase our repo size. The test will be done with "pouch save" functionality.

--- a/test/cli_load_test.go
+++ b/test/cli_load_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/alibaba/pouch/test/environment"
+
+	"github.com/go-check/check"
+)
+
+// PouchLoadSuite is the test suite for load CLI.
+type PouchLoadSuite struct{}
+
+func init() {
+	check.Suite(&PouchLoadSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each test suite.
+func (suite *PouchLoadSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+}
+
+// TODO(fuwei): We cannot upload the oci.v1 format tar into repo because it will
+// increase our repo size. The test will be done with "pouch save" functionality.

--- a/vendor/github.com/containerd/containerd/images/oci/exporter.go
+++ b/vendor/github.com/containerd/containerd/images/oci/exporter.go
@@ -1,0 +1,188 @@
+package oci
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"io"
+	"sort"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	ocispecs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// V1Exporter implements OCI Image Spec v1.
+// It is up to caller to put "org.opencontainers.image.ref.name" annotation to desc.
+//
+// TODO(AkihiroSuda): add V1Exporter{TranslateMediaTypes: true} that transforms media types,
+//                    e.g. application/vnd.docker.image.rootfs.diff.tar.gzip
+//                         -> application/vnd.oci.image.layer.v1.tar+gzip
+type V1Exporter struct {
+}
+
+// Export implements Exporter.
+func (oe *V1Exporter) Export(ctx context.Context, store content.Store, desc ocispec.Descriptor, writer io.Writer) error {
+	tw := tar.NewWriter(writer)
+	defer tw.Close()
+
+	records := []tarRecord{
+		ociLayoutFile(""),
+		ociIndexRecord(desc),
+	}
+
+	algorithms := map[string]struct{}{}
+	exportHandler := func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		records = append(records, blobRecord(store, desc))
+		algorithms[desc.Digest.Algorithm().String()] = struct{}{}
+		return nil, nil
+	}
+
+	handlers := images.Handlers(
+		images.ChildrenHandler(store, platforms.Default()),
+		images.HandlerFunc(exportHandler),
+	)
+
+	// Walk sequentially since the number of fetchs is likely one and doing in
+	// parallel requires locking the export handler
+	if err := images.Walk(ctx, handlers, desc); err != nil {
+		return err
+	}
+
+	if len(algorithms) > 0 {
+		records = append(records, directoryRecord("blobs/", 0755))
+		for alg := range algorithms {
+			records = append(records, directoryRecord("blobs/"+alg+"/", 0755))
+		}
+	}
+
+	return writeTar(ctx, tw, records)
+}
+
+type tarRecord struct {
+	Header *tar.Header
+	CopyTo func(context.Context, io.Writer) (int64, error)
+}
+
+func blobRecord(cs content.Store, desc ocispec.Descriptor) tarRecord {
+	path := "blobs/" + desc.Digest.Algorithm().String() + "/" + desc.Digest.Hex()
+	return tarRecord{
+		Header: &tar.Header{
+			Name:     path,
+			Mode:     0444,
+			Size:     desc.Size,
+			Typeflag: tar.TypeReg,
+		},
+		CopyTo: func(ctx context.Context, w io.Writer) (int64, error) {
+			r, err := cs.ReaderAt(ctx, desc.Digest)
+			if err != nil {
+				return 0, err
+			}
+			defer r.Close()
+
+			// Verify digest
+			dgstr := desc.Digest.Algorithm().Digester()
+
+			n, err := io.Copy(io.MultiWriter(w, dgstr.Hash()), content.NewReader(r))
+			if err != nil {
+				return 0, err
+			}
+			if dgstr.Digest() != desc.Digest {
+				return 0, errors.Errorf("unexpected digest %s copied", dgstr.Digest())
+			}
+			return n, nil
+		},
+	}
+}
+
+func directoryRecord(name string, mode int64) tarRecord {
+	return tarRecord{
+		Header: &tar.Header{
+			Name:     name,
+			Mode:     mode,
+			Typeflag: tar.TypeDir,
+		},
+	}
+}
+
+func ociLayoutFile(version string) tarRecord {
+	if version == "" {
+		version = ocispec.ImageLayoutVersion
+	}
+	layout := ocispec.ImageLayout{
+		Version: version,
+	}
+
+	b, err := json.Marshal(layout)
+	if err != nil {
+		panic(err)
+	}
+
+	return tarRecord{
+		Header: &tar.Header{
+			Name:     ocispec.ImageLayoutFile,
+			Mode:     0444,
+			Size:     int64(len(b)),
+			Typeflag: tar.TypeReg,
+		},
+		CopyTo: func(ctx context.Context, w io.Writer) (int64, error) {
+			n, err := w.Write(b)
+			return int64(n), err
+		},
+	}
+
+}
+
+func ociIndexRecord(manifests ...ocispec.Descriptor) tarRecord {
+	index := ocispec.Index{
+		Versioned: ocispecs.Versioned{
+			SchemaVersion: 2,
+		},
+		Manifests: manifests,
+	}
+
+	b, err := json.Marshal(index)
+	if err != nil {
+		panic(err)
+	}
+
+	return tarRecord{
+		Header: &tar.Header{
+			Name:     "index.json",
+			Mode:     0644,
+			Size:     int64(len(b)),
+			Typeflag: tar.TypeReg,
+		},
+		CopyTo: func(ctx context.Context, w io.Writer) (int64, error) {
+			n, err := w.Write(b)
+			return int64(n), err
+		},
+	}
+}
+
+func writeTar(ctx context.Context, tw *tar.Writer, records []tarRecord) error {
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].Header.Name < records[j].Header.Name
+	})
+
+	for _, record := range records {
+		if err := tw.WriteHeader(record.Header); err != nil {
+			return err
+		}
+		if record.CopyTo != nil {
+			n, err := record.CopyTo(ctx, tw)
+			if err != nil {
+				return err
+			}
+			if n != record.Header.Size {
+				return errors.Errorf("unexpected copy size for %s", record.Header.Name)
+			}
+		} else if record.Header.Size > 0 {
+			return errors.Errorf("no content to write to record with non-zero size for %s", record.Header.Name)
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/containerd/containerd/images/oci/importer.go
+++ b/vendor/github.com/containerd/containerd/images/oci/importer.go
@@ -1,0 +1,188 @@
+// Package oci provides the importer and the exporter for OCI Image Spec.
+package oci
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// V1Importer implements OCI Image Spec v1.
+type V1Importer struct {
+	// ImageName is preprended to either `:` + OCI ref name or `@` + digest (for anonymous refs).
+	// This field is mandatory atm, but may change in the future. maybe ref map[string]string as in moby/moby#33355
+	ImageName string
+}
+
+var _ images.Importer = &V1Importer{}
+
+// Import implements Importer.
+func (oi *V1Importer) Import(ctx context.Context, store content.Store, reader io.Reader) ([]images.Image, error) {
+	if oi.ImageName == "" {
+		return nil, errors.New("ImageName not set")
+	}
+	tr := tar.NewReader(reader)
+	var imgrecs []images.Image
+	foundIndexJSON := false
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeRegA {
+			continue
+		}
+		hdrName := path.Clean(hdr.Name)
+		if hdrName == "index.json" {
+			if foundIndexJSON {
+				return nil, errors.New("duplicated index.json")
+			}
+			foundIndexJSON = true
+			imgrecs, err = onUntarIndexJSON(tr, oi.ImageName)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if strings.HasPrefix(hdrName, "blobs/") {
+			if err := onUntarBlob(ctx, tr, store, hdrName, hdr.Size); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if !foundIndexJSON {
+		return nil, errors.New("no index.json found")
+	}
+	for _, img := range imgrecs {
+		err := setGCRefContentLabels(ctx, store, img.Target)
+		if err != nil {
+			return imgrecs, err
+		}
+	}
+	// FIXME(AkihiroSuda): set GC labels for unreferrenced blobs (i.e. with unknown media types)?
+	return imgrecs, nil
+}
+
+func onUntarIndexJSON(r io.Reader, imageName string) ([]images.Image, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var idx ocispec.Index
+	if err := json.Unmarshal(b, &idx); err != nil {
+		return nil, err
+	}
+	var imgrecs []images.Image
+	for _, m := range idx.Manifests {
+		ref, err := normalizeImageRef(imageName, m)
+		if err != nil {
+			return nil, err
+		}
+		imgrecs = append(imgrecs, images.Image{
+			Name:   ref,
+			Target: m,
+		})
+	}
+	return imgrecs, nil
+}
+
+func normalizeImageRef(imageName string, manifest ocispec.Descriptor) (string, error) {
+	digest := manifest.Digest
+	if digest == "" {
+		return "", errors.Errorf("manifest with empty digest: %v", manifest)
+	}
+	ociRef := manifest.Annotations[ocispec.AnnotationRefName]
+	if ociRef == "" {
+		return imageName + "@" + digest.String(), nil
+	}
+	return imageName + ":" + ociRef, nil
+}
+
+func onUntarBlob(ctx context.Context, r io.Reader, store content.Store, name string, size int64) error {
+	// name is like "blobs/sha256/deadbeef"
+	split := strings.Split(name, "/")
+	if len(split) != 3 {
+		return errors.Errorf("unexpected name: %q", name)
+	}
+	algo := digest.Algorithm(split[1])
+	if !algo.Available() {
+		return errors.Errorf("unsupported algorithm: %s", algo)
+	}
+	dgst := digest.NewDigestFromHex(algo.String(), split[2])
+	return content.WriteBlob(ctx, store, "unknown-"+dgst.String(), r, size, dgst)
+}
+
+// GetChildrenDescriptors returns children blob descriptors for the following supported types:
+// - images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest
+// - images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex
+func GetChildrenDescriptors(r io.Reader, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	switch desc.MediaType {
+	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		var manifest ocispec.Manifest
+		if err := json.NewDecoder(r).Decode(&manifest); err != nil {
+			return nil, err
+		}
+		return append([]ocispec.Descriptor{manifest.Config}, manifest.Layers...), nil
+	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		var index ocispec.Index
+		if err := json.NewDecoder(r).Decode(&index); err != nil {
+			return nil, err
+		}
+		return index.Manifests, nil
+	}
+	return nil, nil
+}
+
+func setGCRefContentLabels(ctx context.Context, store content.Store, desc ocispec.Descriptor) error {
+	info, err := store.Info(ctx, desc.Digest)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			// when the archive is created from multi-arch image,
+			// it may contain only blobs for a certain platform.
+			// So ErrNotFound (on manifest list) is expected here.
+			return nil
+		}
+		return err
+	}
+	ra, err := store.ReaderAt(ctx, desc.Digest)
+	if err != nil {
+		return err
+	}
+	defer ra.Close()
+	r := content.NewReader(ra)
+	children, err := GetChildrenDescriptors(r, desc)
+	if err != nil {
+		return err
+	}
+	if info.Labels == nil {
+		info.Labels = map[string]string{}
+	}
+	for i, child := range children {
+		// Note: child blob is not guaranteed to be written to the content store. (multi-arch)
+		info.Labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = child.Digest.String()
+	}
+	if _, err := store.Update(ctx, info, "labels"); err != nil {
+		return err
+	}
+	for _, child := range children {
+		if err := setGCRefContentLabels(ctx, store, child); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -264,6 +264,14 @@
 			"versionExact": "v1.0.3"
 		},
 		{
+			"checksumSHA1": "Y5+z8z3og/GbOeQNkhKbUHm7rVE=",
+			"path": "github.com/containerd/containerd/images/oci",
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
+		},
+		{
 			"checksumSHA1": "LPyRLtrZmGUuVtKGR2YOEFuUYgE=",
 			"path": "github.com/containerd/containerd/leases",
 			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Allow user to load **oci.v1 format** image by tar stream. 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

Use containerd image oci importer to load the image.

### Ⅳ. Describe how to verify it

First one is help:

```
➜  /tmp pouch load -h
load a set of images by tar stream

Usage:
  pouch load [OPTIONS] [IMAGE_NAME]

Examples:
$ pouch load -i busybox.tar busybox

Flags:
  -h, --help           help for load
  -i, --input string   Read from tar archive file, instead of STDIN
```

Since we don't have dump functionality for pouch, we need to verify it by `ctr`.

```
➜  /tmp ctr images export test.tar registry.hub.docker.com/library/busybox:1.28
➜  /tmp pouch load test < test.tar
➜  /tmp pouch images
IMAGE ID       IMAGE NAME   SIZE
8ac48589692a   test:1.28    710.83 KB
➜  /tmp pouch run 8ac48589692a ls
bin
dev
etc
home
proc
root
run
sys
tmp
usr
var

➜  /tmp # or use input
➜  /tmp pouch load -i test.tar test1
➜  /tmp pouch images
IMAGE ID       IMAGE NAME   SIZE
8ac48589692a   test1:1.28   710.83 KB
8ac48589692a   test:1.28    710.83 KB

➜  /tmp # or without name
➜  /tmp pouch load -i test.tar
➜  /tmp pouch images
IMAGE ID       IMAGE NAME             SIZE
8ac48589692a   unknown/unknown:1.28   710.83 KB
8ac48589692a   test:1.28              710.83 KB
8ac48589692a   test1:1.28             710.83 KB
```

NOTE: The oci.v1 spec says that the `org.opencontainers.image.ref.name` is used as tag in common. 
Based on this, we don't allow user to apply any name which contains digest or tag information.

```
➜  /tmp pouch load -i test.tar test:1
Error: {"message":"the image name should not contains any digest or tag information"}

➜  /tmp pouch load -i test.tar test@sha256:123
Error: {"message":"the image name should not contains any digest or tag information"}
```

### Ⅴ. Special notes for reviews

The output of `docker save` doesn't meet the oci.v1 spec and moby has the enhanced [issue](https://github.com/moby/moby/pull/33355) for this.

For now, this commit have not supported `docker image layout tar` yet. 
We need to implement `docker to oci` related tool to handle the gap between docker and pouchd.
