### PR TITLE
feature: add make help into makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ lint: ## run go lint
 	@test -z "$$(golint ./... | grep -Fv 'vendor/' | grep -Fv 'extra' | grep -v ".pb.go:" | tee /dev/stderr)"
 
 .PHONY: vet
-vet: # run go vet
+vet: ## run go vet
 	@echo $@
 	@test -z "$$(./hack/build vet)"
 
@@ -83,7 +83,7 @@ modules:
 # install them to /usr/local/bin/
 # remove binaries
 .PHONY: install
-install: build
+install: build ## build and install binary into /usr/local/bin
 	@echo $@
 	@echo "installing $(BINARY_NAME) and $(CLI_BINARY_NAME) to $(DESTDIR)/bin"
 	@mkdir -p $(DESTDIR)/bin
@@ -91,7 +91,7 @@ install: build
 	@install $(CLI_BINARY_NAME) $(DESTDIR)/bin
 
 .PHONY: uninstall
-uninstall:
+uninstall: ## uninstall pouchd and pouch binary
 	@echo $@
 	@rm -f $(addprefix $(DESTDIR)/bin/,$(notdir $(BINARY_NAME)))
 	@rm -f $(addprefix $(DESTDIR)/bin/,$(notdir $(CLI_BINARY_NAME)))
@@ -99,13 +99,17 @@ uninstall:
 # For integration-test and test, PATH is not set under sudo, then we set up path mannually.
 # Ref https://unix.stackexchange.com/questions/83191/how-to-make-sudo-preserve-path
 .PHONY: integration-test
-integration-test:
+integration-test: ## build binary and run integration-test
 	@bash -c "env PATH=$(PATH) hack/make.sh build integration-test"
 
 .PHONY: cri-test
-cri-test:
+cri-test: ## build binary and run cri-test
 	@bash -c "env PATH=$(PATH) hack/make.sh build cri-test"
 
 .PHONY: test
-test:
+test: ## run the build integration-test cri-test
 	@bash -c "env PATH=$(PATH) hack/make.sh build integration-test cri-test"
+
+.PHONY: help
+help: ## this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)


### PR DESCRIPTION
Signed-off-by: Leno Hou <lenohou@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
add help info into makefile


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none

### Ⅲ. Describe how you did it
added make help command

### Ⅳ. Describe how to verify it
```
[root@qing pouch]# make help
fmt                  run go fmt
lint                 run go lint
vet                  run go vet
unit-test            run go test
validate-swagger     run swagger validate
install              build and install binary into /usr/local/bin
uninstall            uninstall pouchd and pouch binary
integration-test     build binary and run integration-test
cri-test             build binary and run cri-test
test                 run the build integration-test cri-test
help                 this help
```
### Ⅴ. Special notes for reviews
none

