### PR TITLE
bugfix: list image should ignore error if containerd can't handle well

### DIFF
--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -150,7 +150,8 @@ func (mgr *ImageManager) ListImages(ctx context.Context, filter ...string) ([]ty
 	for _, img := range imgs {
 		imgCfg, err := img.Config(ctx)
 		if err != nil {
-			return nil, err
+			logrus.Warnf("failed to get image config info during list images: %v", err)
+			continue
 		}
 
 		if _, ok := imgInfosIndexByID[imgCfg.Digest.String()]; ok {
@@ -159,10 +160,10 @@ func (mgr *ImageManager) ListImages(ctx context.Context, filter ...string) ([]ty
 
 		imgInfo, err := mgr.containerdImageToImageInfo(ctx, img)
 		if err != nil {
-			return nil, err
+			logrus.Warnf("failed to convert containerd image(%v) to ImageInfo during list images: %v", img.Name(), err)
+			continue
 		}
 		imgInfosIndexByID[imgInfo.ID] = imgInfo
-
 	}
 
 	imgInfos := make([]types.ImageInfo, 0, len(imgInfosIndexByID))


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Since the containerd doesn't identify the application/octet-stream media
type, it will cause ListImages API fails to return images to the caller.
In order to avoid odd thing happen and add patch to containerd, we
should ignore the error to make PouchContainer robust.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Fixed #1583

### Ⅲ. Describe how you did it

Ignore the error.

### Ⅳ. Describe how to verify it

1. pouch pull redis:2
2. pouch images

```
➜  pouch git:(bugfix_make_image_list_successful) pouch images
IMAGE ID       IMAGE NAME                                       SIZE
8c811b4aec35   docker.io/library/busybox:1                      710.81 KB
8c811b4aec35   docker.io/library/busybox:1-uclibc               710.81 KB
8c811b4aec35   registry.hub.docker.com/library/busybox:latest   710.81 KB
```

3. check the pouch daemon log

```
WARN[2018-07-05T10:22:06.69910634+08:00] encountered unknown type application/octet-stream; children may not be fetched
WARN[2018-07-05T10:22:06.703451915+08:00] failed to convert containerd image(registry.hub.docker.com/library/redis:2) to ImageInfo during list images: unknown image config media type application/octet-stream
```

### Ⅴ. Special notes for reviews


