### PR TITLE
bugfix: change the option to set volume size

### DIFF
--- a/apis/server/volume_bridge.go
+++ b/apis/server/volume_bridge.go
@@ -47,24 +47,22 @@ func (s *Server) createVolume(ctx context.Context, rw http.ResponseWriter, req *
 		return err
 	}
 
+	status := map[string]interface{}{}
+	for k, v := range volume.Options() {
+		if k != "" && v != "" {
+			status[k] = v
+		}
+	}
+	status["size"] = volume.Size()
+
 	respVolume := types.VolumeInfo{
 		Name:       name,
 		Driver:     driver,
 		Labels:     config.Labels,
 		Mountpoint: volume.Path(),
+		Status:     status,
 		CreatedAt:  volume.CreationTimestamp.Format("2006-1-2 15:04:05"),
 	}
-
-	var status map[string]interface{}
-	for k, v := range volume.Options() {
-		if k != "" && v != "" {
-			if status == nil {
-				status = make(map[string]interface{})
-			}
-			status[k] = v
-		}
-	}
-	respVolume.Status = status
 
 	return EncodeResponse(rw, http.StatusCreated, respVolume)
 }
@@ -75,24 +73,23 @@ func (s *Server) getVolume(ctx context.Context, rw http.ResponseWriter, req *htt
 	if err != nil {
 		return err
 	}
+
+	status := map[string]interface{}{}
+	for k, v := range volume.Options() {
+		if k != "" && v != "" {
+			status[k] = v
+		}
+	}
+	status["size"] = volume.Size()
+
 	respVolume := types.VolumeInfo{
 		Name:       volume.Name,
 		Driver:     volume.Driver(),
 		Mountpoint: volume.Path(),
 		CreatedAt:  volume.CreateTime(),
 		Labels:     volume.Labels,
+		Status:     status,
 	}
-
-	var status map[string]interface{}
-	for k, v := range volume.Options() {
-		if k != "" && v != "" {
-			if status == nil {
-				status = make(map[string]interface{})
-			}
-			status[k] = v
-		}
-	}
-	respVolume.Status = status
 
 	return EncodeResponse(rw, http.StatusOK, respVolume)
 }
