### PR TITLE
enhance: add more log for creating new objects

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -39,6 +39,8 @@ func (s *Server) createContainer(ctx context.Context, rw http.ResponseWriter, re
 		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
 
+	logCreateOptions("container", config)
+
 	name := req.FormValue("name")
 
 	// to do compensation to potential nil pointer after validation

--- a/apis/server/network_bridge.go
+++ b/apis/server/network_bridge.go
@@ -25,6 +25,8 @@ func (s *Server) createNetwork(ctx context.Context, rw http.ResponseWriter, req 
 		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
 
+	logCreateOptions("network", config)
+
 	network, err := s.NetworkMgr.Create(ctx, *config)
 	if err != nil {
 		return err

--- a/apis/server/utils.go
+++ b/apis/server/utils.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -88,5 +89,15 @@ func writeLogStream(ctx context.Context, w io.Writer, tty bool, opt *types.Conta
 				}
 			}
 		}
+	}
+}
+
+// logCreateOptions will print create args in pouchd logs for debugging.
+func logCreateOptions(objType string, config interface{}) {
+	args, err := json.Marshal(config)
+	if err != nil {
+		logrus.Errorf("failed to marsal config for %s: %v", objType, err)
+	} else {
+		logrus.Infof("create %s with args: %v", objType, string(args))
 	}
 }

--- a/apis/server/volume_bridge.go
+++ b/apis/server/volume_bridge.go
@@ -25,6 +25,8 @@ func (s *Server) createVolume(ctx context.Context, rw http.ResponseWriter, req *
 		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
 
+	logCreateOptions("volume", config)
+
 	name := config.Name
 	driver := config.Driver
 	options := config.DriverOpts


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This pr adds more log on pouchd side. While creating a new container, network or volume, create args will be printed on pouchd log, which enables us to debug a possible creation failure on API side.

```Infof()``` is adopted since we think it is better for production environment, than ```Debugf()```.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #664

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
```
INFO[2018-06-01T07:45:48.197062353Z] Calling POST /v1.24/volumes/create, client @ 
INFO[2018-06-01T07:45:48.197302776Z] create volume with args: {"Driver":"local","DriverOpts":{"opt.size":"100g"},"Name":"pouch-volume"}
```
```
INFO[2018-06-01T07:46:52.219091382Z] Calling POST /v1.24/networks/create, client @ 
INFO[2018-06-01T07:46:52.219286598Z] create network with args: {"Name":"pouchnet","CheckDuplicate":true,"Driver":"bridge","IPAM":{"Config":[{"Gateway":"192.168.1.1","Subnet":"192.168.1.0/24"}],"Driver":"default"}} 
```
```
INFO[2018-06-01T07:48:13.014402291Z] Calling POST /v1.24/containers/create?name=foo, client @ 
INFO[2018-06-01T07:48:13.01545681Z] create container with args: {"Cmd":null,"Entrypoint":[],"Env":null,"Image":"docker.io/library/busybox:latest","OnBuild":null,"Shell":null,"HostConfig":{"NetworkMode":"bridge","OomScoreAdj":-500,"RestartPolicy":{"Name":"no"},"BlkioDeviceReadBps":null,"BlkioDeviceReadIOps":null,"BlkioDeviceWriteBps":null,"BlkioDeviceWriteIOps":null,"BlkioWeightDevice":null,"DeviceCgroupRules":null,"Devices":[],"MemoryExtra":0,"MemorySwappiness":-1,"MemoryWmarkRatio":0,"OomKillDisable":false,"Ulimits":null},"NetworkingConfig":{}} 
```

### Ⅴ. Special notes for reviews
Thx for your hints! 😄 @shaloulcy 

