### PR TITLE
fix: update cpu-quota of 0.2.4 container may occur error

### DIFF
--- a/cli/update.go
+++ b/cli/update.go
@@ -44,11 +44,11 @@ func (uc *UpdateCommand) addFlags() {
 	flagSet.Uint16Var(&uc.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable")
 	flagSet.Int64Var(&uc.cpuperiod, "cpu-period", 0, "Limit CPU CFS (Completely Fair Scheduler) period, range is in [1000(1ms),1000000(1s)]")
 	flagSet.Int64Var(&uc.cpushare, "cpu-share", 0, "CPU shares (relative weight)")
+	flagSet.Int64Var(&uc.cpuquota, "cpu-quota", 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
 	flagSet.StringVar(&uc.cpusetcpus, "cpuset-cpus", "", "CPUs in cpuset")
 	flagSet.StringVar(&uc.cpusetmems, "cpuset-mems", "", "MEMs in cpuset")
 	flagSet.StringVarP(&uc.memory, "memory", "m", "", "Container memory limit")
 	flagSet.StringVar(&uc.memorySwap, "memory-swap", "", "Container swap limit")
-	flagSet.Int64Var(&uc.memorySwappiness, "memory-swappiness", -1, "Container memory swappiness [0, 100]")
 	flagSet.StringSliceVarP(&uc.env, "env", "e", nil, "Set environment variables for container")
 	flagSet.StringSliceVarP(&uc.labels, "label", "l", nil, "Set label for container")
 	flagSet.StringVar(&uc.restartPolicy, "restart", "", "Restart policy to apply when container exits")
@@ -59,16 +59,6 @@ func (uc *UpdateCommand) addFlags() {
 func (uc *UpdateCommand) updateRun(args []string) error {
 	container := args[0]
 	ctx := context.Background()
-
-	// UpdateConfig.Label's type change to []string
-	// labels, err := opts.ParseLabels(uc.labels)
-	// if err != nil {
-	// 	return err
-	// }
-
-	if err := opts.ValidateMemorySwappiness(uc.memorySwappiness); err != nil {
-		return err
-	}
 
 	memory, err := opts.ParseMemory(uc.memory)
 	if err != nil {
@@ -81,14 +71,14 @@ func (uc *UpdateCommand) updateRun(args []string) error {
 	}
 
 	resource := types.Resources{
-		CPUPeriod:        uc.cpuperiod,
-		CPUShares:        uc.cpushare,
-		CpusetCpus:       uc.cpusetcpus,
-		CpusetMems:       uc.cpusetmems,
-		Memory:           memory,
-		MemorySwap:       memorySwap,
-		MemorySwappiness: &uc.memorySwappiness,
-		BlkioWeight:      uc.blkioWeight,
+		CPUPeriod:   uc.cpuperiod,
+		CPUShares:   uc.cpushare,
+		CPUQuota:    uc.cpuquota,
+		CpusetCpus:  uc.cpusetcpus,
+		CpusetMems:  uc.cpusetmems,
+		Memory:      memory,
+		MemorySwap:  memorySwap,
+		BlkioWeight: uc.blkioWeight,
 	}
 
 	restartPolicy, err := opts.ParseRestartPolicy(uc.restartPolicy)

--- a/ctrd/utils.go
+++ b/ctrd/utils.go
@@ -156,14 +156,9 @@ func toLinuxResources(resources types.Resources) (*specs.LinuxResources, error) 
 	}
 
 	// toLinuxMemory
-	var swappiness uint64
-	if resources.MemorySwappiness != nil {
-		swappiness = uint64(*(resources.MemorySwappiness))
-	}
 	r.Memory = &specs.LinuxMemory{
 		Limit:       &resources.Memory,
 		Swap:        &resources.MemorySwap,
-		Swappiness:  &swappiness,
 		Reservation: &resources.MemoryReservation,
 	}
 

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1010,7 +1010,7 @@ func (mgr *ContainerManager) updateContainerResources(c *Container, resources ty
 	if resources.CPUPeriod != 0 {
 		cResources.CPUPeriod = resources.CPUPeriod
 	}
-	if resources.CPUQuota != 0 {
+	if resources.CPUQuota > -1 {
 		cResources.CPUQuota = resources.CPUQuota
 	}
 	if resources.CPUShares != 0 {
@@ -1030,10 +1030,6 @@ func (mgr *ContainerManager) updateContainerResources(c *Container, resources ty
 		}
 		cResources.Memory = resources.Memory
 	}
-	if resources.MemorySwap != 0 {
-		cResources.MemorySwap = resources.MemorySwap
-	}
-
 	if resources.MemorySwap != 0 {
 		cResources.MemorySwap = resources.MemorySwap
 	}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>


### Ⅰ. Describe what this PR did
this PR has done two things:
  * remove update `memory-swappiness`, actually runc not allow to update this param, so it's no sense to update it in pouch.
  * fix update `CPUQuota` , in containerd 1.0.3 this var is defined int64, but in containerd 0.2.4 is defined uint64, so we should not allow to pass `-1` value of `CPUQuota` to containerd.
```
# in pouch and containerd 1.0.3
CPUQuota int64

# in containerd 0.2.4 
CpuQuota uint64
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


