### PR TITLE
refactor: move config file from cli into one places

### DIFF
--- a/apis/opts/config/blkio.go
+++ b/apis/opts/config/blkio.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 import (
 	"fmt"
@@ -61,7 +61,8 @@ func (w *WeightDevice) Type() string {
 	return "value"
 }
 
-func (w *WeightDevice) value() []*types.WeightDevice {
+// Value returns all values as type WeightDevice
+func (w *WeightDevice) Value() []*types.WeightDevice {
 	var weightDevice []*types.WeightDevice
 	for _, v := range w.values {
 		weightDevice = append(weightDevice, v)
@@ -118,7 +119,8 @@ func (t *ThrottleBpsDevice) Type() string {
 	return "value"
 }
 
-func (t *ThrottleBpsDevice) value() []*types.ThrottleDevice {
+// Value returns all values as type ThrottleDevice
+func (t *ThrottleBpsDevice) Value() []*types.ThrottleDevice {
 	var throttleDevice []*types.ThrottleDevice
 	for _, v := range t.values {
 		throttleDevice = append(throttleDevice, v)
@@ -175,7 +177,8 @@ func (t *ThrottleIOpsDevice) Type() string {
 	return "value"
 }
 
-func (t *ThrottleIOpsDevice) value() []*types.ThrottleDevice {
+// Value returns all values
+func (t *ThrottleIOpsDevice) Value() []*types.ThrottleDevice {
 	var throttleDevice []*types.ThrottleDevice
 	for _, v := range t.values {
 		throttleDevice = append(throttleDevice, v)

--- a/apis/opts/config/blkio_test.go
+++ b/apis/opts/config/blkio_test.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 import (
 	"reflect"
@@ -239,7 +239,7 @@ func TestWeightDevice_value(t *testing.T) {
 			w := &WeightDevice{
 				values: tt.fields.values,
 			}
-			if got := w.value(); !reflect.DeepEqual(got, tt.want) {
+			if got := w.Value(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("WeightDevice.value() = %v, want %v", got, tt.want)
 			}
 		})
@@ -462,7 +462,7 @@ func TestThrottleBpsDevice_value(t *testing.T) {
 			throttleBpsDevice := &ThrottleBpsDevice{
 				values: tt.fields.values,
 			}
-			if got := throttleBpsDevice.value(); !reflect.DeepEqual(got, tt.want) {
+			if got := throttleBpsDevice.Value(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ThrottleBpsDevice.value() = %v, want %v", got, tt.want)
 			}
 		})
@@ -685,7 +685,7 @@ func TestThrottleIOpsDevice_value(t *testing.T) {
 			throttleIOpsDevice := &ThrottleIOpsDevice{
 				values: tt.fields.values,
 			}
-			if got := throttleIOpsDevice.value(); !reflect.DeepEqual(got, tt.want) {
+			if got := throttleIOpsDevice.Value(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ThrottleIOpsDevice.value() = %v, want %v", got, tt.want)
 			}
 		})

--- a/apis/opts/config/runtime.go
+++ b/apis/opts/config/runtime.go
@@ -1,4 +1,4 @@
-package opt
+package config
 
 import (
 	"fmt"

--- a/apis/opts/config/runtime_test.go
+++ b/apis/opts/config/runtime_test.go
@@ -1,4 +1,4 @@
-package opt
+package config
 
 import (
 	"testing"

--- a/apis/opts/config/ulimit.go
+++ b/apis/opts/config/ulimit.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 import (
 	"fmt"
@@ -43,8 +43,8 @@ func (u *Ulimit) Type() string {
 	return "value"
 }
 
-// value return ulimit values as type ResourcesUlimitsItems0
-func (u *Ulimit) value() []*types.Ulimit {
+// Value return ulimit values as type Ulimit
+func (u *Ulimit) Value() []*types.Ulimit {
 	var ulimit []*types.Ulimit
 	for _, ul := range u.values {
 		ulimit = append(ulimit, &types.Ulimit{

--- a/cli/container.go
+++ b/cli/container.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/alibaba/pouch/apis/opts"
+	"github.com/alibaba/pouch/apis/opts/config"
 	"github.com/alibaba/pouch/apis/types"
 
 	strfmt "github.com/go-openapi/strfmt"
@@ -26,11 +27,11 @@ type container struct {
 	disableNetworkFiles bool
 
 	blkioWeight          uint16
-	blkioWeightDevice    WeightDevice
-	blkioDeviceReadBps   ThrottleBpsDevice
-	blkioDeviceWriteBps  ThrottleBpsDevice
-	blkioDeviceReadIOps  ThrottleIOpsDevice
-	blkioDeviceWriteIOps ThrottleIOpsDevice
+	blkioWeightDevice    config.WeightDevice
+	blkioDeviceReadBps   config.ThrottleBpsDevice
+	blkioDeviceWriteBps  config.ThrottleBpsDevice
+	blkioDeviceReadIOps  config.ThrottleIOpsDevice
+	blkioDeviceWriteIOps config.ThrottleIOpsDevice
 
 	cpushare   int64
 	cpusetcpus string
@@ -69,7 +70,7 @@ type container struct {
 	oomScoreAdj    int64
 	specAnnotation []string
 	cgroupParent   string
-	ulimit         Ulimit
+	ulimit         config.Ulimit
 	pidsLimit      int64
 	shmSize        string
 
@@ -230,16 +231,16 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 
 				// blkio
 				BlkioWeight:          c.blkioWeight,
-				BlkioWeightDevice:    c.blkioWeightDevice.value(),
-				BlkioDeviceReadBps:   c.blkioDeviceReadBps.value(),
-				BlkioDeviceReadIOps:  c.blkioDeviceReadIOps.value(),
-				BlkioDeviceWriteBps:  c.blkioDeviceWriteBps.value(),
-				BlkioDeviceWriteIOps: c.blkioDeviceWriteIOps.value(),
+				BlkioWeightDevice:    c.blkioWeightDevice.Value(),
+				BlkioDeviceReadBps:   c.blkioDeviceReadBps.Value(),
+				BlkioDeviceReadIOps:  c.blkioDeviceReadIOps.Value(),
+				BlkioDeviceWriteBps:  c.blkioDeviceWriteBps.Value(),
+				BlkioDeviceWriteIOps: c.blkioDeviceWriteIOps.Value(),
 
 				Devices:       deviceMappings,
 				IntelRdtL3Cbm: intelRdtL3Cbm,
 				CgroupParent:  c.cgroupParent,
-				Ulimits:       c.ulimit.value(),
+				Ulimits:       c.ulimit.Value(),
 				PidsLimit:     c.pidsLimit,
 			},
 			EnableLxcfs:   c.enableLxcfs,

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/alibaba/pouch/config/opt"
+	optscfg "github.com/alibaba/pouch/apis/opts/config"
 	"github.com/alibaba/pouch/daemon"
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/lxcfs"
@@ -112,7 +112,7 @@ func setupFlags(cmd *cobra.Command) {
 	flagSet.BoolVar(&cfg.EnableProfiler, "enable-profiler", false, "Set if pouchd setup profiler")
 	flagSet.StringVar(&cfg.Pidfile, "pidfile", "/var/run/pouch.pid", "Save daemon pid")
 	flagSet.IntVar(&cfg.OOMScoreAdjust, "oom-score-adj", -500, "Set the oom_score_adj for the daemon")
-	flagSet.Var(opt.NewRuntime(&cfg.Runtimes), "add-runtime", "register a OCI runtime to daemon")
+	flagSet.Var(optscfg.NewRuntime(&cfg.Runtimes), "add-runtime", "register a OCI runtime to daemon")
 
 }
 


### PR DESCRIPTION
move config file cli/ulimit.go, cli/blkio.go, config/opt/runtime.go
to apis/opts/config, put all user defined flag var type into one places.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


