### PR TITLE
bugfix: use the stable image ID in test

### DIFF
--- a/test/api_image_inspect_test.go
+++ b/test/api_image_inspect_test.go
@@ -21,19 +21,27 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIImageInspectSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
-	PullImage(c, busyboxImage)
+	PullImage(c, fmt.Sprintf("%s:%s", environment.BusyboxRepo, "1.24"))
 }
 
 // TestImageInspectOk tests inspecting images is OK.
 func (suite *APIImageInspectSuite) TestImageInspectOk(c *check.C) {
-	repoID := environment.BusyboxID
-	repoTag, repoDigest := busyboxImage, fmt.Sprintf("%s@%s", environment.BusyboxRepo, environment.BusyboxDigest)
+	var (
+		repo = environment.BusyboxRepo
+		tag  = "1.24"
+
+		id  = "sha256:ca3d7d608b8a8bbaaac2c350bd0f9588cce0509ada74108d5c4b2afb24c46125"
+		dig = "sha256:840f2b98a2540ff1d265782c42543dbec7218d3ab0e73b296d7dac846f146e27"
+	)
+
+	repoTag := fmt.Sprintf("%s:%s", repo, tag)
+	repoDigest := fmt.Sprintf("%s@%s", repo, dig)
 
 	for _, image := range []string{
-		repoID,
+		id,
 		repoTag,
 		repoDigest,
-		fmt.Sprintf("%s:whatever@%s", environment.BusyboxRepo, environment.BusyboxDigest),
+		fmt.Sprintf("%s:whatever@%s", repo, dig),
 	} {
 		resp, err := request.Get("/images/" + image + "/json")
 		c.Assert(err, check.IsNil)
@@ -45,7 +53,7 @@ func (suite *APIImageInspectSuite) TestImageInspectOk(c *check.C) {
 
 		// TODO: More specific check is needed
 		c.Assert(got.Config, check.NotNil)
-		c.Assert(got.ID, check.Equals, repoID)
+		c.Assert(got.ID, check.Equals, id)
 		c.Assert(got.CreatedAt, check.NotNil)
 		c.Assert(got.Size, check.NotNil)
 		c.Assert(reflect.DeepEqual(got.RepoTags, []string{repoTag}), check.Equals, true)

--- a/test/environment/env.go
+++ b/test/environment/env.go
@@ -26,14 +26,8 @@ var (
 	// BusyboxRepo the repository of busybox image
 	BusyboxRepo = "registry.hub.docker.com/library/busybox"
 
-	// BusyboxID the digest ID used for busybox image
-	BusyboxID = "sha256:8ac48589692a53a9b8c2d1ceaa6b402665aa7fe667ba51ccc03002300856d8c7"
-
 	// BusyboxTag the tag used for busybox image
 	BusyboxTag = "1.28"
-
-	// BusyboxDigest the digest used for busybox image
-	BusyboxDigest = "sha256:58ac43b2cc92c687a32c8be6278e50a063579655fe3090125dcb2af0ff9e1a64"
 
 	// HelloworldRepo the repository of hello-world image
 	HelloworldRepo = "registry.hub.docker.com/library/hello-world"


### PR DESCRIPTION


Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

The busybox:1.28 has been repushed so that the imageID will be changed.
In order to make the test stable, we should use the stable image.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

NONE

### Ⅳ. Describe how to verify it

NONE

### Ⅴ. Special notes for reviews


