### PR TITLE
enhance: display network sandbox info for debug

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -67,13 +67,6 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 		return err
 	}
 
-	var netSettings *types.NetworkSettings
-	if c.NetworkSettings != nil {
-		netSettings = &types.NetworkSettings{
-			Networks: c.NetworkSettings.Networks,
-		}
-	}
-
 	mounts := []types.MountPoint{}
 	for _, mp := range c.Mounts {
 		mounts = append(mounts, *mp)
@@ -93,7 +86,7 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 			Data: c.Snapshotter.Data,
 		},
 		Mounts:          mounts,
-		NetworkSettings: netSettings,
+		NetworkSettings: c.NetworkSettings,
 	}
 
 	return EncodeResponse(rw, http.StatusOK, container)


### PR DESCRIPTION
Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

enhance: display network sandbox and more other informations in NetworkSettings for **pouch inspect**


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

NONE

### Ⅳ. Describe how to verify it

```
root@ubuntu-1:~/pouch# pouch inspect 1eff
[
    {
        "Args": null,
        "Created": "2018-06-24T06:45:10.18231873Z",
        "ExecIDs": null,
        "GraphDriver": {
            "Data": {
                "MergedDir": "/var/lib/pouch/containerd/state/io.containerd.runtime.v1.linux/default/1eff63a55384f8900c7a445813f4ab3f1925cd19fbca427eb0c1f48c4af99639/rootfs",
                "UpperDir": "/var/lib/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/835/fs"
            },
            "Name": "overlayfs"
        },
        "HostConfig": {
            "LogConfig": {
                "Type": "json-file"
            },
            "NetworkMode": "bridge",
            "OomScoreAdj": -500,
            "RestartPolicy": {
                "Name": "no"
            },
            "Runtime": "runc",
            "ShmSize": 0,
            "BlkioDeviceReadBps": null,
            "BlkioDeviceReadIOps": null,
            "BlkioDeviceWriteBps": null,
            "BlkioDeviceWriteIOps": null,
            "BlkioWeightDevice": null,
            "CgroupParent": "default",
            "DeviceCgroupRules": null,
            "Devices": [],
            "MemoryExtra": 0,
            "MemorySwappiness": 0,
            "MemoryWmarkRatio": 0,
            "OomKillDisable": false,
            "Ulimits": null
        },
        "Id": "1eff63a55384f8900c7a445813f4ab3f1925cd19fbca427eb0c1f48c4af99639",
        "Image": "registry.hub.docker.com/library/busybox:latest",
        "Mounts": [],
        "Name": "1eff63",
        "NetworkSettings": {
            "Networks": {
                "bridge": {
                    "Aliases": null,
                    "EndpointID": "3fb1ca7f73e0f4c2da7caded9b133d77c352278358959b34865cd96644d9d5f0",
                    "Gateway": "192.168.5.1",
                    "IPAddress": "192.168.5.2",
                    "IPPrefixLen": 24,
                    "Links": null,
                    "MacAddress": "02:42:c0:a8:05:02",
                    "NetworkID": "0f07a5852c5cb1ce5254108ed68134f06bbc3f60a0cae8999a403a6c07ea04c5"
                }
            },
            "SandboxID": "7a78335d06fca3ea79c1c129b4a8b5c8ea29e57db9db666a7fa71ddaa36be0c4",
            "SandboxKey": "/var/run/pouch/netns/7a78335d06fc",
            "SecondaryIPAddresses": null,
            "SecondaryIPv6Addresses": null
        },
        "Snapshotter": {
            "Data": {
                "MergedDir": "/var/lib/pouch/containerd/state/io.containerd.runtime.v1.linux/default/1eff63a55384f8900c7a445813f4ab3f1925cd19fbca427eb0c1f48c4af99639/rootfs",
                "UpperDir": "/var/lib/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/835/fs"
            },
            "Name": "overlayfs"
        },
        "State": {
            "FinishedAt": "2018-06-24T06:58:14.12474128Z",
            "Pid": 1757,
            "StartedAt": "2018-06-24T06:58:26.45954277Z",
            "Status": "running"
        },
        "Config": {
            "Cmd": [
                "sh"
            ],
            "Entrypoint": null,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Hostname": "1eff63a55384",
            "Image": "registry.hub.docker.com/library/busybox:latest",
            "OnBuild": null,
            "Shell": null,
            "Tty": true
        }
    }
]
```


### Ⅴ. Special notes for reviews


