### PR TITLE
bugfix: execConfig remove omitemtpy

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2929,50 +2929,67 @@ definitions:
   ContainerExecInspect:
     type: "object"
     description: holds information about a running process started.
+    required: [ID, Running, ExitCode, ProcessConfig, OpenStdin, OpenStderr, OpenStdout, CanRemove, ContainerID, DetachKeys]
     properties:
       ID:
+        x-nullable: false
         type: "string"
         description: "The ID of this exec"
       Running:
+        x-nullable: false
         type: "boolean"
       ExitCode:
+        x-nullable: false
         type: "integer"
         description: "The last exit code of this container"
       ProcessConfig:
+        x-nullable: false
         $ref: "#/definitions/ProcessConfig"
       OpenStdin:
+        x-nullable: false
         type: "boolean"
       OpenStderr:
+        x-nullable: false
         type: "boolean"
       OpenStdout:
+        x-nullable: false
         type: "boolean"
       CanRemove:
+        x-nullable: false
         type: "boolean"
       ContainerID:
+        x-nullable: false
         type: "string"
         description: "The ID of this container"
       DetachKeys:
+        x-nullable: false
         type: "string"
 
   ProcessConfig:
     type: "object"
     description: ExecProcessConfig holds information about the exec process.
+    required: [privileged, user, tty, entrypoint, arguments]
     properties:
       privileged:
+        x-nullable: false
         type: "boolean"
       user:
+        x-nullable: false
         type: "string"
       tty:
+        x-nullable: false
         type: "boolean"
       entrypoint:
+        x-nullable: false
         type: "string"
       arguments:
+        x-nullable: false
         type: "array"
         items:
           type: "string"
 
   ContainerJSON:
-    description: | 
+    description: |
       ContainerJSON contains response of Engine API:
       GET "/containers/{id}/json"
     type: "object"

