### PR TITLE
feature: add shellcheck to validate shell script

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,25 @@
+# This Dockerfile is used to build an image which is used in circle CI
+# to run the the following check or validation:
+# markdownlint
+# misspell
+# ShellCheck 
+FROM ubuntu:16.04
+
+RUN apt-get update \
+    && apt-get install -y rubygems git curl \
+    && gem install rake \
+    && gem install bundler \
+    && apt-get clean   
+
+# install markdownlint
+RUN git clone https://github.com/markdownlint/markdownlint.git \
+    && cd markdownlint && git checkout v0.4.0 && rake install
+
+# install misspell
+RUN git clone https://github.com/client9/misspell.git \
+    && cd misspell && curl -L -o ./install-misspell.sh https://git.io/misspell && sh ./install-misspell.sh
+
+RUN mv misspell/bin/misspell /usr/local/bin/
+
+# install shellcheck
+RUN apt-get install shellcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,10 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
-  misspell-and-markdown-lint:
+  markdownlint-misspell-shellcheck:
     docker:
-      - image: allencloud/mdlmisspell:v0.1
+      # this image is build from Dockerfile located in ./.circleci/Dockerfile
+      - image: allencloud/pouchlint:v0.1
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     steps:
       - checkout
@@ -15,7 +16,12 @@ jobs:
             find  ./ -name  "*.md" | grep -v vendor | grep -v extra |  grep -v commandline |  grep -v .github |  grep -v swagger |  grep -v api |  xargs mdl -r ~MD010,~MD013,~MD024,~MD029,~MD033,~MD036
       - run:
           name: use opensource tool client9/misspell to correct commonly misspelled English words 
-          command: find  ./* -name  "*"  | grep -v extra | grep -v vendor | xargs misspell -error 
+          command: |
+            find  ./* -name  "*"  | grep -v extra | grep -v vendor | xargs misspell -error
+      - run:
+          name: use ShellCheck (https://github.com/koalaman/shellcheck) to check the validateness of shell scripts in pouch repo
+          command: |
+            find ./ -name "*.sh" | grep -v vendor | grep -v extra | xargs shellcheck
 
   code-check:
     docker: 
@@ -52,6 +58,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - misspell-and-markdown-lint
+      - markdownlint-misspell-shellcheck
       - code-check
       - unit-test


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

use ShellCheck (https://github.com/koalaman/shellcheck) to check the validateness of shell scripts in pouch repo

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none, this pr enhances the validation of project files.


### Ⅲ. Describe how you did it
use ShellCheck (https://github.com/koalaman/shellcheck) to check the validateness
I installed the shellcheck via `apt-get install shellcheck`.
Also, we add a dockerfile for the image `pouchlint:v0.1`.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


