### PR TITLE
feature: add memory cgroup check when validate config

### DIFF
--- a/test/cli_run_memory_test.go
+++ b/test/cli_run_memory_test.go
@@ -36,6 +36,8 @@ func (suite *PouchRunMemorySuite) TearDownTest(c *check.C) {
 // TestRunWithMemoryswap is to verify the valid running container
 // with --memory-swap
 func (suite *PouchRunMemorySuite) TestRunWithMemoryswap(c *check.C) {
+	SkipIfFalse(c, environment.IsMemorySwapSupport)
+
 	cname := "TestRunWithMemoryswap"
 	res := command.PouchRun("run", "-d", "-m", "100m",
 		"--memory-swap", "200m",
@@ -149,6 +151,8 @@ func (suite *PouchRunMemorySuite) TestRunMemoryOOM(c *check.C) {
 
 // TestRunWithMemoryFlag test pouch run with memory flags
 func (suite *PouchRunSuite) TestRunWithMemoryFlag(c *check.C) {
+	SkipIfFalse(c, environment.IsMemorySwapSupport)
+
 	cname := "RunWithOnlyMemorySwap"
 	res := command.PouchRun("run", "-d", "--name", cname, "--memory-swap=1g", busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, cname)

--- a/test/cli_run_memory_test.go
+++ b/test/cli_run_memory_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/test/util"
 
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
@@ -144,4 +145,17 @@ func (suite *PouchRunMemorySuite) TestRunMemoryOOM(c *check.C) {
 	ret := command.PouchRun("run", "-m", "20m", "--name", cname, busyboxImage, "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
 	defer DelContainerForceMultyTime(c, cname)
 	ret.Assert(c, icmd.Expected{ExitCode: 137})
+}
+
+// TestRunWithMemoryFlag test pouch run with memory flags
+func (suite *PouchRunSuite) TestRunWithMemoryFlag(c *check.C) {
+	cname := "RunWithOnlyMemorySwap"
+	res := command.PouchRun("run", "-d", "--name", cname, "--memory-swap=1g", busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, cname)
+	c.Assert(util.PartialEqual(res.Stderr(), "You should always set the Memory limit when using Memoryswap limit"), check.IsNil)
+
+	cname = "RunWithMemorySwapLessThanMemory"
+	res = command.PouchRun("run", "-d", "--name", cname, "-m=500m", "--memory-swap=50m", busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, cname)
+	c.Assert(util.PartialEqual(res.Stderr(), "Minimum memoryswap limit should be larger than memory limit"), check.IsNil)
 }

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -401,7 +401,7 @@ func (suite *PouchRunMemorySuite) TestRunWithShm(c *check.C) {
 	res = command.PouchRun("exec", containerID, "df", "-k", "/dev/shm")
 	res.Assert(c, icmd.Success)
 
-	util.PartialEqual(res.Stdout(), "1048576")
+	c.Assert(util.PartialEqual(res.Stdout(), "1048576"), check.IsNil)
 }
 
 // TestRunSetRunningFlag is to verfy whether set Running Flag in ContainerState

--- a/test/environment/env.go
+++ b/test/environment/env.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/alibaba/pouch/client"
+	"github.com/alibaba/pouch/pkg/system"
 
 	"github.com/gotestyourself/gotestyourself/icmd"
 )
@@ -41,6 +42,20 @@ var (
 	// Subnet default subnet for test
 	Subnet = "192.168.1.0/24"
 )
+
+// the following check funtions provide cgroup file avaible check
+var (
+	cgroupInfo *system.CgroupInfo
+
+	// IsMemorySwapSupport checks if memory swap cgroup is avaible
+	IsMemorySwapSupport = func() bool {
+		return cgroupInfo.Memory.MemorySwap
+	}
+)
+
+func init() {
+	cgroupInfo = system.NewCgroupInfo()
+}
 
 // GetBusybox get image info from test environment variable.
 func GetBusybox() {


### PR DESCRIPTION
add two memory cgroup check when create container,
1. --memory-swap should set with --memory
2. value from --memory-swap should greater than --memory.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


