### PR TITLE
enhance: adjust data stream from pouch pull api

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -47,7 +47,7 @@ func (s *Server) pullImage(ctx context.Context, rw http.ResponseWriter, req *htt
 		}
 	}
 	// Error information has be sent to client, so no need call resp.Write
-	if err := s.ImageMgr.PullImage(ctx, image, &authConfig, rw); err != nil {
+	if err := s.ImageMgr.PullImage(ctx, image, &authConfig, newWriteFlusher(rw)); err != nil {
 		logrus.Errorf("failed to pull image %s: %v", image, err)
 		return nil
 	}

--- a/cli/pull.go
+++ b/cli/pull.go
@@ -15,7 +15,7 @@ import (
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/client"
 	"github.com/alibaba/pouch/credential"
-	"github.com/alibaba/pouch/ctrd"
+	"github.com/alibaba/pouch/pkg/jsonstream"
 	"github.com/alibaba/pouch/pkg/reference"
 
 	"github.com/containerd/containerd/progress"
@@ -93,34 +93,44 @@ func showProgress(body io.ReadCloser) error {
 		output = progress.NewWriter(os.Stdout)
 	}
 
+	pos := make(map[string]int)
+	status := []jsonstream.JSONMessage{}
+
 	dec := json.NewDecoder(body)
-	if _, err := dec.Token(); err != nil {
-		return fmt.Errorf("failed to read the opening token: %v", err)
-	}
+	for {
+		var (
+			msg  jsonstream.JSONMessage
+			msgs []jsonstream.JSONMessage
+		)
 
-	refStatus := make(map[string]string)
-	for dec.More() {
-		var infos []ctrd.ProgressInfo
+		if err := dec.Decode(&msg); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
 
-		if err := dec.Decode(&infos); err != nil {
-			return fmt.Errorf("failed to decode: %v", err)
+		change := true
+		if _, ok := pos[msg.ID]; !ok {
+			status = append(status, msg)
+			pos[msg.ID] = len(status) - 1
+		} else {
+			change = (status[pos[msg.ID]].Status != msg.Status)
+			status[pos[msg.ID]] = msg
 		}
 
 		// only display the new status if the stdout is not terminal
 		if !isTerminal {
-			newInfos := make([]ctrd.ProgressInfo, 0)
-			for i, info := range infos {
-				old, ok := refStatus[info.Ref]
-				if !ok || info.Status != old {
-					refStatus[info.Ref] = info.Status
-					newInfos = append(newInfos, infos[i])
-				}
+			// if the status doesn't change, skip to avoid duplicate status
+			if !change {
+				continue
 			}
-
-			infos = newInfos
+			msgs = []jsonstream.JSONMessage{msg}
+		} else {
+			msgs = status
 		}
 
-		if err := displayProgressInfos(output, isTerminal, infos, start); err != nil {
+		if err := displayImageReferenceProgress(output, isTerminal, msgs, start); err != nil {
 			return fmt.Errorf("failed to display progress: %v", err)
 		}
 
@@ -128,27 +138,27 @@ func showProgress(body io.ReadCloser) error {
 			return fmt.Errorf("failed to display progress: %v", err)
 		}
 	}
-
-	if _, err := dec.Token(); err != nil {
-		return fmt.Errorf("failed to read the closing token: %v", err)
-	}
 	return nil
 }
 
-// displayProgressInfos uses tabwriter to show current progress info.
-func displayProgressInfos(output io.Writer, isTerminal bool, infos []ctrd.ProgressInfo, start time.Time) error {
+// displayImageReferenceProgress uses tabwriter to show current progress status.
+func displayImageReferenceProgress(output io.Writer, isTerminal bool, msgs []jsonstream.JSONMessage, start time.Time) error {
 	var (
-		tw    = tabwriter.NewWriter(output, 1, 8, 1, ' ', 0)
-		total = int64(0)
+		tw      = tabwriter.NewWriter(output, 1, 8, 1, ' ', 0)
+		current = int64(0)
 	)
 
-	for _, info := range infos {
-		if info.ErrorMessage != "" {
-			return fmt.Errorf(info.ErrorMessage)
+	for _, msg := range msgs {
+		if msg.Error != nil {
+			return fmt.Errorf(msg.Error.Message)
 		}
 
-		total += info.Offset
-		if _, err := fmt.Fprint(tw, formatProgressInfo(info, isTerminal)); err != nil {
+		if msg.Detail != nil {
+			current += msg.Detail.Current
+		}
+
+		status := jsonstream.PullReferenceStatus(!isTerminal, msg)
+		if _, err := fmt.Fprint(tw, status); err != nil {
 			return err
 		}
 	}
@@ -157,45 +167,13 @@ func displayProgressInfos(output io.Writer, isTerminal bool, infos []ctrd.Progre
 	if isTerminal {
 		_, err := fmt.Fprintf(tw, "elapsed: %-4.1fs\ttotal: %7.6v\t(%v)\t\n",
 			time.Since(start).Seconds(),
-			progress.Bytes(total),
-			progress.NewBytesPerSecond(total, time.Since(start)))
+			progress.Bytes(current),
+			progress.NewBytesPerSecond(current, time.Since(start)))
 		if err != nil {
 			return err
 		}
 	}
 	return tw.Flush()
-}
-
-// formatProgressInfo formats ProgressInfo into string.
-func formatProgressInfo(info ctrd.ProgressInfo, isTerminal bool) string {
-	if !isTerminal {
-		return fmt.Sprintf("%s:\t%s\n", info.Ref, info.Status)
-	}
-
-	switch info.Status {
-	case "downloading", "uploading":
-		var bar progress.Bar
-		if info.Total > 0.0 {
-			bar = progress.Bar(float64(info.Offset) / float64(info.Total))
-		}
-		return fmt.Sprintf("%s:\t%s\t%40r\t%8.8s/%s\t\n",
-			info.Ref,
-			info.Status,
-			bar,
-			progress.Bytes(info.Offset), progress.Bytes(info.Total))
-
-	case "resolving", "waiting":
-		return fmt.Sprintf("%s:\t%s\t%40r\t\n",
-			info.Ref,
-			info.Status,
-			progress.Bar(0.0))
-
-	default:
-		return fmt.Sprintf("%s:\t%s\t%40r\t\n",
-			info.Ref,
-			info.Status,
-			progress.Bar(1.0))
-	}
 }
 
 // pullExample shows examples in pull command, and is used in auto-generated cli docs.

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -99,7 +99,7 @@ func (mgr *ImageManager) PullImage(ctx context.Context, ref string, authConfig *
 	}
 
 	pctx, cancel := context.WithCancel(ctx)
-	stream := jsonstream.New(out)
+	stream := jsonstream.New(out, nil)
 	wait := make(chan struct{})
 
 	go func() {

--- a/pkg/jsonstream/format.go
+++ b/pkg/jsonstream/format.go
@@ -1,7 +1,6 @@
 package jsonstream
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -17,52 +16,21 @@ type Formater interface {
 	Write(o interface{}) ([]byte, error)
 }
 
-var (
-	jsonBeginDelim = []byte("[")
-	jsonEndDelim   = []byte("]")
-	jsonSep        = []byte(",")
-)
-
-// defaultFormat define the pouch's pull progress, is not compatible with docker's pull.
-type defaultFormat struct {
-	beginDelim []byte
-	endDelim   []byte
-	sep        []byte
-	isFirst    bool
-}
+// defaultFormat define the pouch's pull progress.
+type defaultFormat struct{}
 
 func newDefaultFormat() Formater {
-	return &defaultFormat{
-		beginDelim: jsonBeginDelim,
-		endDelim:   jsonEndDelim,
-		sep:        jsonSep,
-		isFirst:    true,
-	}
+	return &defaultFormat{}
 }
 
 func (f *defaultFormat) BeginWrite() ([]byte, error) {
-	return f.beginDelim, nil
+	return nil, nil
 }
 
 func (f *defaultFormat) EndWrite() ([]byte, error) {
-	return f.endDelim, nil
+	return nil, nil
 }
 
 func (f *defaultFormat) Write(o interface{}) ([]byte, error) {
-	b, err := json.Marshal(o)
-	if err != nil {
-		return nil, err
-	}
-
-	if !f.isFirst {
-		buf := bytes.NewBuffer(f.sep)
-		if _, err := buf.Write(b); err != nil {
-			return nil, err
-		}
-		return buf.Bytes(), nil
-	}
-
-	f.isFirst = false
-
-	return b, nil
+	return json.Marshal(o)
 }

--- a/pkg/jsonstream/image_progress.go
+++ b/pkg/jsonstream/image_progress.go
@@ -1,0 +1,47 @@
+package jsonstream
+
+import (
+	"fmt"
+
+	"github.com/containerd/containerd/progress"
+)
+
+const (
+	// PullStatusDownloading represents downloading status.
+	PullStatusDownloading = "downloading"
+	// PullStatusWaiting represents waiting status.
+	PullStatusWaiting = "waiting"
+	// PullStatusResolving represents resolving status.
+	PullStatusResolving = "resolving"
+	// PullStatusResolved represents resolved status.
+	PullStatusResolved = "resolved"
+	// PullStatusExists represents exist status.
+	PullStatusExists = "exists"
+	// PullStatusDone represents done status.
+	PullStatusDone = "done"
+)
+
+// PullReferenceStatus returns the status of pulling the image reference.
+//
+// NOTE: if the stdout is not terminal, it should only show the reference and
+// status without progress bar.
+func PullReferenceStatus(short bool, msg JSONMessage) string {
+	if short || msg.Detail == nil {
+		return fmt.Sprintf("%s:\t%s\n", msg.ID, msg.Status)
+	}
+
+	switch msg.Status {
+	case PullStatusResolving, PullStatusWaiting:
+		return fmt.Sprintf("%s:\t%s\t%40r\t\n", msg.ID, msg.Status, progress.Bar(0.0))
+	case PullStatusDownloading:
+		bar := progress.Bar(0)
+		current, total := progress.Bytes(msg.Detail.Current), progress.Bytes(msg.Detail.Total)
+
+		if msg.Detail.Total > 0 {
+			bar = progress.Bar(float64(current) / float64(total))
+		}
+		return fmt.Sprintf("%s:\t%s\t%40r\t%8.8s/%s\t\n", msg.ID, msg.Status, bar, current, total)
+	default:
+		return fmt.Sprintf("%s:\t%s\t%40r\t\n", msg.ID, msg.Status, progress.Bar(1.0))
+	}
+}

--- a/pkg/jsonstream/stream.go
+++ b/pkg/jsonstream/stream.go
@@ -17,10 +17,10 @@ type JSONStream struct {
 }
 
 // New creates a 'JSONStream' instance and use a goroutine to recv/send data.
-func New(out io.Writer, f ...Formater) *JSONStream {
-	format := newDefaultFormat()
-	if len(f) != 0 {
-		format = f[0]
+func New(out io.Writer, f Formater) *JSONStream {
+	format := f
+	if format == nil {
+		format = newDefaultFormat()
 	}
 
 	stream := &JSONStream{

--- a/pkg/jsonstream/types.go
+++ b/pkg/jsonstream/types.go
@@ -1,0 +1,34 @@
+package jsonstream
+
+import (
+	"time"
+)
+
+// JSONError wraps a concrete Code and Message as error.
+type JSONError struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// Error implement the error interface.
+func (e *JSONError) Error() string {
+	return e.Message
+}
+
+// ProgressDetail represents the status.
+type ProgressDetail struct {
+	Current int64 `json:"current"`
+	Total   int64 `json:"total"`
+}
+
+// JSONMessage defines a message struct for jsonstream.
+// It describes id, status, progress detail, started and updated.
+type JSONMessage struct {
+	ID     string          `json:"id,omitempty"`
+	Status string          `json:"status,omitempty"`
+	Detail *ProgressDetail `json:"progressDetail,omitempty"`
+	Error  *JSONError      `json:"errorDetail,omitempty"`
+
+	StartedAt time.Time `json:"started_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Since the existing swarm, mesos or other scheduled system maybe use the docker client to pull image from PouchContainer, PouchContainer should change data stream to help user to use PouchContainer.

It can help user to migrate to PouchContainer from docker.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1579

### Ⅲ. Describe how you did it

With original design, the PouchContainer uses the array as data packet in the stream. However, the docker client can only consume the json as one packet in the stream. Before this change, we will got the error like that:

```
docker -H {Pouch Daemon Host} pull busybox
json: cannot unmarshal array into Go value of type jsonmessage.JSONMessage 
```

In order to make it happen, we need to adjust data stream with one json object as packet.

### Ⅳ. Describe how to verify it

Basically, we need to confirm the pouch cli does work well.

```
➜  ~ pouch pull ruby
registry.hub.docker.com/library/ruby:latest:                                      resolved |++++++++++++++++++++++++++++++++++++++|
index-sha256:15cf422c8a386c5dc4ffc51875d09f3e70a9350575aabe710117de452ec36159:    done     |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:d2c3ac773b65fc114065f1b649a71f4183d68eb3e56ca44afefe129b56c5824d: done     |++++++++++++++++++++++++++++++++++++++|
layer-sha256:e6fd54c4bb16195b2277ee283c59ea8cab4bc5d3fad9294d0b78c28b48f4e259:    done     |++++++++++++++++++++++++++++++++++++++|
layer-sha256:231cb0e216d30ea48044d44d37fba016eb67eca9b19b29a741d95775359d3533:    done
layer-sha256:3d2aa70286b89febc36370098220c9b2960cc67c03375c9df4e82736519f1e8a:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:e80dfb6a4adf7a00bab2a596e518acdf66c94fd2534023225f6e1a1861f72417:    done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:857bc7ff918f67a8e74abd01dc02308040f7f7f9b99956a815c5a9cb6393f11f:   done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:9fdce3e4507c8079e74b796cebdd63826089d548bb8dfe64a062c08f3a137d7d:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:590d63dda050c79d76f1e39724ad28d12f66d358d7e6aa08ff9ca84e0401fc24:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:d2c05365ee2a2245bb9f6786bc88aa12bf64da676a52668424437826d0f0cb92:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:cc1a78bfd46becbfc3abb8a74d9a70a0e0dc7a5809bbd12e814f9382db003707:    done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 99.6s


➜  ~ pouch pull unknown
registry.hub.docker.com/library/unknown:latest: resolving      |--------------------------------------|
elapsed: 2.4 s                                  total:   0.0 B (0.0 B/s)
Error: failed to display progress: failed to pull image: server message: insufficient_scope: authorization failed
➜  ~ pouch pull busybox:unknown
registry.hub.docker.com/library/busybox:unknown: resolving      |--------------------------------------|
elapsed: 2.4 s                                   total:   0.0 B (0.0 B/s)
Error: failed to display progress: failed to pull image: registry.hub.docker.com/library/busybox:unknown not found
```

For the docker client, 

```
➜  ~ docker -H tcp://localhost:5000 pull busybox:1.25
registry.hub.docker.com/library/busybox:1.25: resolved
manifest-sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912: done [==================================================>]     527B/527B
layer-sha256:56bec22e355981d8ba0878c6c2f23b21f422f30ab0aba188b54f1ffeff59c190: done [==================================================>]  668.2kB/668.2kB
config-sha256:e02e811dd08fd49e7f6032625495118e63f597eb150403d02e3238af1df240ba: done [==================================================>]  1.464kB/1.464kB

➜  ~ docker -H tcp://localhost:5000 pull busybox:unknown
registry.hub.docker.com/library/busybox:unknown: resolving
failed to pull image: registry.hub.docker.com/library/busybox:unknown not found

➜  ~ docker -H tcp://localhost:5000 pull unknown
Using default tag: latest
registry.hub.docker.com/library/unknown:latest: resolving
failed to pull image: server message: insufficient_scope: authorization failed
➜  ~ echo $?
1
```

### Ⅴ. Special notes for reviews


