### PR TITLE
stdio: add stdin fifo

### DIFF
--- a/daemon/containerio/cio.go
+++ b/daemon/containerio/cio.go
@@ -63,9 +63,12 @@ func NewFifos(id string, stdin bool) (*containerdio.FIFOSet, error) {
 		Err: filepath.Join(dir, id+"-stderr"),
 	}
 
-	if !stdin {
-		fifos.In = ""
-	}
+	/*
+		NOTE(tanghuamin): for compatible docker 1.12
+		if !stdin {
+			fifos.In = ""
+		}
+	*/
 
 	return fifos, nil
 }

--- a/daemon/containerio/container_io.go
+++ b/daemon/containerio/container_io.go
@@ -52,12 +52,16 @@ func NewIO(opt *Option) *IO {
 	i := &IO{
 		Stdout:      create(opt, stdout, backends),
 		Stderr:      create(opt, stderr, backends),
+		Stdin:       create(opt, stdin, backends),
 		MuxDisabled: opt.muxDisabled,
 	}
 
-	if opt.stdin {
-		i.Stdin = create(opt, stdin, backends)
-	}
+	/*
+		NOTE(tanghuamin): for compatible docker 1.12
+		if opt.stdin {
+			i.Stdin = create(opt, stdin, backends)
+		}
+	*/
 
 	return i
 }


### PR DESCRIPTION
we should add stdin fifo for compatible of docker 1.12

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


