### PR TITLE
enhance: add new formatter for syslog

### DIFF
--- a/daemon/logger/syslog/fmt.go
+++ b/daemon/logger/syslog/fmt.go
@@ -23,3 +23,11 @@ func rfc5424MicroFormatterWithTagAsAppName(p srslog.Priority, hostname, tag, con
 		p, 1, timestamp, hostname, tag, pid, tag, content)
 	return msg
 }
+
+func rfc5424MicroFormatterWithSequenceAndTagAsAppName(p srslog.Priority, hostname, tag, content string) string {
+	now := time.Now()
+	pid := os.Getpid()
+	msg := fmt.Sprintf("<%d>%d %d %s %s %s %d %s - %s",
+		p, 1, now.UnixNano(), now.Format(timeRfc5424fmt), hostname, tag, pid, tag, content)
+	return msg
+}

--- a/daemon/logger/syslog/validate.go
+++ b/daemon/logger/syslog/validate.go
@@ -104,6 +104,11 @@ func parseLogFormat(logFmt, proto string) (srslog.Formatter, srslog.Framer, erro
 			return rfc5424MicroFormatterWithTagAsAppName, srslog.RFC5425MessageLengthFramer, nil
 		}
 		return rfc5424MicroFormatterWithTagAsAppName, srslog.DefaultFramer, nil
+	case "rfc5424micro-seq":
+		if proto == secureProto {
+			return rfc5424MicroFormatterWithSequenceAndTagAsAppName, srslog.RFC5425MessageLengthFramer, nil
+		}
+		return rfc5424MicroFormatterWithSequenceAndTagAsAppName, srslog.DefaultFramer, nil
 	default:
 		return nil, nil, ErrInvalidSyslogFormat
 	}

--- a/daemon/logger/syslog/validate_test.go
+++ b/daemon/logger/syslog/validate_test.go
@@ -148,6 +148,16 @@ func TestParseLogFormat(t *testing.T) {
 			formatter: rfc5424MicroFormatterWithTagAsAppName,
 			framer:    srslog.DefaultFramer,
 		}, {
+			fmtTyp:    "rfc5424micro-seq",
+			proto:     "tcp",
+			formatter: rfc5424MicroFormatterWithSequenceAndTagAsAppName,
+			framer:    srslog.DefaultFramer,
+		}, {
+			fmtTyp:    "rfc5424micro-seq",
+			proto:     "tcp+tls",
+			formatter: rfc5424MicroFormatterWithSequenceAndTagAsAppName,
+			framer:    srslog.RFC5425MessageLengthFramer,
+		}, {
 			fmtTyp:   "not support yet",
 			hasError: true,
 		},


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

A lot of log collectors consumes log data and indexs it by the timestamp in millisecond format. In order to make the collector to consume data in the order, we need to add the sequence number in the log. Simplify the case, PouchContainer will uses the nano timestamp as sequene number.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

Add one more syslog formatter

### Ⅳ. Describe how to verify it

First, we should follow the `/var/log/syslog` and run `pouch run --log-driver syslog --log-opt syslog-format=rfc5424micro-seq --log-opt tag={{.DaemonName}} busybox echo hi`.

We will got the message in the syslog like:

```
Jul  2 15:41:02 ubuntu-xenial 1 1530517262291559773 2018-07-02T15:41:02.291559+08:00 ubuntu-xenial pouchd 7335 pouchd - hi
```

### Ⅴ. Special notes for reviews


