### PR TITLE
hack.build: reduce the size of pouch and pouchd binaries

### DIFF
--- a/hack/build
+++ b/hack/build
@@ -38,6 +38,7 @@ function server()
     cd $BUILDPATH/src/github.com/alibaba/pouch
     echo "GOOS=linux $GOBUILD -o $BINARY_NAME"
     GOOS=linux $GOBUILD -ldflags "${GOLDFLAGS}" -o $BINARY_NAME -tags 'selinux'
+    [ -f $(which strip) ] && strip -s  $BINARY_NAME
 }
 
 function client()
@@ -45,6 +46,7 @@ function client()
     cd $BUILDPATH/src/github.com/alibaba/pouch
     echo "$GOBUILD -o $CLI_BINARY_NAME github.com/alibaba/pouch/cli"
     $GOBUILD -o $CLI_BINARY_NAME github.com/alibaba/pouch/cli
+    [ -f $(which strip) ] && strip -s  $CLI_BINARY_NAME
 }
 
 #


### PR DESCRIPTION
This patch is used for fix issue #1477.

# git rev-parse HEAD
6fa7b4b2a52f9f8ceaef7532a3e79ae15fd88c8f

Without this patch:

pouch# make install
pouch# ll -h pouch pouchd
-rwxr-xr-x 1 root root 29M Jun   7 17:21 pouch*
-rwxr-xr-x 1 root root 58M Jun   7 17:21 pouchd*

With the patch:
pouch# make install
pouch# ll -h pouch pouchd
-rwxr-xr-x 1 root root 17M Jun   7 17:19 pouch*
-rwxr-xr-x 1 root root 33M Jun   7 17:19 pouchd*

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
As subject

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it
use strip command to remove the symbol table and debugging information from an executable pouch and pouchd.

### Ⅳ. Describe how to verify it
to compare size of pouch and pouchd binaries by ls -lh before and after applying this patch.

### Ⅴ. Special notes for reviews


