### PR TITLE
Add unit-test for ValidateCPUPeriod

### DIFF
--- a/apis/opts/cpu_test.go
+++ b/apis/opts/cpu_test.go
@@ -10,7 +10,7 @@ func TestValidateCPUPeriod(t *testing.T) {
 		period  int64
 		wantErr bool
 	}{
-		{name: "test1", period: 0, wantErr: true},
+		{name: "test1", period: 0, wantErr: false},
 		{name: "test2", period: 999, wantErr: true},
 		{name: "test3", period: 1001, wantErr: false},
 		{name: "test4", period: 1000001, wantErr: true},

--- a/apis/opts/cpu_test.go
+++ b/apis/opts/cpu_test.go
@@ -5,7 +5,24 @@ import (
 )
 
 func TestValidateCPUPeriod(t *testing.T) {
-	// TODO
+	tests := []struct {
+		name    string
+		period  int64
+		wantErr bool
+	}{
+		{name: "test1", period: 0, wantErr: true},
+		{name: "test2", period: 999, wantErr: true},
+		{name: "test3", period: 1001, wantErr: false},
+		{name: "test4", period: 1000001, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCPUPeriod(tt.period)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCPUPeriod() error = %v", err)
+			}
+		})
+	}
 }
 
 func TestValidateCPUQuota(t *testing.T) {


### PR DESCRIPTION
## Ⅰ. Issue Description
Add unit-test for ValidateCPUPeriod method which locate on apis/opts/cpu.go.
fixes #1637 

## Ⅱ. Describe what happened
Add unit-test for ValidateCPUPeriod method which locate on apis/opts/cpu.go

## Ⅲ. Describe what you expected to happen
All test case passed.

## Ⅳ. How to reproduce it (as minimally and precisely as possible)

## Ⅴ. Anything else we need to know?
Baiji 262 group 2.

Ⅵ. Environment:
pouch version (use pouch version):go1.10.3 darwin/amd64
OS (e.g. from /etc/os-release):  CentOS linux 7
Kernel (e.g. uname -a):3.10.0 
Install tools: visualbox git go
Others:none