### PR TITLE
bugfix: we must call Restore container after initialize network Mgr

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -176,6 +176,12 @@ func (d *Daemon) Run() error {
 	d.networkMgr = networkMgr
 	containerMgr.(*mgr.ContainerManager).NetworkMgr = networkMgr
 
+	// Notes(ziren): we must call containerMgr.Restore after NetworkMgr initialized,
+	// otherwize will panic
+	if err := containerMgr.Restore(ctx); err != nil {
+		return err
+	}
+
 	if err := d.addSystemLabels(); err != nil {
 		return err
 	}

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -49,6 +49,9 @@ import (
 type ContainerMgr interface {
 	// 1. the following functions are related to regular container management
 
+	// Restore containers from meta store to memory and recover those container.
+	Restore(ctx context.Context) error
+
 	// Create a new container.
 	Create(ctx context.Context, name string, config *types.ContainerCreateConfig) (*types.ContainerCreateResp, error)
 
@@ -176,7 +179,7 @@ func NewContainerManager(ctx context.Context, store *meta.Store, cli ctrd.APICli
 
 	go mgr.execProcessGC()
 
-	return mgr, mgr.Restore(ctx)
+	return mgr, nil
 }
 
 // Restore containers from meta store to memory and recover those container.


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

fix bug: containerMgr use the networkMgr struct before initialize it that will occur `panic: runtime error: invalid memory address or nil pointer dereference`

when start `pouchd`, we will call `containerMgr.Restore` to restore all running containers,  if the container has already exited but disk file record the status is `running`, we must  call `markStoppedAndRelease` method to clean the container's resources and mark it `stopped`.

`markStoppedAndRelease` method will call `containerMgr.networkMgr`, so if `networkMgr` not initialized, there will painc:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x17d2e14]

goroutine 47 [running]:
github.com/alibaba/pouch/daemon/mgr.(*ContainerManager).markStoppedAndRelease(0xc4200e03f0, 0xc4203a6000, 0x0, 0x1, 0x1)
	/tmp/pouchbuild/src/github.com/alibaba/pouch/daemon/mgr/container.go:1643 +0x324
github.com/alibaba/pouch/daemon/mgr.(*ContainerManager).Restore.func1(0x26b4a40, 0xc4203a6000, 0x9b6, 0x1c12bc0)
	/tmp/pouchbuild/src/github.com/alibaba/pouch/daemon/mgr/container.go:212 +0x5cf
github.com/alibaba/pouch/pkg/meta.(*Store).ForEach(0xc420297020, 0xc420288d00, 0xc420561cb0, 0xc420561ca0)
	/tmp/pouchbuild/src/github.com/alibaba/pouch/pkg/meta/store.go:197 +0x1e9
github.com/alibaba/pouch/daemon/mgr.(*ContainerManager).Restore(0xc4200e03f0, 0x26c9280, 0xc4201e6240, 0x1, 0xc4202fa990)
	/tmp/pouchbuild/src/github.com/alibaba/pouch/daemon/mgr/container.go:224 +0x8f
github.com/alibaba/pouch/daemon/mgr.NewContainerManager(0x26c9280, 0xc4201e6240, 0xc420297020, 0x26d34e0, 0xc420390140, 0x26ce480, 0xc4201e62c0, 0x26ce4e0, 0xc42000e0a0, 0x271a960, ...)
	/tmp/pouchbuild/src/github.com/alibaba/pouch/daemon/mgr/container.go:179 +0x509
github.com/alibaba/pouch/internal.GenContainerMgr(0x26c9280, 0xc4201e6240, 0x26cee40, 0xc420341540, 0xc42000e0a0, 0x0, 0x0, 0x0)
	/tmp/pouchbuild/src/github.com/alibaba/pouch/internal/generator.go:28 +0x1c7
github.com/alibaba/pouch/daemon.(*Daemon).Run(0xc420341540, 0x0, 0x0)
	/tmp/pouchbuild/src/github.com/alibaba/pouch/daemon/daemon.go:166 +0x22b
main.runDaemon.func2(0xc420296f00, 0xc420341540)
	/tmp/pouchbuild/src/github.com/alibaba/pouch/main.go:202 +0x2b
created by main.runDaemon
	/tmp/pouchbuild/src/github.com/alibaba/pouch/main.go:200 +0x5aa
```

### Ⅱ. Does this pull request fix one issue?
fixes #1421 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


