### PR TITLE
test: add all states container restart validation

### DIFF
--- a/test/cli_restart_test.go
+++ b/test/cli_restart_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strings"
+	"time"
 
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
@@ -30,9 +31,9 @@ func (suite *PouchRestartSuite) SetUpSuite(c *check.C) {
 func (suite *PouchRestartSuite) TearDownTest(c *check.C) {
 }
 
-// TestPouchRestart is to verify the correctness of restarting a running container.
-func (suite *PouchRestartSuite) TestPouchRestart(c *check.C) {
-	name := "TestPouchRestart"
+// TestPouchRestartRunningContainer is to verify the correctness of restarting a running container.
+func (suite *PouchRestartSuite) TestPouchRestartRunningContainer(c *check.C) {
+	name := "TestPouchRestartRunningContainer"
 
 	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
@@ -46,15 +47,45 @@ func (suite *PouchRestartSuite) TestPouchRestart(c *check.C) {
 	}
 }
 
+// TestPouchRestartCreatedContainer is to verify the correctness of restarting a created container.
+// Pouch should be compatible with moby's API. Restarting a created container is allowed.
+func (suite *PouchRestartSuite) TestPouchRestartCreatedContainer(c *check.C) {
+	name := "TestPouchRestartCreatedContainer"
+
+	res := command.PouchRun("create", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+
+	res.Assert(c, icmd.Success)
+
+	command.PouchRun("restart", "-t", "1", name).Assert(c, icmd.Success)
+}
+
+// TestPouchRestartExitedContainer is to verify the correctness of restarting an exited container.
+// Pouch should be compatible with moby's API. Restarting an exited container is allowed.
+func (suite *PouchRestartSuite) TestPouchRestartExitedContainer(c *check.C) {
+	name := "TestPouchRestartExitedContainer"
+
+	// run a container and make it exit within 0.01s, so the status is exited
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "sleep", "0.01")
+	defer DelContainerForceMultyTime(c, name)
+
+	res.Assert(c, icmd.Success)
+	time.Sleep(1 * time.Second)
+
+	command.PouchRun("restart", "-t", "1", name).Assert(c, icmd.Success)
+}
+
 // TestPouchRestartStoppedContainer is to verify the correctness of restarting a stopped container.
 // Pouch should be compatible with moby's API. Restarting a stopped container is allowed.
 func (suite *PouchRestartSuite) TestPouchRestartStoppedContainer(c *check.C) {
 	name := "TestPouchRestartStoppedContainer"
 
-	res := command.PouchRun("create", "--name", name, busyboxImage)
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 
 	res.Assert(c, icmd.Success)
+
+	command.PouchRun("stop", name).Assert(c, icmd.Success)
 
 	command.PouchRun("restart", "-t", "1", name).Assert(c, icmd.Success)
 }
@@ -76,8 +107,7 @@ func (suite *PouchRestartSuite) TestPouchRestartPausedContainer(c *check.C) {
 func (suite *PouchRestartSuite) TestPouchRestartMultiContainers(c *check.C) {
 	containernames := []string{"TestPouchRestartMultiContainer-1", "TestPouchRestartMultiContainer-2"}
 	for _, name := range containernames {
-		res := command.PouchRun("run", "-d",
-			"--name", name, busyboxImage, "top")
+		res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
 		defer DelContainerForceMultyTime(c, name)
 		res.Assert(c, icmd.Success)
 	}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This pr changes the test cases for restart action:
1. add command in running container;
2.add containers with all states to check the restart action, like running, exited, stopped, created.

this is similar to https://github.com/alibaba/pouch/pull/1548

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Describe how you did it
none


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews
@Letty5411 


