### PR TITLE
feature: adjust pouchd unix socket premissions

### DIFF
--- a/apis/server/server.go
+++ b/apis/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/daemon/mgr"
 	"github.com/alibaba/pouch/pkg/httputils"
+	"github.com/alibaba/pouch/pkg/user"
 
 	"github.com/sirupsen/logrus"
 )
@@ -112,13 +113,53 @@ func getListener(addr string, tlsConfig *tls.Config) (net.Listener, error) {
 		}
 		return l, err
 	case "unix":
-		if err := syscall.Unlink(addrParts[1]); err != nil && !os.IsNotExist(err) {
-			return nil, err
-		}
-		mask := syscall.Umask(0777)
-		defer syscall.Umask(mask)
-		return net.Listen("unix", addrParts[1])
+		return newUnixSocket(addrParts[1])
+
 	default:
 		return nil, fmt.Errorf("only unix socket or tcp address is support")
 	}
+}
+
+func newUnixSocket(path string) (net.Listener, error) {
+	if err := syscall.Unlink(path); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	oldmask := syscall.Umask(0777)
+	defer syscall.Umask(oldmask)
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+
+	// chmod unix socket, make other group writable
+	if err := os.Chmod(path, 0660); err != nil {
+		l.Close()
+		return nil, fmt.Errorf("failed to chmod %s: %s", path, err)
+	}
+
+	gid, err := user.ParseID(user.GroupFile, "pouch", func(line, str string, idInt int, idErr error) (uint32, bool) {
+		var (
+			name, placeholder string
+			id                int
+		)
+
+		user.ParseString(line, &name, &placeholder, &id)
+		if str == name {
+			return uint32(id), true
+		}
+		return 0, false
+	})
+	if err != nil {
+		// ignore error when group pouch not exist, group pouch should to be
+		// created before pouchd started, it means code not create pouch group
+		logrus.Warnf("failed to find group pouch, cannot change unix socket %s to pouch group", path)
+		return l, nil
+	}
+
+	// chown unix socket with group pouch
+	if err := os.Chown(path, 0, int(gid)); err != nil {
+		l.Close()
+		return nil, fmt.Errorf("failed to chown %s: %s", path, err)
+	}
+	return l, nil
 }

--- a/pkg/user/user_test.go
+++ b/pkg/user/user_test.go
@@ -17,7 +17,7 @@ func TestParseString(t *testing.T) {
 	} {
 		var u1, u2 string
 		var i1, i2 int
-		parseString(l, &u1, &u2, &i1, &i2)
+		ParseString(l, &u1, &u2, &i1, &i2)
 		assert.Equal(fmt.Sprintf("%s:%s:%d:%d", u1, u2, i1, i2), l)
 	}
 }


### PR DESCRIPTION
adjust pouchd unix socket file mode, make it ownered by group
pouch.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Before this patch, we can only use pouch with user root, with this patch, we add this permission to group pouch. We create a unix sock with pouch group, and change it mode to 0660, make other group can write
```
$ ls -l /run/pouchd.sock 
srw-rw---- 1 root pouch 0 6月  21 12:36 /run/pouchd.sock

$ users
ace

$ pouch images
IMAGE ID       IMAGE NAME                                          SIZE
00f017a8c2a6   reg.docker.alibaba-inc.com/base/busybox:latest      686.62 KB
8ac48589692a   registry.hub.docker.com/library/busybox:1.28        710.83 KB
e38bc07ac18e   registry.hub.docker.com/library/hello-world:linux   5.26 KB
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


