### PR TITLE
bugfix: add attach volume when container start

### DIFF
--- a/daemon/mgr/volume.go
+++ b/daemon/mgr/volume.go
@@ -164,7 +164,7 @@ func (vm *VolumeManager) Attach(ctx context.Context, name string, options map[st
 		ref := v.Option(types.OptionRef)
 		if ref == "" {
 			options[types.OptionRef] = cid
-		} else {
+		} else if !strings.Contains(ref, cid) {
 			options[types.OptionRef] = strings.Join([]string{ref, cid}, ",")
 		}
 	}
@@ -199,7 +199,6 @@ func (vm *VolumeManager) Detach(ctx context.Context, name string, options map[st
 			for i, id := range ids {
 				if id == cid {
 					ids = append(ids[:i], ids[i+1:]...)
-					break
 				}
 			}
 

--- a/storage/volume/driver/driver_interface.go
+++ b/storage/volume/driver/driver_interface.go
@@ -28,6 +28,12 @@ type Opt interface {
 	Options() map[string]types.Option
 }
 
+// Conf represents pass volume config to volume driver.
+type Conf interface {
+	// Config is used to pass the daemon volume config into driver.
+	Config(Context, map[string]interface{}) error
+}
+
 // AttachDetach represents volume attach/detach interface.
 type AttachDetach interface {
 	// Attach a Volume to host, enable the volume.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add attach volume  when container start. Now volume attaching is
at container create stage, but if host have been restarted, container won't be
created, so volume can't be attached.

Add Config() for volume driver, it makes volume driver can use the
configure of volume in daemon. Now set `volume-meta-dir` and
`volume-timeout` into driver config.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
A running container can start again after host have been restarted.

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
