### PR TITLE
enhance: display disconnect result for pouch network disconnect

### DIFF
--- a/cli/network.go
+++ b/cli/network.go
@@ -469,9 +469,7 @@ var networkDisconnectDescription = "Disconnect a container from a network"
 // NetworkDisconnectCommand use to implement 'network disconnect' command, it disconnects given container from given network.
 type NetworkDisconnectCommand struct {
 	baseCommand
-	network   string
-	container string
-	force     bool
+	force bool
 }
 
 // Init initializes 'network disconnect' command.
@@ -497,17 +495,30 @@ func (nd *NetworkDisconnectCommand) addFlags() {
 
 // runNetworkDisconnect is the entry of 'disconnect' command.
 func (nd *NetworkDisconnectCommand) runNetworkDisconnect(args []string) error {
-	nd.network = args[0]
-	nd.container = args[1]
+	network := args[0]
+	container := args[1]
+
+	if network == "" {
+		return fmt.Errorf("network name cannot be empty")
+	}
+	if container == "" {
+		return fmt.Errorf("container name cannot be empty")
+	}
 
 	ctx := context.Background()
 	apiClient := nd.cli.Client()
 
-	return apiClient.NetworkDisconnect(ctx, nd.network, nd.container, nd.force)
+	err := apiClient.NetworkDisconnect(ctx, network, container, nd.force)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("container %s is disconnected from network %s\n successfully", container, network)
+
+	return nil
 }
 
 // networkDisconnectExample shows examples in 'disconnect' command, and is used in auto-generated cli docs.
 func (nd *NetworkDisconnectCommand) networkDisconnectExample() string {
 	return `$ pouch network disconnect bridge test
-	`
+container test is disconnected from network bridge successfully`
 }


### PR DESCRIPTION
Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

enhance: display disconnect result for pouch network disconnect

Now If we disconnect a container from a network, it will display nothing. This PR will print the success message like

```
container test is disconnected from network bridge
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

NONE

### Ⅳ. Describe how to verify it
if **pouch network disconnect** successfully, it will print success
 
### Ⅴ. Special notes for reviews


