### PR TITLE
fix: correct shell script format via shellcheck reports

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,25 @@
+# This Dockerfile is used to build an image which is used in circle CI
+# to run the the following check or validation:
+# markdownlint
+# misspell
+# ShellCheck 
+FROM ubuntu:16.04
+
+RUN apt-get update \
+    && apt-get install -y rubygems git curl \
+    && gem install rake \
+    && gem install bundler \
+    && apt-get clean   
+
+# install markdownlint
+RUN git clone https://github.com/markdownlint/markdownlint.git \
+    && cd markdownlint && git checkout v0.4.0 && rake install
+
+# install misspell
+RUN git clone https://github.com/client9/misspell.git \
+    && cd misspell && curl -L -o ./install-misspell.sh https://git.io/misspell && sh ./install-misspell.sh
+
+RUN mv misspell/bin/misspell /usr/local/bin/
+
+# install shellcheck
+RUN apt-get install shellcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,10 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
-  misspell-and-markdown-lint:
+  markdownlint-misspell-shellcheck:
     docker:
-      - image: allencloud/mdlmisspell:v0.1
+      # this image is build from Dockerfile located in ./.circleci/Dockerfile
+      - image: allencloud/pouchlint:v0.1
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     steps:
       - checkout
@@ -15,7 +16,12 @@ jobs:
             find  ./ -name  "*.md" | grep -v vendor | grep -v extra |  grep -v commandline |  grep -v .github |  grep -v swagger |  grep -v api |  xargs mdl -r ~MD010,~MD013,~MD024,~MD029,~MD033,~MD036
       - run:
           name: use opensource tool client9/misspell to correct commonly misspelled English words 
