### PR TITLE
bugfix:  fix open the file "/proc/1/mountinfo" , but does't close it.

### DIFF
--- a/lxcfs/lxcfs.go
+++ b/lxcfs/lxcfs.go
@@ -29,6 +29,7 @@ func CheckLxcfsMount() error {
 	if err != nil {
 		return fmt.Errorf("Check lxcfs mounts failed: %v", err)
 	}
+	defer f.Close()
 	fr := bufio.NewReader(f)
 	for {
 		line, err := fr.ReadBytes('\n')


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
fix open the file "/proc/1/mountinfo" , but does't close it.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #1488

### Ⅲ. Describe how you did it
add defer f.Close()

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


