### PR TITLE
Add unit-test for ValidateCPUQuota

### DIFF
--- a/apis/opts/cpu_test.go
+++ b/apis/opts/cpu_test.go
@@ -1,0 +1,32 @@
+package opts
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestValidateCPUPeriod(t *testing.T) {
+	//TODO
+}
+
+func TestValidateCPUQuota(t *testing.T) {
+	// TODO
+	tests := []struct {
+		name    string
+		period  int64
+		wantErr bool
+	}{
+		//测试用例
+		{name: "test1", period: 0, wantErr: false},
+		{name: "test2", period: rand.Int63n(1000), wantErr: true},
+		{name: "test2", period: 1001, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCPUPeriod(tt.period)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCPUQuota() error = %v", err) //若不符合预期则报错
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ⅰ. Issue Description
Add unit-test for ValidateCPUQuota method which locate on apis/opts/cpu.go.

Ⅱ. Describe what happened
Add unit-test for ValidateCPUQuota method which locate on apis/opts/cpu.go
Ⅲ. Describe what you expected to happen
All test case passed.
Ⅳ. How to reproduce it (as minimally and precisely as possible)
Ⅴ. Anything else we need to know?
Baiji 262 group 2.

Ⅵ. Environment:
pouch version (use pouch version):go1.10.3 darwin/amd64
OS (e.g. from /etc/os-release):  CentOS linux 7
Kernel (e.g. uname -a):3.10.0 
Install tools: visualbox git go
Others:none