### PR TITLE
blkio: allow --blkio-weight-device only base in CFQ

### DIFF
--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -73,6 +73,9 @@ var (
 
 	// PidsLimitWarn is warning for flag --pids-limit
 	PidsLimitWarn = "Current Kernel does not support pids cgroup, discard --pids-limit"
+
+	// CFQWarn is warning for flag --blkio-weight-device
+	CFQWarn = "Weight Device need CFQ IO Scheduler support, discard --blkio-weight-device"
 )
 
 const (

--- a/daemon/mgr/container_utils.go
+++ b/daemon/mgr/container_utils.go
@@ -2,6 +2,7 @@ package mgr
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strconv"
 	"strings"
 
@@ -244,7 +245,19 @@ func validateConfig(config *types.ContainerConfig, hostConfig *types.HostConfig,
 		return warnings, fmt.Errorf("shm-size %d should greater than 0", *hostConfig.ShmSize)
 	}
 
-	// TODO: add more validate here
+	// validate if weight blkio device is cfq io scheduler
+	if len(hostConfig.Resources.BlkioWeightDevice) > 0 {
+		dev := []string{}
+		for _, d := range hostConfig.Resources.BlkioWeightDevice {
+			dev = append(dev, d.Path)
+		}
+		if !isCFQScheduler(dev) {
+			logrus.Warn(CFQWarn)
+			warnings = append(warnings, CFQWarn)
+			hostConfig.Resources.BlkioWeightDevice = []*types.WeightDevice{}
+		}
+	}
+
 	return warnings, nil
 }
 
@@ -378,4 +391,21 @@ func amendContainerSettings(config *types.ContainerConfig, hostConfig *types.Hos
 	if r.Memory > 0 && r.MemorySwap == 0 {
 		r.MemorySwap = 2 * r.Memory
 	}
+}
+
+// isCFQScheduler checks if dev slice is all cfq io scheduler
+func isCFQScheduler(dev []string) bool {
+	for _, d := range dev {
+		index := strings.LastIndex(d, "/")
+		raw, err := ioutil.ReadFile(fmt.Sprintf("/sys/block/%s/queue/scheduler", d[index+1:]))
+		if err != nil {
+			// continue if file can not open
+			continue
+		}
+		if !strings.Contains(string(raw), "[cfq]") {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
weight device setting only allow in cfq io scheduler, check io scheduler
used by device, since --blkio-weight-device can pass more than one device,
we assume that if one device is not meets the conditions, then the weight
is not suit for all device, we will discard all parameters.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

weight device setting only allow in cfq io scheduler, check io scheduler
used by device, since --blkio-weight-device can pass more than one device,
we assume that if one device is not meets the conditions, then the weight
is not suit for all device, we will discard all parameters.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


