### PR TITLE
feature: add command column for pouch ps

### DIFF
--- a/cli/ps.go
+++ b/cli/ps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/alibaba/pouch/apis/types"
@@ -13,7 +14,7 @@ import (
 )
 
 // psDescription is used to describe ps command in detail and auto generate command doc.
-var psDescription = "\nList Containers with container name, ID, status, creation time, image reference and runtime."
+var psDescription = "\nList Containers with container name, ID, status, creation time, image reference, runtime and quoted command."
 
 // containerList is used to save the container list.
 type containerList []*types.Container
@@ -77,7 +78,7 @@ func (p *PsCommand) runPs(args []string) error {
 	}
 
 	display := p.cli.NewTableDisplay()
-	display.AddRow([]string{"Name", "ID", "Status", "Created", "Image", "Runtime"})
+	display.AddRow([]string{"Name", "ID", "Status", "Created", "Image", "Runtime", "Command"})
 
 	for _, c := range containers {
 		created, err := utils.FormatTimeInterval(c.Created)
@@ -90,7 +91,15 @@ func (p *PsCommand) runPs(args []string) error {
 			id = c.ID
 		}
 
-		display.AddRow([]string{c.Names[0], id, c.Status, created + " ago", c.Image, c.HostConfig.Runtime})
+		var command string
+		if len(c.Command) > 20 {
+			command = string([]byte(c.Command)[:17]) + "..."
+		} else {
+			command = c.Command
+		}
+		command = strings.Join([]string{`"`, command, `"`}, "")
+
+		display.AddRow([]string{c.Names[0], id, c.Status, created + " ago", c.Image, c.HostConfig.Runtime, command})
 	}
 	display.Flush()
 	return nil
@@ -99,15 +108,15 @@ func (p *PsCommand) runPs(args []string) error {
 // psExample shows examples in ps command, and is used in auto-generated cli docs.
 func psExample() string {
 	return `$ pouch ps
-Name   ID       Status          Created          Image                              Runtime
-2      e42c68   Up 15 minutes   16 minutes ago   docker.io/library/busybox:latest   runc
-1      a8c2ea   Up 16 minutes   17 minutes ago   docker.io/library/busybox:latest   runc
+Name   ID       Status          Created          Image                              Runtime   Command
+2      e42c68   Up 15 minutes   16 minutes ago   docker.io/library/busybox:latest   runc      "sh"
+1      a8c2ea   Up 16 minutes   17 minutes ago   docker.io/library/busybox:latest   runc      "sh"
 
 $ pouch ps -a
-Name   ID       Status          Created          Image                              Runtime
-3      faf132   created         16 seconds ago   docker.io/library/busybox:latest   runc
-2      e42c68   Up 16 minutes   16 minutes ago   docker.io/library/busybox:latest   runc
-1      a8c2ea   Up 17 minutes   18 minutes ago   docker.io/library/busybox:latest   runc
+Name   ID       Status          Created          Image                              Runtime   Command
+3      faf132   created         16 seconds ago   docker.io/library/busybox:latest   runc      "sh"
+2      e42c68   Up 16 minutes   16 minutes ago   docker.io/library/busybox:latest   runc      "sh"
+1      a8c2ea   Up 17 minutes   18 minutes ago   docker.io/library/busybox:latest   runc      "sh"
 
 $ pouch ps -q
 e42c68
@@ -119,19 +128,19 @@ e42c68
 a8c2ea
 
 $ pouch ps --no-trunc
-Name   ID                                                                 Status        Created        Image                            Runtime
-foo2   692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48   Up 1 minute   1 minute ago   docker.io/library/redis:alpine   runc
-foo    18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5   Up 1 minute   1 minute ago   docker.io/library/redis:alpine   runc
+Name   ID                                                                 Status        Created        Image                            Runtime   Command
+foo2   692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48   Up 1 minute   1 minute ago   docker.io/library/redis:alpine   runc      "sh"
+foo    18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5   Up 1 minute   1 minute ago   docker.io/library/redis:alpine   runc      "sh"
 
 $ pouch ps --no-trunc -q
 692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48
 18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5
 
 $ pouch ps --no-trunc -a
-Name   ID                                                                 Status         Created         Image                            Runtime
-foo3   63fd6371f3d614bb1ecad2780972d5975ca1ab534ec280c5f7d8f4c7b2e9989d   created        2 minutes ago   docker.io/library/redis:alpine   runc
-foo2   692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48   Up 2 minutes   2 minutes ago   docker.io/library/redis:alpine   runc
-foo    18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5   Up 2 minutes   2 minutes ago   docker.io/library/redis:alpine   runc
+Name   ID                                                                 Status         Created         Image                            Runtime   Command
+foo3   63fd6371f3d614bb1ecad2780972d5975ca1ab534ec280c5f7d8f4c7b2e9989d   created        2 minutes ago   docker.io/library/redis:alpine   runc      "sh"
+foo2   692c77587b38f60bbd91d986ec3703848d72aea5030e320d4988eb02aa3f9d48   Up 2 minutes   2 minutes ago   docker.io/library/redis:alpine   runc      "sh"
+foo    18592900006405ee64788bd108ef1de3d24dc3add73725891f4787d0f8e036f5   Up 2 minutes   2 minutes ago   docker.io/library/redis:alpine   runc      "sh"
 `
 }
 

--- a/test/cli_ps_test.go
+++ b/test/cli_ps_test.go
@@ -47,6 +47,7 @@ func (suite *PouchPsSuite) TestPsWorks(c *check.C) {
 
 		c.Assert(kv[name].status[0], check.Equals, "created")
 		c.Assert(kv[name].image, check.Equals, busyboxImage)
+		c.Assert(kv[name].command, check.Equals, `"top"`)
 	}
 
 	// running
@@ -139,6 +140,7 @@ type psTable struct {
 	created []string
 	image   string
 	runtime string
+	command string
 }
 
 // psToKV parse "pouch ps" into key-value mapping.
@@ -163,16 +165,19 @@ func psToKV(ps string) map[string]psTable {
 			pst.created = items[5:8]
 			pst.image = items[8]
 			pst.runtime = items[9]
+			pst.command = items[10]
 		} else if items[2] == "Stopped" || items[2] == "Exited" {
 			pst.status = items[2:6]
 			pst.created = items[6:9]
 			pst.image = items[9]
 			pst.runtime = items[10]
+			pst.command = items[11]
 		} else {
 			pst.status = items[2:3]
 			pst.created = items[3:6]
 			pst.image = items[6]
 			pst.runtime = items[7]
+			pst.command = items[8]
 		}
 		res[items[0]] = pst
 	}


### PR DESCRIPTION
Signed-off-by: xiechengsheng <XIE1995@whut.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
add command column for `pouch ps` client.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE.

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
```
$ pouch run -d --name=foo busybox top
$ pouch ps
Name   ID       Status         Created         Image                                            Runtime   Command
foo    a623be   Up 3 seconds   3 seconds ago   registry.hub.docker.com/library/busybox:latest   runc      "top"
```

### Ⅴ. Special notes for reviews


