### PR TITLE
[WIP] feature: add notification from our friend PouchRobot when circleci fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,11 @@ jobs:
       - run:
           name: upload code coverage report
           command: bash <(curl -s https://codecov.io/bash)
-
+notify:
+  webhooks:
+    - url: http://121.201.63.16:6789/circleci_notifications
+    - on_failure: always
+    - on_error: always
 workflows:
   version: 2
   ci:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ go_import_path: github.com/alibaba/pouch
 notifications:
   webhooks:
     urls:
-      - http://121.201.63.16:6789/ci_notifications
+      - http://121.201.63.16:6789/travis_ci_notifications
     on_failure: always
     on_error: always
 


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This pr add webhook notification mechanism in circleci config file. In this case, when circleci fails our friend PouchRobot will make a comment to report.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


