### PR TITLE
feature: support creating container by just specifying rootfs

### DIFF
--- a/ctrd/container_types.go
+++ b/ctrd/container_types.go
@@ -6,13 +6,22 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-// Container wraps container's info.
+// Container wraps container's info. there have two kind of containers now:
+// One is created by pouch: first using image to create snapshot,
+// then create container by specifying the snapshot;
+// The other is create container by specify container rootfs, we use `RootFSProvided` flag to mark it,
 type Container struct {
 	ID      string
 	Image   string
 	Runtime string
 	IO      *containerio.IO
 	Spec    *specs.Spec
+
+	// BaseFS is rootfs used by containerd container
+	BaseFS string
+
+	// RootFSProvided is a flag to point the container is created by specifying rootfs
+	RootFSProvided bool
 }
 
 // Process wraps exec process's info.

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -180,6 +180,9 @@ type Container struct {
 
 	// Escape keys for detach
 	DetachKeys string
+
+	// RootFSProvided is a flag to point the container is created by specify rootfs
+	RootFSProvided bool
 }
 
 // Key returns container's id.

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -1,0 +1,31 @@
+package mount
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// IsLikelyNotMountPoint determines if a directory is not a mountpoint.
+// It is fast but not necessarily ALWAYS correct. If the path is in fact
+// a bind mount from one part of a mount to another it will not be detected.
+// mkdir /tmp/a /tmp/b; mount --bin /tmp/a /tmp/b; IsLikelyNotMountPoint("/tmp/b")
+// will return true. When in fact /tmp/b is a mount point. If this situation
+// if of interest to you, don't use this function...
+func IsLikelyNotMountPoint(file string) (bool, error) {
+	stat, err := os.Stat(file)
+	if err != nil {
+		return true, err
+	}
+	rootStat, err := os.Lstat(filepath.Dir(strings.TrimSuffix(file, "/")))
+	if err != nil {
+		return true, err
+	}
+	// If the directory has a different device as parent, then it is a mountpoint.
+	if stat.Sys().(*syscall.Stat_t).Dev != rootStat.Sys().(*syscall.Stat_t).Dev {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -1,0 +1,29 @@
+package mount
+
+import "testing"
+
+func TestIsLikelyNotMountPoint(t *testing.T) {
+	type args struct {
+		file string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsLikelyNotMountPoint(tt.args.file)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsLikelyNotMountPoint() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsLikelyNotMountPoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

Actually, the containerd support creating a container by just specifying the container rootfs, the feature is very useful when we want to take over the container created by other container hypervisor.

in order to distinguish container that created by specifying rootfs or snapshot, we add a flag `RootFSProvided`, when the flag set, the container is created by just specifying rootfs.

this feature is also needed by upgrade docker to PouchContainer,  we must support taking over containers created by docker

we also should consider the abnormal situations like host crashed etc. so when starting a `RootFSProvided` container , we should check if the `rootfs` has mounted, if not, we must mount it. 



### Ⅱ. Does this pull request fix one issue?



### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


