### PR TITLE
feature: make runtime choosing supported in CRI managers for Kubernetes

### DIFF
--- a/cri/annotations/annotations.go
+++ b/cri/annotations/annotations.go
@@ -1,0 +1,19 @@
+package annotations
+
+// ContainerType values
+const (
+	// ContainerTypeSandbox represents a pod sandbox container
+	ContainerTypeSandbox = "sandbox"
+
+	// ContainerTypeContainer represents a container running within a pod
+	ContainerTypeContainer = "container"
+
+	// ContainerType is the container type (sandbox or container) annotation
+	ContainerType = "io.kubernetes.cri-o.ContainerType"
+
+	// SandboxName is the sandbox name annotation
+	SandboxName = "io.kubernetes.cri-o.SandboxName"
+
+	// KubernetesRuntime is the runtime
+	KubernetesRuntime = "io.kubernetes.runtime"
+)

--- a/cri/v1alpha1/cri.go
+++ b/cri/v1alpha1/cri.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	apitypes "github.com/alibaba/pouch/apis/types"
+	anno "github.com/alibaba/pouch/cri/annotations"
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/daemon/mgr"
 	"github.com/alibaba/pouch/pkg/errtypes"
@@ -236,6 +237,7 @@ func (c *CriManager) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		ID:        id,
 		Config:    config,
 		NetNSPath: netnsPath,
+		Runtime:   config.Annotations[anno.KubernetesRuntime],
 	}
 	c.SandboxStore.Put(sandboxMeta)
 
@@ -462,6 +464,11 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if iSpec := config.GetImage(); iSpec != nil {
 		image = iSpec.Image
 	}
+
+	specAnnotation := make(map[string]string)
+	specAnnotation[anno.ContainerType] = anno.ContainerTypeContainer
+	specAnnotation[anno.SandboxName] = podSandboxID
+
 	createConfig := &apitypes.ContainerCreateConfig{
 		ContainerConfig: apitypes.ContainerConfig{
 			Entrypoint: config.Command,
@@ -471,9 +478,10 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 			WorkingDir: config.WorkingDir,
 			Labels:     labels,
 			// Interactive containers:
-			OpenStdin: config.Stdin,
-			StdinOnce: config.StdinOnce,
-			Tty:       config.Tty,
+			OpenStdin:      config.Stdin,
+			StdinOnce:      config.StdinOnce,
+			Tty:            config.Tty,
+			SpecAnnotation: specAnnotation,
 		},
 		HostConfig: &apitypes.HostConfig{
 			Binds: generateMountBindings(config.GetMounts()),

--- a/cri/v1alpha1/cri_types.go
+++ b/cri/v1alpha1/cri_types.go
@@ -14,6 +14,9 @@ type SandboxMeta struct {
 
 	// NetNSPath is the network namespace used by the sandbox.
 	NetNSPath string
+
+	// Runtime is the runtime of sandbox
+	Runtime string
 }
 
 // Key returns sandbox's id.

--- a/cri/v1alpha2/cri_types.go
+++ b/cri/v1alpha2/cri_types.go
@@ -14,6 +14,9 @@ type SandboxMeta struct {
 
 	// NetNSPath is the network namespace used by the sandbox.
 	NetNSPath string
+
+	// Runtime is the runtime of sandbox
+	Runtime string
 }
 
 // Key returns sandbox's id.

--- a/cri/v1alpha2/cri_utils.go
+++ b/cri/v1alpha2/cri_utils.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	apitypes "github.com/alibaba/pouch/apis/types"
+	anno "github.com/alibaba/pouch/cri/annotations"
 	"github.com/alibaba/pouch/daemon/mgr"
 	"github.com/alibaba/pouch/pkg/utils"
 
@@ -240,8 +241,13 @@ func makeSandboxPouchConfig(config *runtime.PodSandboxConfig, image string) (*ap
 	labels := makeLabels(config.GetLabels(), config.GetAnnotations())
 	// Apply a label to distinguish sandboxes from regular containers.
 	labels[containerTypeLabelKey] = containerTypeLabelSandbox
-
 	hc := &apitypes.HostConfig{}
+
+	// Apply runtime options.
+	if annotations := config.GetAnnotations(); annotations != nil {
+		hc.Runtime = annotations[anno.KubernetesRuntime]
+	}
+
 	createConfig := &apitypes.ContainerCreateConfig{
 		ContainerConfig: apitypes.ContainerConfig{
 			Hostname: strfmt.Hostname(config.Hostname),
@@ -610,6 +616,16 @@ func applyContainerSecurityContext(lc *runtime.LinuxContainerConfig, podSandboxI
 
 // Apply Linux-specific options if applicable.
 func (c *CriManager) updateCreateConfig(createConfig *apitypes.ContainerCreateConfig, config *runtime.ContainerConfig, sandboxConfig *runtime.PodSandboxConfig, podSandboxID string) error {
+	// Apply runtime options.
+	res, err := c.SandboxStore.Get(podSandboxID)
+	if err != nil {
+		return fmt.Errorf("failed to get metadata of %q from SandboxStore: %v", podSandboxID, err)
+	}
+	sandboxMeta := res.(*SandboxMeta)
+	if sandboxMeta.Runtime != "" {
+		createConfig.HostConfig.Runtime = sandboxMeta.Runtime
+	}
+
 	if lc := config.GetLinux(); lc != nil {
 		// TODO: resource restriction.
 


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1580

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
1. Prerequisites Installation, the runtime binaries you will use is necessary
2. You should start pouchd with the configuration like 
```
pouchd --enable-cri --cri-version v1alpha2 --add-runtime runv=runv >pouchd.log 2>&1  &
```
3. After setting up your kubernetes cluster, you can create a deployment like this :
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: pouch
  labels:
    pouch: pouch
spec:
  selector:
    matchLabels:
      pouch: pouch
  template:
    metadata:
      labels:
        pouch: pouch
      annotations:
        io.kubernetes.runtime: runv
    spec:
      containers:
      - name: pouch
        image: docker.io/library/nginx:latest
        ports:
        - containerPort: 80
```
3. Use command  `pouch ps` to observe the runtime of the container.
### Ⅴ. Special notes for reviews


