### PR TITLE
bugfix: refine tests with specifying CMD

### DIFF
--- a/test/api_container_logs_test.go
+++ b/test/api_container_logs_test.go
@@ -57,8 +57,6 @@ func (suite *APIContainerLogsSuite) TestNoShowStdoutAndShowStderr(c *check.C) {
 	resp, err := request.Get(fmt.Sprintf("/containers/%s/logs", name))
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, http.StatusBadRequest)
-
-	DelContainerForceOk(c, name)
 }
 
 // TestStdout tests stdout stream.

--- a/test/cli_alikernel_test.go
+++ b/test/cli_alikernel_test.go
@@ -56,8 +56,8 @@ func (suite *PouchAliKernelSuite) TestAliKernelDiskQuotaWorks(c *check.C) {
 
 	// generate a file larger than 1G should fail.
 	expct = icmd.Expected{
-		// TODO: Add exit code check when pouch exec return the exit code of process
-		Error: "Disk quota exceeded",
+		ExitCode: 1,
+		Error:    "Disk quota exceeded",
 	}
 	cmd := "dd if=/dev/zero of=/mnt/test bs=1024k count=1500"
 	err = command.PouchRun("exec", funcname, "sh", "-c", cmd).Compare(expct)

--- a/test/cli_restart_test.go
+++ b/test/cli_restart_test.go
@@ -34,7 +34,7 @@ func (suite *PouchRestartSuite) TearDownTest(c *check.C) {
 func (suite *PouchRestartSuite) TestPouchRestart(c *check.C) {
 	name := "TestPouchRestart"
 
-	res := command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
@@ -76,7 +76,8 @@ func (suite *PouchRestartSuite) TestPouchRestartPausedContainer(c *check.C) {
 func (suite *PouchRestartSuite) TestPouchRestartMultiContainers(c *check.C) {
 	containernames := []string{"TestPouchRestartMultiContainer-1", "TestPouchRestartMultiContainer-2"}
 	for _, name := range containernames {
-		res := command.PouchRun("run", "-d", "--cpu-share", "20", "--name", name, busyboxImage)
+		res := command.PouchRun("run", "-d",
+			"--name", name, busyboxImage, "top")
 		defer DelContainerForceMultyTime(c, name)
 		res.Assert(c, icmd.Success)
 	}

--- a/test/cli_run_blkio_test.go
+++ b/test/cli_run_blkio_test.go
@@ -107,7 +107,7 @@ func (suite *PouchRunBlkioSuite) TestRunWithBlkioWeight(c *check.C) {
 	name := "test-run-with-blkio-weight"
 
 	res := command.PouchRun("run", "-d", "--name", name,
-		"--blkio-weight", "500", busyboxImage)
+		"--blkio-weight", "500", busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 }

--- a/test/cli_run_pid_test.go
+++ b/test/cli_run_pid_test.go
@@ -38,7 +38,7 @@ func (suite *PouchRunPidSuite) TestRunWithPIDMode(c *check.C) {
 	name := "test-run-with-pid-mode"
 
 	res := command.PouchRun("run", "-d", "--name", name,
-		"--pid", "host", busyboxImage)
+		"--pid", "host", busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 
 	res.Assert(c, icmd.Success)

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -145,7 +145,7 @@ func (suite *PouchRunSuite) TestRunWithIPCMode(c *check.C) {
 	name := "test-run-with-ipc-mode"
 
 	res := command.PouchRun("run", "-d", "--name", name,
-		"--ipc", "host", busyboxImage)
+		"--ipc", "host", busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 
 	res.Assert(c, icmd.Success)
@@ -156,7 +156,7 @@ func (suite *PouchRunSuite) TestRunWithUTSMode(c *check.C) {
 	name := "test-run-with-uts-mode"
 
 	res := command.PouchRun("run", "-d", "--name", name,
-		"--uts", "host", busyboxImage)
+		"--uts", "host", busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 
 	res.Assert(c, icmd.Success)
@@ -186,7 +186,7 @@ func (suite *PouchRunSuite) TestRunWithAppArmor(c *check.C) {
 	name := "run-apparmor"
 
 	res := command.PouchRun("run", "-d", "--name", name,
-		"--security-opt", appArmor, busyboxImage)
+		"--security-opt", appArmor, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 
 	res.Assert(c, icmd.Success)
@@ -200,7 +200,7 @@ func (suite *PouchRunSuite) TestRunWithSeccomp(c *check.C) {
 	name := "run-seccomp"
 
 	res := command.PouchRun("run", "-d", "--name", name,
-		"--security-opt", seccomp, busyboxImage)
+		"--security-opt", seccomp, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 
 	res.Assert(c, icmd.Success)
@@ -281,7 +281,7 @@ func (suite *PouchRunSuite) TestRunWithAnnotation(c *check.C) {
 	cname := "TestRunWithAnnotation"
 	res := command.PouchRun("run", "-d", "--annotation", "a=b",
 		"--annotation", "foo=bar",
-		"--name", cname, busyboxImage).Assert(c, icmd.Success)
+		"--name", cname, busyboxImage, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, cname)
 	res.Assert(c, icmd.Success)
 

--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -247,7 +247,7 @@ func (suite *PouchStartSuite) TestStartWithPrivilege(c *check.C) {
 func (suite *PouchStartSuite) TestStartWithAnnotation(c *check.C) {
 	name := "start-annotation"
 
-	res := command.PouchRun("create", "--name", name, "--annotation", "a=b", busyboxImage)
+	res := command.PouchRun("create", "--name", name, "--annotation", "a=b", busyboxImage, "top")
 	res.Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
@@ -279,7 +279,8 @@ func (suite *PouchStartSuite) TestStartWithExitCode(c *check.C) {
 func (suite *PouchStartSuite) TestStartWithUlimit(c *check.C) {
 	name := "start-ulimit"
 
-	res := command.PouchRun("create", "--name", name, "--ulimit", "nproc=256", busyboxImage)
+	res := command.PouchRun("create", "--name", name,
+		"--ulimit", "nproc=256", busyboxImage, "top")
 	res.Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
@@ -290,7 +291,8 @@ func (suite *PouchStartSuite) TestStartWithUlimit(c *check.C) {
 func (suite *PouchStartSuite) TestStartWithPidsLimit(c *check.C) {
 	name := "TestStartWithPidsLimit"
 	pidfile := "/sys/fs/cgroup/pids/pids.max"
-	res := command.PouchRun("create", "--pids-limit", "10", "--name", name, busyboxImage, "cat", pidfile)
+	res := command.PouchRun("create", "--pids-limit", "10",
+		"--name", name, busyboxImage, "cat", pidfile)
 	res.Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 

--- a/test/cli_upgrade_test.go
+++ b/test/cli_upgrade_test.go
@@ -41,7 +41,7 @@ func (suite *PouchUpgradeSuite) TeadDownTest(c *check.C) {
 func (suite *PouchUpgradeSuite) TestPouchUpgrade(c *check.C) {
 	name := "TestPouchUpgrade"
 
-	res := command.PouchRun("run", "-d", "--name", name, busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
@@ -57,7 +57,7 @@ func (suite *PouchUpgradeSuite) TestPouchUpgrade(c *check.C) {
 func (suite *PouchUpgradeSuite) TestPouchUpgradeNoChange(c *check.C) {
 	name := "TestPouchUpgradeNoChange"
 
-	res := command.PouchRun("run", "-d", "--name", name, busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
@@ -92,11 +92,13 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeStoppedContainer(c *check.C) {
 func (suite *PouchUpgradeSuite) TestPouchUpgradeContainerMemCpu(c *check.C) {
 	name := "TestPouchUpgradeContainerMemCpu"
 
-	res := command.PouchRun("run", "-d", "-m", "300m", "--cpu-share", "20", "--name", name, busyboxImage, "top")
+	res := command.PouchRun("run", "-d", "-m", "300m",
+		"--cpu-share", "20", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
-	command.PouchRun("upgrade", "-m", "500m", "--cpu-share", "40", "--name", name, busyboxImage125).Assert(c, icmd.Success)
+	command.PouchRun("upgrade", "-m", "500m",
+		"--cpu-share", "40", "--name", name, busyboxImage125).Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}
@@ -143,11 +145,13 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeContainerMemCpu(c *check.C) {
 func (suite *PouchUpgradeSuite) TestPouchUpgradeContainerLabels(c *check.C) {
 	name := "TestPouchUpgradeContainerLabels"
 
-	res := command.PouchRun("run", "-d", "--label", "test=foo", "--name", name, busyboxImage)
+	res := command.PouchRun("run", "-d", "--label", "test=foo",
+		"--name", name, busyboxImage)
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
-	command.PouchRun("upgrade", "--label", "test1=bar", "--name", name, busyboxImage125).Assert(c, icmd.Success)
+	command.PouchRun("upgrade", "--label", "test1=bar",
+		"--name", name, busyboxImage125).Assert(c, icmd.Success)
 
 	output := command.PouchRun("inspect", name).Stdout()
 	result := []types.ContainerJSON{}

--- a/test/z_cli_daemon_test.go
+++ b/test/z_cli_daemon_test.go
@@ -40,14 +40,16 @@ func (suite *PouchDaemonSuite) TestDaemonCgroupParent(c *check.C) {
 
 	cname := "TestDaemonCgroupParent"
 	{
-		result := command.PouchRun("--host", daemon.Listen, "pull", busyboxImage)
+
+		result := RunWithSpecifiedDaemon(dcfg, "pull", busyboxImage)
 		if result.ExitCode != 0 {
 			dcfg.DumpLog()
 			c.Fatalf("pull image failed, err:%v", result)
 		}
 	}
 	{
-		result := command.PouchRun("--host", daemon.Listen, "run", "-d", "--name", cname, busyboxImage)
+		result := RunWithSpecifiedDaemon(dcfg, "run",
+			"-d", "--name", cname, busyboxImage, "top")
 		if result.ExitCode != 0 {
 			dcfg.DumpLog()
 			c.Fatalf("run container failed, err:%v", result)
@@ -56,7 +58,7 @@ func (suite *PouchDaemonSuite) TestDaemonCgroupParent(c *check.C) {
 	defer DelContainerForceMultyTime(c, cname)
 
 	// test if the value is in inspect result
-	output := command.PouchRun("inspect", "--host", daemon.Listen, cname).Stdout()
+	output := RunWithSpecifiedDaemon(dcfg, "inspect", cname).Stdout()
 	result := []types.ContainerJSON{}
 	if err := json.Unmarshal([]byte(output), &result); err != nil {
 		c.Errorf("failed to decode inspect output: %v", err)


### PR DESCRIPTION
Signed-off-by: letty <letty.ll@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add "top" CMD when running a container. If we don't specify CMD when starting a container, it will use the default one in image, most of time it is `sh`. Sometimes, test may expect the container in `running` state, which is not true if CMD is not specified explicitly.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


