### PR TITLE
bugfix: fix exec stuck when exec get error

### DIFF
--- a/apis/server/exec_bridge.go
+++ b/apis/server/exec_bridge.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
 )
 
 func (s *Server) createContainerExec(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
@@ -55,8 +56,13 @@ func (s *Server) startContainerExec(ctx context.Context, rw http.ResponseWriter,
 	name := mux.Vars(req)["name"]
 	_, upgrade := req.Header["Upgrade"]
 
+	if err := s.ContainerMgr.CheckExecExist(ctx, name); err != nil {
+		return err
+	}
+
 	var attach *mgr.AttachConfig
 
+	// TODO(huamin.thm): support detach exec process through http post method
 	if !config.Detach {
 		hijacker, ok := rw.(http.Hijacker)
 		if !ok {
@@ -72,7 +78,11 @@ func (s *Server) startContainerExec(ctx context.Context, rw http.ResponseWriter,
 		}
 	}
 
-	return s.ContainerMgr.StartExec(ctx, name, config, attach)
+	if err := s.ContainerMgr.StartExec(ctx, name, attach); err != nil {
+		logrus.Errorf("failed to run exec process: %s", err)
+	}
+
+	return nil
 }
 
 func (s *Server) getExecInfo(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {

--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -186,6 +186,7 @@ func filter(handler handler, s *Server) http.HandlerFunc {
 			return
 		}
 		// Handle error if request handling fails.
+		logrus.Errorf("Handler for %s %s, client %s returns error: %s", req.Method, req.URL.RequestURI(), clientInfo, err)
 		HandleErrorResponse(w, err)
 	}
 }

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -1,15 +1,17 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
-	"sync"
 
 	"github.com/alibaba/pouch/apis/types"
-	"github.com/docker/docker/pkg/stdcopy"
 
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -61,6 +63,7 @@ func (e *ExecCommand) runExec(args []string) error {
 	id := args[0]
 	command := args[1:]
 
+	// TODO(huamin.thm): exec detach not implement now, detach mode not hijack connect
 	createExecConfig := &types.ExecCreateConfig{
 		Cmd:          command,
 		Tty:          e.Terminal,
@@ -85,44 +88,13 @@ func (e *ExecCommand) runExec(args []string) error {
 
 	conn, reader, err := apiClient.ContainerStartExec(ctx, createResp.ID, startExecConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create exec: %v", err)
+		return fmt.Errorf("failed to start exec: %v", err)
 	}
-	defer conn.Close()
 
 	// handle stdio.
-	var wg sync.WaitGroup
-
-	if createExecConfig.AttachStderr || createExecConfig.AttachStdout {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if !e.Terminal {
-				stdcopy.StdCopy(os.Stdout, os.Stderr, reader)
-			} else {
-				io.Copy(os.Stdout, reader)
-			}
-		}()
+	if err := holdHijackConnection(ctx, conn, reader, createExecConfig.AttachStdin, createExecConfig.AttachStdout, createExecConfig.AttachStderr, e.Terminal); err != nil {
+		return err
 	}
-
-	if createExecConfig.AttachStdin {
-		if e.Terminal {
-			in, out, err := setRawMode(true, false)
-			if err != nil {
-				return fmt.Errorf("failed to set raw mode")
-			}
-			defer func() {
-				if err := restoreMode(in, out); err != nil {
-					fmt.Fprintf(os.Stderr, "failed to restore term mode")
-				}
-			}()
-		}
-
-		go func() {
-			io.Copy(conn, os.Stdin)
-		}()
-	}
-
-	wg.Wait()
 
 	execInfo, err := apiClient.ContainerExecInspect(ctx, createResp.ID)
 	if err != nil {
@@ -132,6 +104,65 @@ func (e *ExecCommand) runExec(args []string) error {
 	code := execInfo.ExitCode
 	if code != 0 {
 		return ExitError{Code: int(code)}
+	}
+
+	return nil
+}
+
+func holdHijackConnection(ctx context.Context, conn net.Conn, reader *bufio.Reader, stdin, stdout, stderr, tty bool) error {
+	if stdin && tty {
+		in, out, err := setRawMode(true, false)
+		if err != nil {
+			return fmt.Errorf("failed to set raw mode")
+		}
+		defer func() {
+			if err := restoreMode(in, out); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to restore term mode")
+			}
+		}()
+	}
+
+	stdoutDone := make(chan error, 1)
+	go func() {
+		var err error
+		if stderr || stdout {
+			if !tty {
+				_, err = stdcopy.StdCopy(os.Stdout, os.Stderr, reader)
+			} else {
+				_, err = io.Copy(os.Stdout, reader)
+			}
+		}
+		stdoutDone <- err
+	}()
+
+	stdinDone := make(chan struct{})
+	go func() {
+		if stdin {
+			io.Copy(conn, os.Stdin)
+		}
+
+		// TODO: close write side of conn
+		close(stdinDone)
+	}()
+
+	select {
+	case err := <-stdoutDone:
+		if err != nil {
+			logrus.Debugf("receive stdout error: %s", err)
+			return err
+		}
+
+	case <-stdinDone:
+		if stdout || stderr {
+			select {
+			case err := <-stdoutDone:
+				logrus.Debugf("receive stdout error: %s", err)
+				return err
+			case <-ctx.Done():
+			}
+		}
+
+	case <-ctx.Done():
 	}
 
 	return nil

--- a/cri/v1alpha1/cri.go
+++ b/cri/v1alpha1/cri.go
@@ -773,9 +773,7 @@ func (c *CriManager) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (
 		MuxDisabled: true,
 	}
 
-	startConfig := &apitypes.ExecStartConfig{}
-
-	err = c.ContainerMgr.StartExec(ctx, execid, startConfig, attachConfig)
+	err = c.ContainerMgr.StartExec(ctx, execid, attachConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start exec for container %q: %v", id, err)
 	}

--- a/cri/v1alpha1/cri_stream.go
+++ b/cri/v1alpha1/cri_stream.go
@@ -57,13 +57,12 @@ func (s *streamRuntime) Exec(containerID string, cmd []string, streamOpts *remot
 		return 0, fmt.Errorf("failed to create exec for container %q: %v", containerID, err)
 	}
 
-	startConfig := &apitypes.ExecStartConfig{}
 	attachConfig := &mgr.AttachConfig{
 		Streams:     streams,
 		MuxDisabled: true,
 	}
 
-	err = s.containerMgr.StartExec(ctx, execid, startConfig, attachConfig)
+	err = s.containerMgr.StartExec(ctx, execid, attachConfig)
 	if err != nil {
 		return 0, fmt.Errorf("failed to start exec for container %q: %v", containerID, err)
 	}

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -779,9 +779,7 @@ func (c *CriManager) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (
 		MuxDisabled: true,
 	}
 
-	startConfig := &apitypes.ExecStartConfig{}
-
-	err = c.ContainerMgr.StartExec(ctx, execid, startConfig, attachConfig)
+	err = c.ContainerMgr.StartExec(ctx, execid, attachConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start exec for container %q: %v", id, err)
 	}

--- a/cri/v1alpha2/cri_stream.go
+++ b/cri/v1alpha2/cri_stream.go
@@ -57,13 +57,12 @@ func (s *streamRuntime) Exec(containerID string, cmd []string, streamOpts *remot
 		return 0, fmt.Errorf("failed to create exec for container %q: %v", containerID, err)
 	}
 
-	startConfig := &apitypes.ExecStartConfig{}
 	attachConfig := &mgr.AttachConfig{
 		Streams:     streams,
 		MuxDisabled: true,
 	}
 
-	err = s.containerMgr.StartExec(ctx, execid, startConfig, attachConfig)
+	err = s.containerMgr.StartExec(ctx, execid, attachConfig)
 	if err != nil {
 		return 0, fmt.Errorf("failed to start exec for container %q: %v", containerID, err)
 	}

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -108,13 +108,16 @@ type ContainerMgr interface {
 	CreateExec(ctx context.Context, name string, config *types.ExecCreateConfig) (string, error)
 
 	// StartExec executes a new process in container.
-	StartExec(ctx context.Context, execid string, config *types.ExecStartConfig, attach *AttachConfig) error
+	StartExec(ctx context.Context, execid string, attach *AttachConfig) error
 
 	// InspectExec returns low-level information about exec command.
 	InspectExec(ctx context.Context, execid string) (*types.ContainerExecInspect, error)
 
 	// GetExecConfig returns execonfig of a exec process inside container.
 	GetExecConfig(ctx context.Context, execid string) (*ContainerExecConfig, error)
+
+	// CheckExecExist check if exec process `name` exist
+	CheckExecExist(ctx context.Context, name string) error
 
 	// 3. The following two function is related to network management.
 	// TODO: inconsistency, Connect/Disconnect operation is in newtork_bridge.go in upper API layer.

--- a/test/cli_exec_test.go
+++ b/test/cli_exec_test.go
@@ -143,3 +143,11 @@ func (suite *PouchExecSuite) TestExecExitCode(c *check.C) {
 	command.PouchRun("exec", name, "sh", "-c", "exit 101").Assert(c, icmd.Expected{ExitCode: 101})
 	command.PouchRun("exec", name, "sh", "-c", "exit 0").Assert(c, icmd.Success)
 }
+
+// TestExecFail test exec fail should not hang.
+func (suite *PouchExecSuite) TestExecFail(c *check.C) {
+	name := "TestExecFail"
+	res := command.PouchRun("run", "-d", "--name", name, "-u", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	c.Assert(res.Stderr(), check.NotNil)
+}


### PR DESCRIPTION
when daemon deal with exec process get error, process will get stuck,
since http connection has been hijacked, it won't finish and return
with error message. Fix it by write error message into hijacked
connection, close io when process get error.

fixes: #1151

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes: #1151

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


