### PR TITLE
bugfix: we should set Running flag to true when started container

### DIFF
--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -403,3 +403,22 @@ func (suite *PouchRunMemorySuite) TestRunWithShm(c *check.C) {
 
 	util.PartialEqual(res.Stdout(), "1048576")
 }
+
+// TestRunSetRunningFlag is to verfy whether set Running Flag in ContainerState
+// when started a container
+func (suite *PouchRunSuite) TestRunSetRunningFlag(c *check.C) {
+	cname := "TestRunSetRunningFlag"
+	res := command.PouchRun("run", "-d", "--name", cname, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
+
+	// test if the value is in inspect result
+	res = command.PouchRun("inspect", cname)
+	res.Assert(c, icmd.Success)
+
+	result := []types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(res.Stdout()), &result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result[0].State.Running, check.Equals, true)
+}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>


### Ⅰ. Describe what this PR did
`SetStatus` set Running flag to true when started a container

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes https://github.com/alibaba/pouch/issues/1602

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


