### PR TITLE
feature: travis doesn't run document-only changed commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,14 @@ notifications:
     on_error: always
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq autoconf automake
+  |
+    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)' || {
+      echo "travis doesn't run for document-only changed"
+      exit
+    }
+
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq autoconf automake
 
 env:
   - TEST_SUITE=integration-test


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

When the PR only changes the doc file, we should not run the integration test because it will take us so long to wait.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

Use `TRAVIS_COMMIT_RANGE` to make diff.

### Ⅳ. Describe how to verify it

NONE

### Ⅴ. Special notes for reviews


