### PR TITLE
if run sandbox failed, clean up; deduplicate the default mounts with user defined ones

### DIFF
--- a/daemon/mgr/spec_mount.go
+++ b/daemon/mgr/spec_mount.go
@@ -23,8 +23,23 @@ func clearReadonly(m *specs.Mount) {
 
 // setupMounts create mount spec.
 func setupMounts(ctx context.Context, c *Container, s *specs.Spec) error {
+	var mounts []specs.Mount
+	// Override the default mounts which are duplicate with user defined ones.
+	for _, sm := range s.Mounts {
+		dup := false
+		for _, cm := range c.Mounts {
+			if sm.Destination == cm.Destination {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		mounts = append(mounts, sm)
+	}
 	// TODO: we can suggest containerd to add the cgroup into the default spec.
-	mounts := append(s.Mounts, specs.Mount{
+	mounts = append(mounts, specs.Mount{
 		Destination: "/sys/fs/cgroup",
 		Type:        "cgroup",
 		Source:      "cgroup",


### PR DESCRIPTION


Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

When I try to launch a pod of flannel, there are two problems:

1. flannel pod will mount the `/run` in the host to the container's `/run`, which is duplicate with the default mounts created by pouchd and we should override the default one.

2. When an error occurred in the process of running a sandbox (for example, network not initialized), we should delete the running sandbox container. Otherwise kubelet will list the sandboxes and to wrongly assume the error sandbox is running which is not expected.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