--- a/apis/types/container_exec_inspect.go
+++ b/apis/types/container_exec_inspect.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // ContainerExecInspect holds information about a running process started.
@@ -18,34 +19,44 @@ import (
 type ContainerExecInspect struct {
 
 	// can remove
-	CanRemove bool `json:"CanRemove,omitempty"`
+	// Required: true
+	CanRemove bool `json:"CanRemove"`
 
 	// The ID of this container
-	ContainerID string `json:"ContainerID,omitempty"`
+	// Required: true
+	ContainerID string `json:"ContainerID"`
 
 	// detach keys
-	DetachKeys string `json:"DetachKeys,omitempty"`
+	// Required: true
+	DetachKeys string `json:"DetachKeys"`
 
 	// The last exit code of this container
-	ExitCode int64 `json:"ExitCode,omitempty"`
+	// Required: true
+	ExitCode int64 `json:"ExitCode"`
 
 	// The ID of this exec
-	ID string `json:"ID,omitempty"`
+	// Required: true
+	ID string `json:"ID"`
 
 	// open stderr
-	OpenStderr bool `json:"OpenStderr,omitempty"`
+	// Required: true
+	OpenStderr bool `json:"OpenStderr"`
 
 	// open stdin
-	OpenStdin bool `json:"OpenStdin,omitempty"`
+	// Required: true
+	OpenStdin bool `json:"OpenStdin"`
 
 	// open stdout
-	OpenStdout bool `json:"OpenStdout,omitempty"`
+	// Required: true
+	OpenStdout bool `json:"OpenStdout"`
 
 	// process config
-	ProcessConfig *ProcessConfig `json:"ProcessConfig,omitempty"`
+	// Required: true
+	ProcessConfig *ProcessConfig `json:"ProcessConfig"`
 
 	// running
-	Running bool `json:"Running,omitempty"`
+	// Required: true
+	Running bool `json:"Running"`
 }
 
 /* polymorph ContainerExecInspect CanRemove false */
@@ -72,7 +83,52 @@ type ContainerExecInspect struct {
 func (m *ContainerExecInspect) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateCanRemove(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateContainerID(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateDetachKeys(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateExitCode(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateID(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateOpenStderr(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateOpenStdin(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateOpenStdout(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateProcessConfig(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateRunning(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -83,10 +139,82 @@ func (m *ContainerExecInspect) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *ContainerExecInspect) validateCanRemove(formats strfmt.Registry) error {
+
+	if err := validate.Required("CanRemove", "body", bool(m.CanRemove)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerExecInspect) validateContainerID(formats strfmt.Registry) error {
+
+	if err := validate.RequiredString("ContainerID", "body", string(m.ContainerID)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerExecInspect) validateDetachKeys(formats strfmt.Registry) error {
+
+	if err := validate.RequiredString("DetachKeys", "body", string(m.DetachKeys)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerExecInspect) validateExitCode(formats strfmt.Registry) error {
+
+	if err := validate.Required("ExitCode", "body", int64(m.ExitCode)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerExecInspect) validateID(formats strfmt.Registry) error {
+
+	if err := validate.RequiredString("ID", "body", string(m.ID)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerExecInspect) validateOpenStderr(formats strfmt.Registry) error {
+
+	if err := validate.Required("OpenStderr", "body", bool(m.OpenStderr)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerExecInspect) validateOpenStdin(formats strfmt.Registry) error {
+
+	if err := validate.Required("OpenStdin", "body", bool(m.OpenStdin)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerExecInspect) validateOpenStdout(formats strfmt.Registry) error {
+
+	if err := validate.Required("OpenStdout", "body", bool(m.OpenStdout)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *ContainerExecInspect) validateProcessConfig(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.ProcessConfig) { // not required
-		return nil
+	if err := validate.Required("ProcessConfig", "body", m.ProcessConfig); err != nil {
+		return err
 	}
 
 	if m.ProcessConfig != nil {
@@ -97,6 +225,15 @@ func (m *ContainerExecInspect) validateProcessConfig(formats strfmt.Registry) er
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *ContainerExecInspect) validateRunning(formats strfmt.Registry) error {
+
+	if err := validate.Required("Running", "body", bool(m.Running)); err != nil {
+		return err
 	}
 
 	return nil

--- a/apis/types/process_config.go
+++ b/apis/types/process_config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // ProcessConfig ExecProcessConfig holds information about the exec process.
@@ -18,19 +19,24 @@ import (
 type ProcessConfig struct {
 
 	// arguments
+	// Required: true
 	Arguments []string `json:"arguments"`
 
 	// entrypoint
-	Entrypoint string `json:"entrypoint,omitempty"`
+	// Required: true
+	Entrypoint string `json:"entrypoint"`
 
 	// privileged
-	Privileged bool `json:"privileged,omitempty"`
+	// Required: true
+	Privileged bool `json:"privileged"`
 
 	// tty
-	Tty bool `json:"tty,omitempty"`
+	// Required: true
+	Tty bool `json:"tty"`
 
 	// user
-	User string `json:"user,omitempty"`
+	// Required: true
+	User string `json:"user"`
 }
 
 /* polymorph ProcessConfig arguments false */
@@ -52,6 +58,26 @@ func (m *ProcessConfig) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateEntrypoint(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validatePrivileged(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateTty(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateUser(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -60,8 +86,44 @@ func (m *ProcessConfig) Validate(formats strfmt.Registry) error {
 
 func (m *ProcessConfig) validateArguments(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Arguments) { // not required
-		return nil
+	if err := validate.Required("arguments", "body", m.Arguments); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ProcessConfig) validateEntrypoint(formats strfmt.Registry) error {
+
+	if err := validate.RequiredString("entrypoint", "body", string(m.Entrypoint)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ProcessConfig) validatePrivileged(formats strfmt.Registry) error {
+
+	if err := validate.Required("privileged", "body", bool(m.Privileged)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ProcessConfig) validateTty(formats strfmt.Registry) error {
+
+	if err := validate.Required("tty", "body", bool(m.Tty)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ProcessConfig) validateUser(formats strfmt.Registry) error {
+
+	if err := validate.RequiredString("user", "body", string(m.User)); err != nil {
+		return err
 	}
 
 	return nil

--- a/apis/types/registry_service_config.go
+++ b/apis/types/registry_service_config.go
@@ -41,7 +41,7 @@ type RegistryServiceConfig struct {
 	// > are in compliance with any terms that cover redistributing
 	// > nondistributable artifacts.
 	//
-	AllowNondistributableArtifactsCIDRs []string `json:"AllowNondistributableArtifactsCIDRs"`
+	AllowNondistributableArtifactsCIDRs []string `json:"AllowNondistributableArtifactsCIDRs,omitempty"`
 
 	// List of registry hostnames to which nondistributable artifacts can be
 	// pushed, using the format `<hostname>[:<port>]` or `<IP address>[:<port>]`.
@@ -64,7 +64,7 @@ type RegistryServiceConfig struct {
 	// > are in compliance with any terms that cover redistributing
 	// > nondistributable artifacts.
 	//
-	AllowNondistributableArtifactsHostnames []string `json:"AllowNondistributableArtifactsHostnames"`
+	AllowNondistributableArtifactsHostnames []string `json:"AllowNondistributableArtifactsHostnames,omitempty"`
 
 	// index configs
 	IndexConfigs map[string]IndexInfo `json:"IndexConfigs,omitempty"`
@@ -93,10 +93,10 @@ type RegistryServiceConfig struct {
 	// > security, users should add their CA to their system's list of trusted
 	// > CAs instead of enabling this option.
 	//
-	InsecureRegistryCIDRs []string `json:"InsecureRegistryCIDRs"`
+	InsecureRegistryCIDRs []string `json:"InsecureRegistryCIDRs,omitempty"`
 
 	// List of registry URLs that act as a mirror for the official registry.
-	Mirrors []string `json:"Mirrors"`
+	Mirrors []string `json:"Mirrors,omitempty"`
 }
 
 /* polymorph RegistryServiceConfig AllowNondistributableArtifactsCIDRs false */

--- a/daemon/mgr/container_exec.go
+++ b/daemon/mgr/container_exec.go
@@ -112,12 +112,22 @@ func (mgr *ContainerManager) InspectExec(ctx context.Context, execid string) (*t
 		return nil, err
 	}
 
+	entrypoint, args := mgr.getEntrypointAndArgs(execConfig.Cmd)
+	processConfig := &types.ProcessConfig{
+		Privileged: execConfig.Privileged,
+		Tty:        execConfig.Tty,
+		User:       execConfig.User,
+		Arguments:  args,
+		Entrypoint: entrypoint,
+	}
+
 	return &types.ContainerExecInspect{
 		ID: execConfig.ExecID,
 		// FIXME: try to use the correct running status of exec
-		Running:     execConfig.Running,
-		ExitCode:    execConfig.ExitCode,
-		ContainerID: execConfig.ContainerID,
+		Running:       execConfig.Running,
+		ExitCode:      execConfig.ExitCode,
+		ContainerID:   execConfig.ContainerID,
+		ProcessConfig: processConfig,
 	}, nil
 }
 
@@ -132,4 +142,12 @@ func (mgr *ContainerManager) GetExecConfig(ctx context.Context, execid string) (
 		return nil, fmt.Errorf("invalid exec config type")
 	}
 	return execConfig, nil
+}
+
+func (mgr *ContainerManager) getEntrypointAndArgs(cmd []string) (string, []string) {
+	if len(cmd) == 0 {
+		return "", []string{}
+	}
+
+	return cmd[0], cmd[1:]
 }


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

exec inspect return json body align with moby api. delete all `omitemtpy` flag from ContainerExecInspect

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