-          command: find  ./* -name  "*"  | grep -v extra | grep -v vendor | xargs misspell -error 
+          command: |
+            find  ./* -name  "*"  | grep -v extra | grep -v vendor | xargs misspell -error
+      - run:
+          name: use ShellCheck (https://github.com/koalaman/shellcheck) to check the validateness of shell scripts in pouch repo
+          command: |
+            find ./ -name "*.sh" | grep -v vendor | grep -v extra | xargs shellcheck
 
   code-check:
     docker: 
@@ -52,6 +58,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - misspell-and-markdown-lint
+      - markdownlint-misspell-shellcheck
       - code-check
       - unit-test

--- a/hack/cri-test/test-cri.sh
+++ b/hack/cri-test/test-cri.sh
@@ -17,7 +17,7 @@
 set -o nounset
 set -o pipefail
 
-source $(dirname "${BASH_SOURCE[0]}")/test-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/test-utils.sh"
 
 POUCH_SOCK="/var/run/pouchcri.sock"
 
@@ -42,8 +42,8 @@ GOPATH=${GOPATH%%:*}
 # Install CNI first
 mkdir -p /etc/cni/net.d /opt/cni/bin
 
-git clone https://github.com/containernetworking/plugins $GOPATH/src/github.com/containernetworking/plugins
-cd $GOPATH/src/github.com/containernetworking/plugins
+git clone https://github.com/containernetworking/plugins "$GOPATH/src/github.com/containernetworking/plugins"
+cd "$GOPATH/src/github.com/containernetworking/plugins"
 
 ./build.sh
 cp bin/* /opt/cni/bin
@@ -89,26 +89,26 @@ GINKGO=${GOPATH}/bin/ginkgo
 GINKGO_PKG=github.com/onsi/ginkgo/ginkgo
 
 # Install critest
-if [ ! -x "$(command -v ${CRITEST})" ]; then
+if [ ! -x "$(command -v "${CRITEST}")" ]; then
   go get -d ${CRITOOL_PKG}/...
-  cd ${GOPATH}/src/${CRITOOL_PKG}
+  cd "${GOPATH}/src/${CRITOOL_PKG}"
   git fetch --all
-  git checkout ${CRITOOL_VERSION}
+  git checkout "${CRITOOL_VERSION}"
   make
 fi
-which ${CRITEST}
+which "${CRITEST}"
 
 # Install ginkgo
-if [ ! -x "$(command -v ${GINKGO})" ]; then
+if [ ! -x "$(command -v "${GINKGO}")" ]; then
   go get -u ${GINKGO_PKG}
 fi
-which ${GINKGO}
+which "${GINKGO}"
 
-mkdir -p ${REPORT_DIR}
-test_setup ${REPORT_DIR}
+mkdir -p "${REPORT_DIR}"
+test_setup "${REPORT_DIR}"
 
 # Run cri validation test
-sudo env PATH=${PATH} GOPATH=${GOPATH} ${CRITEST} --runtime-endpoint=${POUCH_SOCK} --ginkgo.focus="${CRI_FOCUS}" --ginkgo.skip="${CRI_SKIP}"
+sudo env PATH="${PATH}" GOPATH="${GOPATH}" "${CRITEST}" --runtime-endpoint=${POUCH_SOCK} --ginkgo.focus="${CRI_FOCUS}" --ginkgo.skip="${CRI_SKIP}"
 test_exit_code=$?
 
 test_teardown

--- a/hack/cri-test/test-utils.sh
+++ b/hack/cri-test/test-utils.sh
@@ -15,13 +15,13 @@
 # limitations under the License.
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-. ${ROOT}/versions
+. "${ROOT}/versions"
 # POUCH_FLAGS are the extra flags to use when start pouchd.
 POUCH_FLAGS=${POUCH_FLAGS:-""}
 # RESTART_WAIT_PERIOD is the period to wait before restarting pouchd/containerd.
 RESTART_WAIT_PERIOD=${RESTART_WAIT_PERIOD:-10}
 
-POUCH_SOCK=/var/run/pouchcri.sock
+# POUCH_SOCK=/var/run/pouchcri.sock
 
 pouch_pid=
 containerd_pid=
@@ -35,10 +35,10 @@ test_setup() {
     echo "containerd is not installed, please run hack/make.sh"
     exit 1
   fi
-  containerd_pid_command=`pgrep containerd`
+  containerd_pid_command=$(pgrep containerd)
   containerd_pid=${containerd_pid_command}
   if [ ! -n "${containerd_pid}" ]; then
-    keepalive "/usr/local/bin/containerd" ${RESTART_WAIT_PERIOD} &> ${report_dir}/containerd.log &
+    keepalive "/usr/local/bin/containerd" "${RESTART_WAIT_PERIOD}" &> "${report_dir}/containerd.log" &
     containerd_pid=$!
   fi
   # Wait for containerd to be running by using the containerd client ctr to check the version
@@ -46,11 +46,11 @@ test_setup() {
   readiness_check "ctr version"
 
   # Start pouchd
-  pouch_pid_command=`pgrep pouchd`
+  pouch_pid_command=$(pgrep pouchd)
   pouch_pid=${pouch_pid_command}
   if [ ! -n "${pouch_pid}" ]; then
     keepalive "pouchd --enable-cri --sandbox-image=gcr.io/google_containers/pause-amd64:3.0 ${POUCH_FLAGS}" \
-	  ${RESTART_WAIT_PERIOD} &> ${report_dir}/pouch.log &
+	  "${RESTART_WAIT_PERIOD}" &> "${report_dir}/pouch.log" &
     pouch_pid=$!
   fi
   readiness_check "pouch version"
@@ -71,11 +71,11 @@ test_teardown() {
 # keepalive process is eventually killed in test_teardown.
 keepalive() {
   local command=$1
-  echo ${command}
+  echo "${command}"
   local wait_period=$2
   while true; do
     ${command}
-    sleep ${wait_period}
+    sleep "${wait_period}"
   done
 }
 

--- a/hack/generate-swagger-models.sh
+++ b/hack/generate-swagger-models.sh
@@ -7,4 +7,4 @@
 # Get the absolute path of this file
 DIR="$( cd "$( dirname "$0"  )" && pwd  )"
 
-swagger generate model -f $DIR/../apis/swagger.yml -t $DIR/../apis -m types
+swagger generate model -f "$DIR/../apis/swagger.yml" -t "$DIR/../apis" -m types

--- a/hack/install_lxcfs_on_centos.sh
+++ b/hack/install_lxcfs_on_centos.sh
@@ -5,14 +5,14 @@
 #
 
 yes | yum install autotools-dev m4 autoconf2.13 autobook autoconf-archive gnu-standards autoconf-doc libtool
-yes | yum install fuse-devel.$(uname -p)
-yes | yum install pam-devel.$(uname -p)
-yes | yum install fuse.$(uname -p)
+yes | yum install "fuse-devel.$(uname -p)"
+yes | yum install "pam-devel.$(uname -p)"
+yes | yum install "fuse.$(uname -p)"
 
 TMP=$(mktemp -d)
-trap "rm -rf $TMP" EXIT
+trap 'rm -rf "$TMP"' EXIT
 
-cd $TMP &&
+cd "$TMP" &&
 git clone -b stable-2.0 https://github.com/lxc/lxcfs.git &&
 cd lxcfs
 

--- a/hack/package/deb/build.sh
+++ b/hack/package/deb/build.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-TMP=$(mktemp -d /tmp/pouch.XXXXXX)
 DEFAULT_GPG_KEY=${GPGKEY:-"439AE9EC"}
 MOUNTDIR=/root/deb
 PACKAGEDIR=/root/deb/package/deb/
@@ -42,7 +41,7 @@ dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
 apt-ftparchive release ./ > Release
 
 # if you want to use your gpg key, you should replace '439AE9EC' with your key
-gpg -abs --default-key $DEFAULT_GPG_KEY -o Release.gpg Release
-gpg --clearsign --default-key $DEFAULT_GPG_KEY -o InRelease Release
+gpg -abs --default-key "$DEFAULT_GPG_KEY" -o Release.gpg Release
+gpg --clearsign --default-key "$DEFAULT_GPG_KEY" -o InRelease Release
 
 echo "Build deb package successfully! Please get the package in $PACKAGEDIR!"

--- a/hack/package/package.sh
+++ b/hack/package/package.sh
@@ -24,7 +24,7 @@ GITCOMMIT=$( git rev-parse HEAD )
 DIR="$( cd "$( dirname "$0" )/../.." && pwd )"
 
 # Replace Version, BuildTime and CommitID in version.go
-pushd $DIR
+pushd "$DIR"
 sed -i "s#^const Version.*#const Version = \"$VERSION\"#g" version/version.go
 sed -i "s#^var BuildTime.*#var BuildTime = \"$BUILDTIME\"#g" version/version.go
 sed -i "s#^var GitCommit.*#var GitCommit = \"$GITCOMMIT\"#g" version/version.go
@@ -32,25 +32,25 @@ sed -i "s#^var GitCommit.*#var GitCommit = \"$GITCOMMIT\"#g" version/version.go
 # build rpm packages
 function build_rpm() {
 	# build images
-	docker build --network host -t pouch:rpm -f $DIR/hack/package/rpm/centos-7/Dockerfile.x86_64 .
+	docker build --network host -t pouch:rpm -f "$DIR/hack/package/rpm/centos-7/Dockerfile.x86_64" .
 	(( $? != 0 )) && echo "failed to build pouch:rpm image." && exit 1
 
 	docker run --network host -it --rm \
 		-e VERSION="$VERSION" \
 		-e ITERATION="$ITERATION" \
-		-v $KEYDIR:/root/rpm \
+		-v "$KEYDIR:/root/rpm" \
 		pouch:rpm
 }
 
 # build deb packages
 function build_deb() {
 	# build images
-	docker build --network host -t pouch:deb -f $DIR/hack/package/deb/ubuntu-xenial/Dockerfile.x86_64 .
+	docker build --network host -t pouch:deb -f "$DIR/hack/package/deb/ubuntu-xenial/Dockerfile.x86_64" .
 	(( $? != 0 )) && echo "failed to build pouch:deb image." && exit 1
 
 	docker run --network host -it --rm \
 		-e VERSION="$VERSION" \
-		-v $KEYDIR/:/root/deb \
+		-v "$KEYDIR/:/root/deb" \
 		pouch:deb
 }
 

--- a/hack/package/rpm/build.sh
+++ b/hack/package/rpm/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -13,11 +13,11 @@ SERVICEDIR=$BASEDIR/pouch/hack/package/rpm/service
 SCRIPTSDIR=$BASEDIR/pouch/hack/package/rpm/scripts
 
 POUCHDIR=$TMP/source
-[ -d $POUCHDIR ] || mkdir -p $POUCHDIR
+[ -d "$POUCHDIR" ] || mkdir -p "$POUCHDIR"
 BINDIR=$POUCHDIR/bin
-[ -d $BINDIR ] || mkdir -p $BINDIR
+[ -d "$BINDIR" ] || mkdir -p "$BINDIR"
 LXC_DIR=$TMP/lxc
-[ -d $LXC_DIR ] || mkdir -p $LXC_DIR
+[ -d "$LXC_DIR" ] || mkdir -p "$LXC_DIR"
 
 # lxcfs stable branch
 LXC_BRANCH="stable-2.0"
@@ -30,16 +30,15 @@ CATEGORY='Tools/Pouch'
 # The maintainer of this package.
 MAINTAINER='Pouch pouch-dev@list.alibaba-inc.com'
 VENDOR='Pouch'
-SUMMARY='The open-source reliable application container engine.'
 
 # build lxcfs
 function build_lxcfs ()
 {
-    pushd $LXC_DIR
-    git clone -b $LXC_BRANCH https://github.com/lxc/lxcfs.git && cd lxcfs
+    pushd "$LXC_DIR"
+    git clone -b "$LXC_BRANCH" https://github.com/lxc/lxcfs.git && cd lxcfs
     ./bootstrap.sh > /dev/null 2>&1
     ./configure > /dev/null 2>&1
-    make install DESTDIR=$LXC_DIR > /dev/null 2>&1
+    make install DESTDIR="$LXC_DIR" > /dev/null 2>&1
     popd
 }
 
@@ -48,19 +47,19 @@ function build_pouch()
 {
     # install containerd
     echo "Downloading containerd."
-    wget --quiet https://github.com/containerd/containerd/releases/download/v1.0.3/containerd-1.0.3.linux-amd64.tar.gz -P $TMP
-    tar xf $TMP/containerd-1.0.3.linux-amd64.tar.gz -C $TMP && cp -f $TMP/bin/* $BINDIR/
+    wget --quiet https://github.com/containerd/containerd/releases/download/v1.0.3/containerd-1.0.3.linux-amd64.tar.gz -P "$TMP"
+    tar xf "$TMP/containerd-1.0.3.linux-amd64.tar.gz -C $TMP && cp -f $TMP/bin/* $BINDIR/"
 
     # install runc
     echo "Downloading runc."
-    wget --quiet https://github.com/alibaba/runc/releases/download/v1.0.0-rc4-1/runc.amd64 -P $BINDIR/
-    chmod +x $BINDIR/runc.amd64
-    mv $BINDIR/runc.amd64 $BINDIR/runc
+    wget --quiet https://github.com/alibaba/runc/releases/download/v1.0.0-rc4-1/runc.amd64 -P "$BINDIR/"
+    chmod +x "$BINDIR/runc.amd64"
+    mv "$BINDIR/runc.amd64" "$BINDIR/runc"
 
     # build pouch
     echo "Building pouch."
     pushd $BASEDIR/pouch
-    make install DESTDIR=$POUCHDIR
+    make install DESTDIR="$POUCHDIR"
     popd
 }
 
@@ -79,13 +78,13 @@ function build_rpm ()
     fpm -f -s dir \
           -t rpm \
           -n pouch \
-          -v $VERSION \
-          --iteration $ITERATION \
-          -a $ARCHITECTURE \
-          -p $PACKAGEDIR \
+          -v "$VERSION" \
+          --iteration "$ITERATION" \
+          -a "$ARCHITECTURE" \
+          -p "$PACKAGEDIR" \
           --description 'Pouch is an open-source project created by Alibaba Group to promote the container technology movement.
 
-    Pouchs vision is to advance container ecosystem and promote container standards OCI, so that container technologies become the foundation for application development in the Cloud era.
+    Pouch'"'"'s vision is to advance container ecosystem and promote container standards OCI, so that container technologies become the foundation for application development in the Cloud era.
 
     Pouch can pack, deliver and run any application. It provides applications with a lightweight runtime environment with strong isolation and minimal overhead. Pouch isolates applications from varying runtime environment, and minimizes operational workload. Pouch minimizes the effort for application developers to write Cloud-native applications, or to migrate legacy ones to a Cloud platform.' \
           --url 'https://github.com/alibaba/pouch' \
@@ -94,21 +93,21 @@ function build_rpm ()
           --before-remove $SCRIPTSDIR/before-remove.sh \
           --after-remove $SCRIPTSDIR/after-remove.sh \
           --rpm-posttrans $SCRIPTSDIR/after-trans.sh \
-          --license 'Apache License 2.0' \
+          --license "$LICENSE" \
           --verbose \
-          --category 'Tools/Pouch' \
-          -m 'Pouch pouch-dev@list.alibaba-inc.com' \
-          --vendor Pouch \
+          --category "$CATEGORY" \
+          -m "$MAINTAINER" \
+          --vendor "$VENDOR" \
           --rpm-sign \
           -d pam-devel \
           -d fuse-devel \
           -d fuse-libs \
           -d fuse \
-          $BINDIR/=/usr/local/bin/ \
-          $SERVICEDIR/=/usr/lib/systemd/system/ \
-          $LXC_DIR/usr/local/bin/lxcfs=/usr/bin/lxcfs \
-          $LXC_DIR/usr/local/lib/lxcfs/liblxcfs.so=/usr/lib64/liblxcfs.so \
-          $LXC_DIR/usr/local/share/=/usr/share
+          "$BINDIR/"=/usr/local/bin/ \
+          "$SERVICEDIR/"=/usr/lib/systemd/system/ \
+          "$LXC_DIR/usr/local/bin/lxcfs"=/usr/bin/lxcfs \
+          "$LXC_DIR/usr/local/lib/lxcfs/liblxcfs.so"=/usr/lib64/liblxcfs.so \
+          "$LXC_DIR/usr/local/share/"=/usr/share
 
 }
 

--- a/hack/package/rpm/scripts/after-install.sh
+++ b/hack/package/rpm/scripts/after-install.sh
@@ -1,4 +1,5 @@
-if [ $1 -eq 1 ] ; then
+#!/usr/bin/env bash
+if [ "$1" -eq 1 ] ; then
 	systemctl preset pouch > /dev/null 2>&1
 	
 fi

--- a/hack/package/rpm/scripts/after-remove.sh
+++ b/hack/package/rpm/scripts/after-remove.sh
@@ -1,4 +1,5 @@
+#!/usr/bin/env bash
 systemctl daemon-reload > /dev/null 2>&1
-if [ $1 -ge 1 ] ; then
+if [ "$1" -ge 1 ] ; then
 	systemctl try-restart pouch > /dev/null 2>&1
 fi

--- a/hack/package/rpm/scripts/after-trans.sh
+++ b/hack/package/rpm/scripts/after-trans.sh
@@ -1,8 +1,8 @@
-if [ $1 -ge 0 ] ; then
+#!/usr/bin/env bash
+if [ "$1" -ge 0 ] ; then
 	# check if pouch is running before upgrade
 	if [ -f /var/lib/rpm-state/pouch-is-active ] ; then
 		systemctl start pouch > /dev/null 2>&1
 		rm -f /var/lib/rpm-state/pouch-is-active > /dev/null 2>&1
 	fi
 fi
-

--- a/hack/package/rpm/scripts/before-install.sh
+++ b/hack/package/rpm/scripts/before-install.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 if [ "$1" -gt 0 ] ; then
 	rm -f /var/lib/rpm-state/pouch-is-active > /dev/null 2>&1
 	if systemctl is-active pouch > /dev/null 2>&1 ; then

--- a/hack/package/rpm/scripts/before-remove.sh
+++ b/hack/package/rpm/scripts/before-remove.sh
@@ -1,4 +1,5 @@
-if [ $1 -eq 0 ] ; then
+#!/usr/bin/env bash
+if [ "$1" -eq 0 ] ; then
 	# Package removal
 	systemctl --no-reload disable pouch > /dev/null 2>&1
 	systemctl stop pouch > /dev/null 2>&1

--- a/hack/vagrant/bootstrap.sh
+++ b/hack/vagrant/bootstrap.sh
@@ -31,13 +31,16 @@ install_go(){
     git clone --depth=1 https://github.com/syndbg/goenv.git ~/.goenv
 
     PROFILE="$HOME/.bashrc"
-    echo 'export GOENV_ROOT="$HOME/.goenv"' >> $PROFILE
-    echo 'export PATH="$GOENV_ROOT/bin:$PATH"' >> $PROFILE
-    echo 'eval "$(goenv init -)"' >> $PROFILE
-    echo 'export GOPATH="/go"' >> $PROFILE
+    # shellcheck disable=SC2016
+    echo 'export GOENV_ROOT="$HOME/.goenv"' >> "$PROFILE"
+    # shellcheck disable=SC2016
+    echo 'export PATH="$GOENV_ROOT/bin:$PATH"' >> "$PROFILE"
+    # shellcheck disable=SC2016
+    echo 'eval "$(goenv init -)"' >> "$PROFILE"
+    echo 'export GOPATH="/go"' >> "$PROFILE"
 
-    $HOME/.goenv/bin/goenv install $GOVERSION
-    $HOME/.goenv/bin/goenv global $GOVERSION
+    "$HOME/.goenv/bin/goenv" install "$GOVERSION"
+    "$HOME/.goenv/bin/goenv" global "$GOVERSION"
 }
 
 # install_docker install docker with get.docker.com's shell script


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This PR help pouch to pass the ShellCheck (https://github.com/koalaman/shellcheck). There is a short report.

SC2086 Double quote to prevent globbing and word splitting **94** fail(s)
SC2046 Quote this to prevent word splitting **8** fail(s)
SC2034 POUCH_SOCK appears unused. Verify it or export it **7** fail(s)
SC2039 In POSIX sh, 'pushd' is not supported **6** fail(s)
SC2148 Tips depend on target shell and yours is unknown. Add a shebang **5** fail(s)
SC2112 'function' keyword is non-standard. Delete it **4** fail(s)
SC2016 Expressions don't expand in single quotes, use double quotes for that **3** fail(s)
SC2006 Use $(..) instead of legacy `..` **2** fail(s)
SC2129 Consider using { cmd1; cmd2; } >> file instead of individual redirects **1** fail(s)
SC2071 < is for string comparisons. Use -lt instead **1** fail(s)
SC2068 Double quote array expansions, otherwise they're like $* and break on spaces **1** fail(s)
SC2064 Use single quotes, otherwise this expands now rather than when signalled **1** fail(s)

You can find the detailed rules [here](https://github.com/koalaman/shellcheck/wiki)

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it

ShellCheck don't report error. 
```bash
find ./ -name "*.sh" | grep -v vendor | grep -v extra | xargs shellcheck
```
Shell script still works fine.

### Ⅴ. Special notes for reviews

In rule SC2086
> When quoting composite arguments, make sure to exclude globs and brace expansions, which lose their special meaning in double quotes: "$HOME/$dir/src/\*.c" will not expand, but "$HOME/$dir/src"/\*.c will.
