### PR TITLE
feature: for "none", "host" and "container" network mode, bypass libnetwork

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -353,7 +353,10 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 	if len(config.NetworkingConfig.EndpointsConfig) > 0 {
 		container.NetworkSettings.Networks = config.NetworkingConfig.EndpointsConfig
 	}
-	if container.NetworkSettings.Networks == nil && !IsContainer(config.HostConfig.NetworkMode) {
+
+	// For "container", "none" and "host" mode network, no need to configure it with libnetwork.
+	networkMode = config.HostConfig.NetworkMode
+	if container.NetworkSettings.Networks == nil && !IsContainer(networkMode) && !IsHost(networkMode) && !IsNone(networkMode) {
 		container.NetworkSettings.Networks = make(map[string]*types.EndpointSettings)
 		container.NetworkSettings.Networks[config.HostConfig.NetworkMode] = new(types.EndpointSettings)
 	}

--- a/test/cli_run_memory_test.go
+++ b/test/cli_run_memory_test.go
@@ -138,7 +138,6 @@ func (suite *PouchRunMemorySuite) TestRunWithLimitedMemory(c *check.C) {
 	checkFileContains(c, path, "104857600")
 }
 
-
 // TestRunMemoryOOM is to verify return value when a container is OOM.
 func (suite *PouchRunMemorySuite) TestRunMemoryOOM(c *check.C) {
 	cname := "TestRunMemoryOOM"


### PR DESCRIPTION

Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

If the container's network mode is "none", "host" or "container", we don't need to configure the network of container through libnetwork.

As the issue mentioned in #1543 , there will be so many open files when we use pouchd to create almost a thousand containers.

Through my research, the reason is when we create a container and use libnetwork to configure it, it will launch a "resolve server" for it which will open an socket and it will not be closed when the container is stopped and removed.

For CRI part the "resolver server" and libnetwork is both unneeded, so we bypass them in this PR to fix it.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1543 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


