### PR TITLE
bugfix: vendor latest libnetwork for connect panic

### DIFF
--- a/vendor/github.com/docker/libnetwork/sandbox_store.go
+++ b/vendor/github.com/docker/libnetwork/sandbox_store.go
@@ -217,6 +217,7 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 			endpoints:          []*endpoint{},
 			populatedEndpoints: map[string]struct{}{},
 			dbIndex:            sbs.dbIndex,
+			epPriority:         sbs.EpPriority,
 			isStub:             true,
 			dbExists:           true,
 		}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -809,13 +809,11 @@
 			"revisionTime": "2017-12-19T08:35:33Z"
 		},
 		{
-			"checksumSHA1": "9fs73UF7mj6VtGjZcpYvkfZTgH4=",
+			"checksumSHA1": "P6rfMC0ECx56UDSrnnb8InINEVc=",
 			"origin": "github.com/alibaba/libnetwork",
 			"path": "github.com/docker/libnetwork",
-			"revision": "04a77bdbfb6f51185791ee3d61e3644f058e6b21",
-			"revisionTime": "2018-06-11T16:09:43Z",
-			"version": "=master",
-			"versionExact": "master"
+			"revision": "7c0569783f2eea427d5c2ea032856e5d0edc38dd",
+			"revisionTime": "2018-06-21T03:37:56Z"
 		},
 		{
 			"checksumSHA1": "PjtJFUyEOokrmiBiHmfXrX/lAug=",
@@ -1912,7 +1910,6 @@
 		},
 		{
 			"checksumSHA1": "o+lVDhZsT+PFILKt5S6CgBmcrMs=",
-			"origin": "github.com/alibaba/pouch/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2",
 			"path": "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2",
 			"revision": "86bd9771515c19a8df7128f53b1c1fa4f00d64ee",
 			"revisionTime": "2018-05-23T02:20:24Z"


### PR DESCRIPTION
It seems a bug of libnetwork. When libnetwork restores the sandbox, it forgets to initialize the epPriority map. So the Join panic. The latest alibaba/libnetwork has fixed the bug. We will vendor the latest libnetwork and add some test cases
    
    https://github.com/alibaba/libnetwork/commit/655f08f8be32ff847d0554ef0128a3de80665cd6

Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

It seems a bug of libnetwork. When libnetwork restores the sandbox, it forgets to initialize the epPriority map. So the Join panic. The latest alibaba/libnetwork has fixed the bug. We will vendor the latest libnetwork and add some test cases


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1550 


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


