### PR TITLE
test: sort image list before check

### DIFF
--- a/test/cli_images_test.go
+++ b/test/cli_images_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/alibaba/pouch/apis/types"
@@ -39,6 +40,12 @@ func (suite *PouchImagesSuite) TestImagesWorks(c *check.C) {
 	image, err := getImageInfo(apiClient, busyboxImage)
 	c.Assert(err, check.IsNil)
 
+	sortImageID := func(ids string) string {
+		idSlice := strings.Fields(ids)
+		sort.Strings(idSlice)
+		return strings.Join(idSlice, "\n")
+	}
+
 	// without flag
 	{
 		res := command.PouchRun("images").Assert(c, icmd.Success)
@@ -52,8 +59,10 @@ func (suite *PouchImagesSuite) TestImagesWorks(c *check.C) {
 		resQ := command.PouchRun("images", "-q").Assert(c, icmd.Success)
 		resQuiet := command.PouchRun("images", "--quiet").Assert(c, icmd.Success)
 
-		c.Assert(resQ.Combined(), check.Equals, resQuiet.Combined())
-		err := util.PartialEqual(strings.TrimSpace(resQ.Combined()), utils.TruncateID(image.ID))
+		qIDs, quietIDs := sortImageID(resQ.Combined()), sortImageID(resQuiet.Combined())
+
+		c.Assert(qIDs, check.Equals, quietIDs)
+		err := util.PartialEqual(strings.TrimSpace(qIDs), utils.TruncateID(image.ID))
 		c.Assert(err, check.IsNil)
 	}
 


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Since the image mgr return the images list in random order, in testing
we should sort before check and match.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

NONE

### Ⅳ. Describe how to verify it

NONE

### Ⅴ. Special notes for reviews


