### PR TITLE
bugfix: change the order of generating MountPoints

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1880,24 +1880,28 @@ func (mgr *ContainerManager) generateMountPoints(ctx context.Context, c *Contain
 		}
 	}()
 
-	err = mgr.getMountPointFromVolumes(ctx, c, volumeSet)
+	// 1. read MountPoints from other containers
+	err = mgr.getMountPointFromContainers(ctx, c, volumeSet)
 	if err != nil {
-		return errors.Wrap(err, "failed to get mount point from volumes")
+		return errors.Wrap(err, "failed to get mount point from containers")
 	}
 
-	err = mgr.getMountPointFromImage(ctx, c, volumeSet)
-	if err != nil {
-		return errors.Wrap(err, "failed to get mount point from image")
-	}
-
+	// 2. read MountPoints from binds
 	err = mgr.getMountPointFromBinds(ctx, c, volumeSet)
 	if err != nil {
 		return errors.Wrap(err, "failed to get mount point from binds")
 	}
 
-	err = mgr.getMountPointFromContainers(ctx, c, volumeSet)
+	// 3. read MountPoints from image
+	err = mgr.getMountPointFromImage(ctx, c, volumeSet)
 	if err != nil {
-		return errors.Wrap(err, "failed to get mount point from containers")
+		return errors.Wrap(err, "failed to get mount point from image")
+	}
+
+	// 4. read MountPoints from Config.Volumes
+	err = mgr.getMountPointFromVolumes(ctx, c, volumeSet)
+	if err != nil {
+		return errors.Wrap(err, "failed to get mount point from volumes")
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

change the order of generating mountpoints.

1. generate MountPoints from other containers(volumes-from)
2. generate MountPoints from binds
3. generate MountPoints from images
4. generate MountPoints from Config.Volumes

Why?

Every volume has a destination in container. So if two volume have the same destination, only one volume takes effect. 

Now the order of volume taking effect is 

1. generate MountPoints from Config.Volumes
2. generate MountPoints from images
3. generate MountPoints from binds
4. generate MountPoints from other containers(volume-from)

So if Config.Volumes,  images, binds and volume-from all have a volume whose destination is the same. Only the Config.Volumes will take effect.

Indeed, the right order is

volumes-from 》 binds 》images 》Config.Volumes




I will add some test-cases in other Prs



### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

change the order of generating MountPoints

volumes-from 》 binds 》images 》Config.Volumes


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


