### PR TITLE
fix: rename cpu-share to cpu-shares in command line

### DIFF
--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -21,7 +21,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringSliceVar(&c.capDrop, "cap-drop", nil, "Drop Linux capabilities")
 
 	// cpu
-	flagSet.Int64Var(&c.cpushare, "cpu-share", 0, "CPU shares (relative weight)")
+	flagSet.Int64Var(&c.cpushare, "cpu-shares", 0, "CPU shares (relative weight)")
 	flagSet.StringVar(&c.cpusetcpus, "cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)")
 	flagSet.StringVar(&c.cpusetmems, "cpuset-mems", "", "MEMs in which to allow execution (0-3, 0,1)")
 	flagSet.Int64Var(&c.cpuperiod, "cpu-period", 0, "Limit CPU CFS (Completely Fair Scheduler) period, range is in [1000(1ms),1000000(1s)]")

--- a/cli/update.go
+++ b/cli/update.go
@@ -43,7 +43,7 @@ func (uc *UpdateCommand) addFlags() {
 	flagSet.SetInterspersed(false)
 	flagSet.Uint16Var(&uc.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable")
 	flagSet.Int64Var(&uc.cpuperiod, "cpu-period", 0, "Limit CPU CFS (Completely Fair Scheduler) period, range is in [1000(1ms),1000000(1s)]")
-	flagSet.Int64Var(&uc.cpushare, "cpu-share", 0, "CPU shares (relative weight)")
+	flagSet.Int64Var(&uc.cpushare, "cpu-shares", 0, "CPU shares (relative weight)")
 	flagSet.Int64Var(&uc.cpuquota, "cpu-quota", 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
 	flagSet.StringVar(&uc.cpusetcpus, "cpuset-cpus", "", "CPUs in cpuset")
 	flagSet.StringVar(&uc.cpusetmems, "cpuset-mems", "", "MEMs in cpuset")

--- a/daemon/mgr/container_utils.go
+++ b/daemon/mgr/container_utils.go
@@ -296,7 +296,7 @@ func validateResource(r *types.Resources) ([]string, error) {
 			r.CpusetMems = ""
 		}
 		if r.CPUShares > 0 && !cgroupInfo.CPU.CPUShares {
-			warn := "Current Kernel does not support cpu shares, discard --cpu-share"
+			warn := "Current Kernel does not support cpu shares, discard --cpu-shares"
 			logrus.Warn(warn)
 			warnings = append(warnings, warn)
 			r.CPUShares = 0

--- a/test/cli_restart_test.go
+++ b/test/cli_restart_test.go
@@ -76,8 +76,7 @@ func (suite *PouchRestartSuite) TestPouchRestartPausedContainer(c *check.C) {
 func (suite *PouchRestartSuite) TestPouchRestartMultiContainers(c *check.C) {
 	containernames := []string{"TestPouchRestartMultiContainer-1", "TestPouchRestartMultiContainer-2"}
 	for _, name := range containernames {
-		res := command.PouchRun("run", "-d",
-			"--name", name, busyboxImage, "top")
+		res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 		defer DelContainerForceMultyTime(c, name)
 		res.Assert(c, icmd.Success)
 	}

--- a/test/cli_run_cpu_test.go
+++ b/test/cli_run_cpu_test.go
@@ -38,7 +38,7 @@ func (suite *PouchRunCPUSuite) TestRunWithCPULimit(c *check.C) {
 	res := command.PouchRun("run", "-d",
 		"--cpuset-cpus", "0",
 		"--cpuset-mems", "0",
-		"--cpu-share", "1000",
+		"--cpu-shares", "1000",
 		"--cpu-period", "1000",
 		"--cpu-quota", "1000",
 		"--name", cname,

--- a/test/cli_update_test.go
+++ b/test/cli_update_test.go
@@ -39,7 +39,7 @@ func (suite *PouchUpdateSuite) TearDownTest(c *check.C) {
 func (suite *PouchUpdateSuite) TestUpdateCpu(c *check.C) {
 	name := "update-container-cpu"
 
-	res := command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage, "top")
+	res := command.PouchRun("run", "-d", "--cpu-shares", "20", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
@@ -55,7 +55,7 @@ func (suite *PouchUpdateSuite) TestUpdateCpu(c *check.C) {
 		c.Fatalf("container %s cgroup mountpoint not exists", containerID)
 	}
 
-	command.PouchRun("update", "--cpu-share", "40", name).Assert(c, icmd.Success)
+	command.PouchRun("update", "--cpu-shares", "40", name).Assert(c, icmd.Success)
 
 	out, err := exec.Command("cat", file).Output()
 	if err != nil {

--- a/test/cli_upgrade_test.go
+++ b/test/cli_upgrade_test.go
@@ -93,12 +93,12 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeContainerMemCpu(c *check.C) {
 	name := "TestPouchUpgradeContainerMemCpu"
 
 	res := command.PouchRun("run", "-d", "-m", "300m",
-		"--cpu-share", "20", "--name", name, busyboxImage, "top")
+		"--cpu-shares", "20", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
 	command.PouchRun("upgrade", "-m", "500m",
-		"--cpu-share", "40", "--name", name, busyboxImage125).Assert(c, icmd.Success)
+		"--cpu-shares", "40", "--name", name, busyboxImage125).Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

the related command line flag about cpu share should be `--cpu-shares` rather than `--cpu-share`.
This update would be compatible with moby's way.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Describe how you did it
change the flag file and test


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

