### PR TITLE
bugfix: fix pouch not restore containerd when containerd killed unexpectly

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -36,6 +36,10 @@ type containerPack struct {
 	// client is to record which stream client the container connect with
 	client        *WrapperClient
 	skipStopHooks bool
+
+	// done used when contianerd get accident and dead, task info is connect
+	// to the dead containerd, so the task should be restored.
+	done bool
 }
 
 // ExecContainer executes a process in container.


### PR DESCRIPTION
fix pouch not restore containerd when it get accident，refactor
the way in wait task exit, detail is in
https://github.com/alibaba/pouch/issues/1460

Fixes: #1460

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


