### PR TITLE
bugfix: rename lxcfs to pouch-lxcfs in pouch.rpm

### DIFF
--- a/hack/package/rpm/build.sh
+++ b/hack/package/rpm/build.sh
@@ -39,6 +39,9 @@ function build_lxcfs ()
 {
     pushd "$LXC_DIR"
     git clone -b "$LXC_BRANCH" https://github.com/lxc/lxcfs.git && cd lxcfs
+    
+    # change liblxcfs.so to libpouchlxcfs.so
+    sed -i 's/liblxcfs/libpouchlxcfs/g' "$(grep -r "liblxcfs" . |awk -F':' '{print $1}'|uniq )"
     ./bootstrap.sh > /dev/null 2>&1
     ./configure > /dev/null 2>&1
     make install DESTDIR="$LXC_DIR" > /dev/null 2>&1
@@ -108,9 +111,8 @@ function build_rpm ()
           -d fuse \
           "$BINDIR/"=/usr/local/bin/ \
           "$SERVICEDIR/"=/usr/lib/systemd/system/ \
-          "$LXC_DIR/usr/local/bin/lxcfs"=/usr/bin/lxcfs \
-          "$LXC_DIR/usr/local/lib/lxcfs/liblxcfs.so"=/usr/lib64/liblxcfs.so \
-          "$LXC_DIR/usr/local/share/"=/usr/share
+          "$LXC_DIR/usr/local/bin/lxcfs"=/usr/bin/pouch-lxcfs \
+          "$LXC_DIR/usr/local/lib/lxcfs/libpouchlxcfs.so"=/usr/lib64/libpouchlxcfs.so \
 
 }
 

--- a/hack/package/rpm/scripts/after-install.sh
+++ b/hack/package/rpm/scripts/after-install.sh
@@ -7,6 +7,6 @@ if ! getent group pouch > /dev/null; then
 	groupadd --system pouch
 fi
 
-if [ ! -d "/var/lib/lxcfs" ] ; then
-    mkdir -p /var/lib/lxcfs
+if [ ! -d "/var/lib/pouch-lxcfs" ] ; then
+    mkdir -p /var/lib/pouch-lxcfs
 fi

--- a/hack/package/rpm/service/pouch-lxcfs.service
+++ b/hack/package/rpm/service/pouch-lxcfs.service
@@ -5,10 +5,10 @@ Before=lxc.service
 Documentation=man:lxcfs(1)
 
 [Service]
-ExecStart=/usr/bin/lxcfs /var/lib/lxcfs/
+ExecStart=/usr/bin/pouch-lxcfs /var/lib/pouch-lxcfs/
 KillMode=process
 Restart=on-failure
-ExecStopPost=-/usr/bin/fusermount -u /var/lib/lxcfs
+ExecStopPost=-/usr/bin/fusermount -u /var/lib/pouch-lxcfs
 Delegate=yes
 ExecStartPost=pouch remount-lxcfs
 


### PR DESCRIPTION
Signed-off-by: letty <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Instead of offering `lxcfs` binary, pouch rpm offers a `pouch-lxcfs` binary to avoid conflict with users environment.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #1476 


### Ⅲ. Describe how you did it
1. change the `liblxcfs.so` to `libpouchlxcfs.so` in lxcfs source code.
2. remove files in `share` directory, which is used for LXC
3. rename lxcfs.service to pouch-lxcfs.service


### Ⅳ. Describe how to verify it
Now rpm includes the following files:
```
#rpm -qlp pouch-1.0.0-1.el7.centos.x86_64.rpm
warning: pouch-1.0.0-1.el7.centos.x86_64.rpm: Header V4 RSA/SHA1 Signature, key ID 439ae9ec: NOKEY
/usr/bin/pouch-lxcfs
/usr/lib/systemd/system/pouch-lxcfs.service
/usr/lib/systemd/system/pouch.service
/usr/lib64/libpouchlxcfs.so
/usr/local/bin/containerd
/usr/local/bin/containerd-release
/usr/local/bin/containerd-shim
/usr/local/bin/containerd-stress
/usr/local/bin/ctr
/usr/local/bin/pouch
/usr/local/bin/pouchd
/usr/local/bin/runc
```
start pouch-lxcfs service
```
#systemctl start pouch-lxcfs

[root@r10e16207.sqa.zmf /tmp]
#ps -aux|grep lxcfs
root      16303  0.2  0.0  95316  1036 ?        Ssl  11:17   0:00 /usr/bin/pouch-lxcfs /var/lib/pouch-lxcfs/
root      23888  0.0  0.0 234720  3084 ?        Ssl  Apr18   0:28 /usr/bin/lxcfs /var/lib/lxcfs/
root      32367  0.0  0.0 112668   960 pts/0    S+   11:17   0:00 grep --color=auto lxcfs

#ls /var/lib/pouch-lxcfs/
cgroup  proc
```
Start pouchd with lxcfs enabled:
```
pouchd --enable-lxcfs --lxcfs /usr/local/bin/pouch-lxcfs --lxcfs-home /var/lib/pouch-lxcfs
```
Verify lxcfs works:
```
#pouch run -it -m 500m busybox
/ # cd /proc/
1/        bus/      fs/       irq/      net/      self/     sysvipc/
acpi/     driver/   ipmi/     mpt/      scsi/     sys/      tty/
/ # cat /proc/meminfo
MemTotal:         512000 kB
```
### Ⅴ. Special notes for reviews


