### PR TITLE
bugfix: network not found

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -169,18 +169,16 @@ func (d *Daemon) Run() error {
 	}
 	d.containerMgr = containerMgr
 
+	if err := containerMgr.Restore(ctx); err != nil {
+		return err
+	}
+
 	networkMgr, err := internal.GenNetworkMgr(d.config, d)
 	if err != nil {
 		return err
 	}
 	d.networkMgr = networkMgr
 	containerMgr.(*mgr.ContainerManager).NetworkMgr = networkMgr
-
-	// Notes(ziren): we must call containerMgr.Restore after NetworkMgr initialized,
-	// otherwize will panic
-	if err := containerMgr.Restore(ctx); err != nil {
-		return err
-	}
 
 	if err := d.addSystemLabels(); err != nil {
 		return err

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1939,6 +1939,15 @@ func (mgr *ContainerManager) releaseContainerResources(c *Container) error {
 func (mgr *ContainerManager) releaseContainerNetwork(c *Container) error {
 	c.Lock()
 	defer c.Unlock()
+
+	// NetworkMgr is nil, which means the pouch daemon is initializing.
+	// And the libnetwork will also initialize, which will release all
+	// staled network resources(endpoint, network and namespace). So we
+	// don't need release the network resources.
+	if mgr.NetworkMgr == nil {
+		return nil
+	}
+
 	if c.NetworkSettings == nil {
 		return nil
 	}

--- a/daemon/mgr/network.go
+++ b/daemon/mgr/network.go
@@ -284,6 +284,12 @@ func (nm *NetworkManager) EndpointCreate(ctx context.Context, endpoint *types.En
 	}
 
 	endpointName := containerID[:8]
+
+	// ensure the endpoint has been deleted before creating
+	if ep, _ := n.EndpointByName(endpointName); ep != nil {
+		ep.Delete(true)
+	}
+
 	ep, err := n.CreateEndpoint(endpointName, epOptions...)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
the network manager must be initialized after container manager has restored all containers, as the network manager need to get the real ActiveSandboxes which are returned by container manager?

Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

the network manager must be initialized after container manager has restored all containers, as the network manager need to get the real ActiveSandboxes which are returned by container manager?

what is real ActiveSandboxes?  

For example,  a container is running. Then we reboot the OS, the container status in metadata is running. But actually it is stopped. We must restore all containers,  then we can get the real container status


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixed #1439 


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


