### PR TITLE
bugfix: containerd instance exit may cause container exit

### DIFF
--- a/ctrd/client.go
+++ b/ctrd/client.go
@@ -302,6 +302,10 @@ func (c *Client) Cleanup() error {
 		return err
 	}
 
+	// Note(ziren): notify containerd is dead before containerd
+	// is really dead
+	c.watch.setContainerdDead(true)
+
 	// Ask the daemon to quit
 	syscall.Kill(c.daemonPid, syscall.SIGTERM)
 


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>


### Ⅰ. Describe what this PR did
fix problem: container may be killed when containerd process exit

we use a channel to listen container's task status, when channel return, we think the container is quit in simple, so we will kill container and container's task.

but when we restart pouchd, it will cause all channels broken, so we `wrongly` judge container task exited, and will  kill running container.
```
time="2018-05-24T11:42:49.209164971+08:00" level=info msg="the task has quit, id: 5e487dbae0b37c8d2c83328c1a5cccc449645365b58036e3b5c4795b8bd86c6c, err: rpc error: code = Internal desc = transport is closing, exitcode: 255, time: 0001-01-01 00:00:00 +0000 UTC"
time="2018-05-24T11:42:49.209504432+08:00" level=error msg="failed to delete task, container id: 5e487dbae0b37c8d2c83328c1a5cccc449645365b58036e3b5c4795b8bd86c6c: grpc: the client connection is closing: failed precondition"
time="2018-05-24T11:42:49.209601826+08:00" level=error msg="failed to delete container, container id: 5e487dbae0b37c8d2c83328c1a5cccc449645365b58036e3b5c4795b8bd86c6c: grpc: the client connection is closing: failed precondition"
time="2018-05-24T11:42:49.577074167+08:00" level=info msg="close containerio backend: jsonfile, id: 5e487dbae0b37c8d2c83328c1a5cccc449645365b58036e3b5c4795b8bd86c6c"
time="2018-05-24T11:42:49.577130322+08:00" level=debug msg="%p after pop end wait %d %d %v&{{1 0} 0xc420d29200 0xc42169e4a0 0xc42169e4e0 true} 0 1 <nil>"
time="2018-05-24T11:42:49.577178302+08:00" level=info msg="finished to subscribe io, backend: jsonfile, id: 5e487dbae0b37c8d2c83328c1a5cccc449645365b58036e3b5c4795b8bd86c6c"
time="2018-05-24T11:42:49.577145494+08:00" level=debug msg="%p after pop end wait %d %d %v&{{9 0} 0xc420d29180 0xc42169e300 0xc42169e320 true} 0 1 <nil>"
time="2018-05-24T11:42:49.577199819+08:00" level=info msg="finished to subscribe io, backend: jsonfile, id: 5e487dbae0b37c8d2c83328c1a5cccc449645365b58036e3b5c4795b8bd86c6c"
time="2018-05-24T11:42:49.577213563+08:00" level=info msg="close containerio backend: jsonfile, id: 5e487dbae0b37c8d2c83328c1a5cccc449645365b58036e3b5c4795b8bd86c6c"
time="2018-05-24T11:42:49.577295216+08:00" level=debug msg="remove endpoint(0c8079230c201c1c63ca159798885fb0ac8ebeaf78fcd3e9b81bb0e84d491468) on network(bridge_11.160.218.247)"
time="2018-05-24T11:42:49.577385785+08:00" level=debug msg="Revoking external connectivity on endpoint 5e487dba (0c8079230c201c1c63ca159798885fb0ac8ebeaf78fcd3e9b81bb0e84d491468)"
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


