### PR TITLE
bugfix: panic when execute exec command with flag -d

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1528,12 +1528,12 @@ func (mgr *ContainerManager) openExecIO(id string, attach *AttachConfig) (*conta
 
 	options := []func(*containerio.Option){
 		containerio.WithID(id),
-		containerio.WithStdin(attach.Stdin),
-		containerio.WithMuxDisabled(attach.MuxDisabled),
 	}
 
 	if attach != nil {
 		options = append(options, attachConfigToOptions(attach)...)
+		options = append(options, containerio.WithStdin(attach.Stdin))
+		options = append(options, containerio.WithMuxDisabled(attach.MuxDisabled))
 	} else {
 		options = append(options, containerio.WithDiscard())
 	}
@@ -1551,11 +1551,11 @@ func (mgr *ContainerManager) openAttachIO(id string, attach *AttachConfig) (*con
 		containerio.WithID(id),
 		containerio.WithRootDir(rootDir),
 		containerio.WithJSONFile(),
-		containerio.WithStdin(attach.Stdin),
 	}
 
 	if attach != nil {
 		options = append(options, attachConfigToOptions(attach)...)
+		options = append(options, containerio.WithStdin(attach.Stdin))
 	} else {
 		options = append(options, containerio.WithDiscard())
 	}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

fix panic when execute `exec` command with flag `-d`

### Ⅱ. Does this pull request fix one issue?
fixes #1392 


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


