### PR TITLE
feature: add container's network files

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1787,6 +1787,11 @@ definitions:
         type: "boolean"
         x-nullable: false
         default: true
+      DisableNetworkFiles:
+        description: "Whether to generate the network files(/etc/hostname, /etc/hosts and /etc/resolv.conf) for container."
+        type: "boolean"
+        x-nullable: false
+        default: false
       ExposedPorts:
         description: "An object mapping ports to an empty object in the form:`{<port>/<tcp|udp>: {}}`"
         type: "object"

--- a/apis/types/container_config.go
+++ b/apis/types/container_config.go
@@ -35,6 +35,9 @@ type ContainerConfig struct {
 	// Command to run specified an array of strings.
 	Cmd []string `json:"Cmd"`
 
+	// Whether to generate the network files(/etc/hostname, /etc/hosts and /etc/resolv.conf) for container.
+	DisableNetworkFiles bool `json:"DisableNetworkFiles,omitempty"`
+
 	// Set disk quota for container
 	DiskQuota map[string]string `json:"DiskQuota,omitempty"`
 
@@ -125,6 +128,8 @@ type ContainerConfig struct {
 /* polymorph ContainerConfig AttachStdout false */
 
 /* polymorph ContainerConfig Cmd false */
+
+/* polymorph ContainerConfig DisableNetworkFiles false */
 
 /* polymorph ContainerConfig DiskQuota false */
 

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -34,6 +34,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringVar(&c.entrypoint, "entrypoint", "", "Overwrite the default ENTRYPOINT of the image")
 	flagSet.StringSliceVarP(&c.env, "env", "e", nil, "Set environment variables for container")
 	flagSet.StringVar(&c.hostname, "hostname", "", "Set container's hostname")
+	flagSet.BoolVar(&c.disableNetworkFiles, "disable-network-files", false, "Disable the generation of network files(/etc/hostname, /etc/hosts and /etc/resolv.conf) for container. If true, no network files will be generated. Default false")
 
 	// Intel RDT
 	flagSet.StringVar(&c.IntelRdtL3Cbm, "intel-rdt-l3-cbm", "", "Limit container resource for Intel RDT/CAT which introduced in Linux 4.10 kernel")

--- a/cli/container.go
+++ b/cli/container.go
@@ -10,19 +10,20 @@ import (
 )
 
 type container struct {
-	labels      []string
-	name        string
-	tty         bool
-	volume      []string
-	volumesFrom []string
-	runtime     string
-	env         []string
-	entrypoint  string
-	workdir     string
-	user        string
-	groupAdd    []string
-	hostname    string
-	rm          bool
+	labels              []string
+	name                string
+	tty                 bool
+	volume              []string
+	volumesFrom         []string
+	runtime             string
+	env                 []string
+	entrypoint          string
+	workdir             string
+	user                string
+	groupAdd            []string
+	hostname            string
+	rm                  bool
+	disableNetworkFiles bool
 
 	blkioWeight          uint16
 	blkioWeightDevice    WeightDevice
@@ -173,20 +174,21 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 
 	config := &types.ContainerCreateConfig{
 		ContainerConfig: types.ContainerConfig{
-			Tty:            c.tty,
-			Env:            c.env,
-			Entrypoint:     strings.Fields(c.entrypoint),
-			WorkingDir:     c.workdir,
-			User:           c.user,
-			Hostname:       strfmt.Hostname(c.hostname),
-			Labels:         labels,
-			Rich:           c.rich,
-			RichMode:       c.richMode,
-			InitScript:     c.initScript,
-			ExposedPorts:   ports,
-			DiskQuota:      diskQuota,
-			QuotaID:        c.quotaID,
-			SpecAnnotation: specAnnotation,
+			Tty:                 c.tty,
+			Env:                 c.env,
+			Entrypoint:          strings.Fields(c.entrypoint),
+			WorkingDir:          c.workdir,
+			User:                c.user,
+			Hostname:            strfmt.Hostname(c.hostname),
+			DisableNetworkFiles: c.disableNetworkFiles,
+			Labels:              labels,
+			Rich:                c.rich,
+			RichMode:            c.richMode,
+			InitScript:          c.initScript,
+			ExposedPorts:        ports,
+			DiskQuota:           diskQuota,
+			QuotaID:             c.quotaID,
+			SpecAnnotation:      specAnnotation,
 		},
 
 		HostConfig: &types.HostConfig{

--- a/cri/v1alpha1/cri_utils.go
+++ b/cri/v1alpha1/cri_utils.go
@@ -216,6 +216,9 @@ func applySandboxSecurityContext(lc *runtime.LinuxPodSandboxConfig, config *apit
 
 // applySandboxLinuxOptions applies LinuxPodSandboxConfig to pouch's HostConfig and ContainerCreateConfig.
 func applySandboxLinuxOptions(hc *apitypes.HostConfig, lc *runtime.LinuxPodSandboxConfig, createConfig *apitypes.ContainerCreateConfig, image string) error {
+	// apply the sandbox network_mode, "none" is default.
+	hc.NetworkMode = namespaceModeNone
+
 	if lc == nil {
 		return nil
 	}

--- a/cri/v1alpha2/cri_utils.go
+++ b/cri/v1alpha2/cri_utils.go
@@ -216,6 +216,9 @@ func applySandboxSecurityContext(lc *runtime.LinuxPodSandboxConfig, config *apit
 
 // applySandboxLinuxOptions applies LinuxPodSandboxConfig to pouch's HostConfig and ContainerCreateConfig.
 func applySandboxLinuxOptions(hc *apitypes.HostConfig, lc *runtime.LinuxPodSandboxConfig, createConfig *apitypes.ContainerCreateConfig, image string) error {
+	// apply the sandbox network_mode, "none" is default.
+	hc.NetworkMode = namespaceModeNone
+
 	if lc == nil {
 		return nil
 	}

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -250,6 +250,12 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 		return nil, errors.Wrap(errtypes.ErrAlreadyExisted, "container name: "+name)
 	}
 
+	// set hostname.
+	if config.Hostname.String() == "" {
+		// if hostname is empty, take the part of id as the hostname
+		config.Hostname = strfmt.Hostname(id[:12])
+	}
+
 	// set container runtime
 	if config.HostConfig.Runtime == "" {
 		config.HostConfig.Runtime = mgr.Config.DefaultRuntime
@@ -322,13 +328,12 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 	networkMode := config.HostConfig.NetworkMode
 	if networkMode == "" {
 		config.HostConfig.NetworkMode = "bridge"
-		container.Config.NetworkDisabled = true
 	}
 	container.NetworkSettings = new(types.NetworkSettings)
 	if len(config.NetworkingConfig.EndpointsConfig) > 0 {
 		container.NetworkSettings.Networks = config.NetworkingConfig.EndpointsConfig
 	}
-	if container.NetworkSettings.Networks == nil && networkMode != "" && !IsContainer(networkMode) {
+	if container.NetworkSettings.Networks == nil && !IsContainer(config.HostConfig.NetworkMode) {
 		container.NetworkSettings.Networks = make(map[string]*types.EndpointSettings)
 		container.NetworkSettings.Networks[config.HostConfig.NetworkMode] = new(types.EndpointSettings)
 	}
@@ -454,31 +459,51 @@ func (mgr *ContainerManager) start(ctx context.Context, c *Container, detachKeys
 		c.ResolvConfPath = origContainer.ResolvConfPath
 		c.Config.Hostname = origContainer.Config.Hostname
 		c.Config.Domainname = origContainer.Config.Domainname
-	}
+	} else {
+		// initialise host network mode
+		if IsHost(networkMode) {
+			hostname, err := os.Hostname()
+			if err != nil {
+				return err
+			}
+			c.Config.Hostname = strfmt.Hostname(hostname)
+		}
 
-	// initialise host network mode
-	if IsHost(networkMode) {
-		hostname, err := os.Hostname()
-		if err != nil {
+		// build the network related path.
+		if err := mgr.buildNetworkRelatedPath(c); err != nil {
 			return err
 		}
-		c.Config.Hostname = strfmt.Hostname(hostname)
-	}
 
-	// initialise network endpoint
-	if c.NetworkSettings != nil {
-		for name, endpointSetting := range c.NetworkSettings.Networks {
-			endpoint := mgr.buildContainerEndpoint(c)
-			endpoint.Name = name
-			endpoint.EndpointConfig = endpointSetting
-			if _, err := mgr.NetworkMgr.EndpointCreate(ctx, endpoint); err != nil {
-				logrus.Errorf("failed to create endpoint: %v", err)
-				return err
+		// initialise network endpoint
+		if c.NetworkSettings != nil {
+			for name, endpointSetting := range c.NetworkSettings.Networks {
+				endpoint := mgr.buildContainerEndpoint(c)
+				endpoint.Name = name
+				endpoint.EndpointConfig = endpointSetting
+				if _, err := mgr.NetworkMgr.EndpointCreate(ctx, endpoint); err != nil {
+					logrus.Errorf("failed to create endpoint: %v", err)
+					return err
+				}
 			}
 		}
 	}
 
 	return mgr.createContainerdContainer(ctx, c)
+}
+
+// buildNetworkRelatedPath builds the network related path.
+func (mgr *ContainerManager) buildNetworkRelatedPath(c *Container) error {
+	// set the hosts file path.
+	c.HostsPath = path.Join(mgr.Store.Path(c.ID), "hosts")
+
+	// set the resolv.conf file path.
+	c.ResolvConfPath = path.Join(mgr.Store.Path(c.ID), "resolv.conf")
+
+	// set the hostname file path.
+	c.HostnamePath = path.Join(mgr.Store.Path(c.ID), "hostname")
+
+	// write the hostname file, other files are filled by libnetwork.
+	return ioutil.WriteFile(c.HostnamePath, []byte(c.Config.Hostname+"\n"), 0644)
 }
 
 func (mgr *ContainerManager) createContainerdContainer(ctx context.Context, c *Container) error {

--- a/daemon/mgr/spec_mount.go
+++ b/daemon/mgr/spec_mount.go
@@ -3,8 +3,12 @@ package mgr
 import (
 	"context"
 	"fmt"
+	"os"
+
+	"github.com/alibaba/pouch/apis/types"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 )
 
 func clearReadonly(m *specs.Mount) {
@@ -31,6 +35,11 @@ func setupMounts(ctx context.Context, c *Container, s *specs.Spec) error {
 		return nil
 	}
 	for _, mp := range c.Mounts {
+		if trySetupNetworkMount(mp, c) {
+			// ignore the network mount, we will handle it later.
+			continue
+		}
+
 		// check duplicate mountpoint
 		for _, sm := range mounts {
 			if sm.Destination == mp.Destination {
@@ -69,6 +78,12 @@ func setupMounts(ctx context.Context, c *Container, s *specs.Spec) error {
 			Options:     opts,
 		})
 	}
+
+	// if disable hostfiles, we will not mount the hosts files into container.
+	if !c.Config.DisableNetworkFiles {
+		mounts = append(mounts, generateNetworkMounts(c)...)
+	}
+
 	s.Mounts = mounts
 
 	if c.HostConfig.Privileged {
@@ -82,4 +97,57 @@ func setupMounts(ctx context.Context, c *Container, s *specs.Spec) error {
 		}
 	}
 	return nil
+}
+
+// generateNetworkMounts will generate network mounts.
+func generateNetworkMounts(c *Container) []specs.Mount {
+	mounts := make([]specs.Mount, 0)
+
+	fileBinds := []struct {
+		Name   string
+		Source string
+		Dest   string
+	}{
+		{"HostnamePath", c.HostnamePath, "/etc/hostname"},
+		{"HostsPath", c.HostsPath, "/etc/hosts"},
+		{"ResolvConfPath", c.ResolvConfPath, "/etc/resolv.conf"},
+	}
+
+	for _, bind := range fileBinds {
+		if bind.Source != "" {
+			_, err := os.Stat(bind.Source)
+			if err != nil {
+				logrus.Warnf("%s set to %s, but stat error: %v, skip it", bind.Name, bind.Source, err)
+			} else {
+				mounts = append(mounts, specs.Mount{
+					Source:      bind.Source,
+					Destination: bind.Dest,
+					Type:        "bind",
+					Options:     []string{"rbind", "rprivate"},
+				})
+			}
+		}
+	}
+
+	return mounts
+}
+
+// trySetupNetworkMount will try to set network mount.
+func trySetupNetworkMount(mount *types.MountPoint, c *Container) bool {
+	if mount.Destination == "/etc/hostname" {
+		c.HostnamePath = mount.Source
+		return true
+	}
+
+	if mount.Destination == "/etc/hosts" {
+		c.HostsPath = mount.Source
+		return true
+	}
+
+	if mount.Destination == "/etc/resolv.conf" {
+		c.ResolvConfPath = mount.Source
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Now when we start a container,  it has no network files, including /etc/hosts, /etc/hostname and /etc/resolv.conf. In this PR, we will generate container's network files when container starts


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes https://github.com/alibaba/pouch/issues/1162

### Ⅲ. Describe how you did it

The libnetwork will help us generate network files(/etc/hosts and /etc/resolv.conf). /etc/hostname will be generated by pouchd.

At last, we should mount it into container.
 


### Ⅳ. Describe how to verify it

start a container,  and list /etc

```
# pouch run -it --hostname helloPouch  reg.docker.alibaba-inc.com/busybox:latest sh


BusyBox v1.21.1 (Ubuntu 1:1.21.0-1ubuntu1) built-in shell (ash)
Enter 'help' for a list of built-in commands.

~ # ls /etc/
group          hosts          passwd
hostname       nsswitch.conf  resolv.conf
```
check network files

```
~ # cat /etc/hostname
helloPouch
~ # cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.17.0.5	helloPouch
~ # ifconfig
eth0      Link encap:Ethernet  HWaddr 02:42:AC:11:00:05  
          inet addr:172.17.0.5  Bcast:0.0.0.0  Mask:255.255.255.0
          inet6 addr: fe80::42:acff:fe11:5/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:8 errors:0 dropped:0 overruns:0 frame:0
          TX packets:8 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0 
          RX bytes:648 (648.0 B)  TX bytes:648 (648.0 B)

lo        Link encap:Local Loopback  
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

~ # cat /etc/resolv.conf 
search DHCP
nameserver 127.0.0.11
options ndots:0
```


### Ⅴ. Special notes for reviews