@@ -105,25 +102,22 @@ func (s *Server) listVolume(ctx context.Context, rw http.ResponseWriter, req *ht
 
 	respVolumes := types.VolumeListResp{Volumes: []*types.VolumeInfo{}, Warnings: nil}
 	for _, volume := range volumes {
+		status := map[string]interface{}{}
+		for k, v := range volume.Options() {
+			if k != "" && v != "" {
+				status[k] = v
+			}
+		}
+		status["size"] = volume.Size()
+
 		respVolume := &types.VolumeInfo{
 			Name:       volume.Name,
 			Driver:     volume.Driver(),
 			Mountpoint: volume.Path(),
 			CreatedAt:  volume.CreateTime(),
 			Labels:     volume.Labels,
+			Status:     status,
 		}
-
-		var status map[string]interface{}
-		for k, v := range volume.Options() {
-			if k != "" && v != "" {
-				if status == nil {
-					status = make(map[string]interface{})
-				}
-				status[k] = v
-			}
-		}
-		respVolume.Status = status
-
 		respVolumes.Volumes = append(respVolumes.Volumes, respVolume)
 	}
 	return EncodeResponse(rw, http.StatusOK, respVolumes)

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -959,7 +959,7 @@ paths:
                   Scope: "local"
                   Options:
                     device: "tmpfs"
-                    o: "size=100m,uid=1000"
+                    o: "opt.size=100m,uid=1000"
                     type: "tmpfs"
               Warnings: []
         500:

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -152,7 +152,7 @@ func parseVolume(volumeCreateConfig *types.VolumeCreateConfig, v *VolumeCreateCo
 
 // volumeCreateExample shows examples in volume create command, and is used in auto-generated cli docs.
 func volumeCreateExample() string {
-	return `$ pouch volume create -d local -n pouch-volume -o size=100g
+	return `$ pouch volume create -d local -n pouch-volume -o opt.size=100g
 Mountpoint:
 Name:         pouch-volume
 Scope:

--- a/storage/volume/modules/local/local.go
+++ b/storage/volume/modules/local/local.go
@@ -93,7 +93,7 @@ func (p *Local) Options() map[string]types.Option {
 func (p *Local) Attach(ctx driver.Context, v *types.Volume, s *types.Storage) error {
 	ctx.Log.Debugf("Local attach volume: %s", v.Name)
 	mountPath := v.Path()
-	size := v.Option("size")
+	size := v.Size()
 	reqID := v.Option("reqID")
 	ids := v.Option("ids")
 

--- a/test/cli_alikernel_test.go
+++ b/test/cli_alikernel_test.go
@@ -41,7 +41,7 @@ func (suite *PouchAliKernelSuite) TestAliKernelDiskQuotaWorks(c *check.C) {
 		funcname = tmpname[i]
 	}
 
-	command.PouchRun("volume", "create", "--name", funcname, "-d", "local", "-o", "size=1g").Assert(c, icmd.Success)
+	command.PouchRun("volume", "create", "--name", funcname, "-d", "local", "-o", "opt.size=1g").Assert(c, icmd.Success)
 	defer command.PouchRun("volume", "rm", funcname)
 
 	command.PouchRun("run", "-d", "-v", funcname+":/mnt", "--name", funcname, busyboxImage, "top").Assert(c, icmd.Success)
@@ -76,10 +76,10 @@ func (suite *PouchAliKernelSuite) TestAliKernelDiskQuotaMultiWorks(c *check.C) {
 	name1 := funcname + "1"
 	name2 := funcname + "2"
 
-	command.PouchRun("volume", "create", "--name", name1, "-d", "local", "-o", "size=2.2g").Assert(c, icmd.Success)
+	command.PouchRun("volume", "create", "--name", name1, "-d", "local", "-o", "opt.size=2.2g").Assert(c, icmd.Success)
 	defer command.PouchRun("volume", "rm", name1)
 
-	command.PouchRun("volume", "create", "--name", name2, "-d", "local", "-o", "size=3.2g").Assert(c, icmd.Success)
+	command.PouchRun("volume", "create", "--name", name2, "-d", "local", "-o", "opt.size=3.2g").Assert(c, icmd.Success)
 	defer command.PouchRun("volume", "rm", name2)
 
 	command.PouchRun("run", "-d", "-v", name1+":/mnt/test1", "-v", name2+":/mnt/test2", "--name", funcname, busyboxImage, "top").Assert(c, icmd.Success)

--- a/test/cli_run_volume_test.go
+++ b/test/cli_run_volume_test.go
@@ -180,7 +180,7 @@ func (suite *PouchRunVolumeSuite) TestRunWithDiskQuotaRegular(c *check.C) {
 	containerName := "diskquota-regular"
 
 	ret := command.PouchRun("volume", "create", "-n", volumeName,
-		"-o", "size=256m", "-o", "mount=/data/volume")
+		"-o", "opt.size=256m", "-o", "mount=/data/volume")
 	defer func() {
 		command.PouchRun("volume", "rm", volumeName).Assert(c, icmd.Success)
 	}()

--- a/test/cli_volume_test.go
+++ b/test/cli_volume_test.go
@@ -147,7 +147,7 @@ func (suite *PouchVolumeSuite) TestVolumeCreateWithSelector(c *check.C) {
 	defer command.PouchRun("volume", "remove", funcname)
 }
 
-// TestVolumeCreateWithSize tests creating volume with -o size=xxx.
+// TestVolumeCreateWithSize tests creating volume with -o opt.size=xxx.
 func (suite *PouchVolumeSuite) TestVolumeCreateWithSize(c *check.C) {
 	pc, _, _, _ := runtime.Caller(0)
 	tmpname := strings.Split(runtime.FuncForPC(pc).Name(), ".")
@@ -156,7 +156,7 @@ func (suite *PouchVolumeSuite) TestVolumeCreateWithSize(c *check.C) {
 		funcname = tmpname[i]
 	}
 
-	command.PouchRun("volume", "create", "--name", funcname, "-o", "size=1048576").Assert(c, icmd.Success)
+	command.PouchRun("volume", "create", "--name", funcname, "-o", "opt.size=1048576").Assert(c, icmd.Success)
 	defer command.PouchRun("volume", "remove", funcname)
 }
 
@@ -267,15 +267,15 @@ func (suite *PouchVolumeSuite) TestVolumeList(c *check.C) {
 
 	volumeName := "volume_" + funcname
 	volumeName1 := "volume_" + funcname + "_1"
-	command.PouchRun("volume", "create", "--name", volumeName1, "-o", "size=1g").Assert(c, icmd.Success)
+	command.PouchRun("volume", "create", "--name", volumeName1, "-o", "opt.size=1g").Assert(c, icmd.Success)
 	defer command.PouchRun("volume", "rm", volumeName1)
 
 	volumeName2 := "volume_" + funcname + "_2"
-	command.PouchRun("volume", "create", "--name", volumeName2, "-o", "size=2g").Assert(c, icmd.Success)
+	command.PouchRun("volume", "create", "--name", volumeName2, "-o", "opt.size=2g").Assert(c, icmd.Success)
 	defer command.PouchRun("volume", "rm", volumeName2)
 
 	volumeName3 := "volume_" + funcname + "_3"
-	command.PouchRun("volume", "create", "--name", volumeName3, "-o", "size=3g").Assert(c, icmd.Success)
+	command.PouchRun("volume", "create", "--name", volumeName3, "-o", "opt.size=3g").Assert(c, icmd.Success)
 	defer command.PouchRun("volume", "rm", volumeName3)
 
 	ret := command.PouchRun("volume", "list")
@@ -302,15 +302,15 @@ func (suite *PouchVolumeSuite) TestVolumeListOptions(c *check.C) {
 
 	volumeName := "volume_" + funcname
 	volumeName1 := "volume_" + funcname + "_1"
-	command.PouchRun("volume", "create", "--name", volumeName1, "-o", "size=1g").Assert(c, icmd.Success)
+	command.PouchRun("volume", "create", "--name", volumeName1, "-o", "opt.size=1g").Assert(c, icmd.Success)
 	defer command.PouchRun("volume", "rm", volumeName1)
 
 	volumeName2 := "volume_" + funcname + "_2"
-	command.PouchRun("volume", "create", "--name", volumeName2, "-o", "size=2g").Assert(c, icmd.Success)
+	command.PouchRun("volume", "create", "--name", volumeName2, "-o", "opt.size=2g").Assert(c, icmd.Success)
 	defer command.PouchRun("volume", "rm", volumeName2)
 
 	volumeName3 := "volume_" + funcname + "_3"
-	command.PouchRun("volume", "create", "--name", volumeName3, "-o", "size=3g").Assert(c, icmd.Success)
+	command.PouchRun("volume", "create", "--name", volumeName3, "-o", "opt.size=3g").Assert(c, icmd.Success)
 	defer command.PouchRun("volume", "rm", volumeName3)
 
 	ret := command.PouchRun("volume", "list", "--size", "--mountpoint")
@@ -319,7 +319,7 @@ func (suite *PouchVolumeSuite) TestVolumeListOptions(c *check.C) {
 	for _, line := range strings.Split(ret.Stdout(), "\n") {
 		if strings.Contains(line, volumeName) {
 			if !strings.Contains(line, "local") ||
-				!strings.Contains(line, "g") ||
+				!strings.Contains(line, "M") ||
 				!strings.Contains(line, DefaultVolumeMountPath) {
 				c.Errorf("list result have no driver or name or size or mountpoint, line: %s", line)
 				break


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Before use 'size' or 'opt.size' to set volume size, now change it to
'opt.size', 'size' will not effective.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1399 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
use this way to create volume
```
# pouch volume create -n diskquota -o opt.size=256m -o mount=/data/volume
```

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
