### PR TITLE
Revert "hack.build: reduce the size of pouch and pouchd binaries"

### DIFF
--- a/hack/build
+++ b/hack/build
@@ -38,7 +38,6 @@ function server()
     cd $BUILDPATH/src/github.com/alibaba/pouch
     echo "GOOS=linux $GOBUILD -o $BINARY_NAME"
     GOOS=linux $GOBUILD -ldflags "${GOLDFLAGS}" -o $BINARY_NAME -tags 'selinux'
-    [ -f $(which strip) ] && strip -s  $BINARY_NAME
 }
 
 function client()
@@ -46,7 +45,6 @@ function client()
     cd $BUILDPATH/src/github.com/alibaba/pouch
     echo "$GOBUILD -o $CLI_BINARY_NAME github.com/alibaba/pouch/cli"
     $GOBUILD -o $CLI_BINARY_NAME github.com/alibaba/pouch/cli
-    [ -f $(which strip) ] && strip -s  $CLI_BINARY_NAME
 }
 
 #


### PR DESCRIPTION
Reverts alibaba/pouch#1484

 debug symbols also are removed by strip, although size of pouch and pouchd binaries are reduced, perhaps, we can append --only-keep-debug option to strip to avoid this issue later.