### PR TITLE
enhance: add ExtraAttribute functionality in LogInfo

### DIFF
--- a/daemon/logger/info.go
+++ b/daemon/logger/info.go
@@ -1,6 +1,9 @@
 package logger
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/alibaba/pouch/pkg/utils"
 )
 
@@ -13,6 +16,7 @@ type Info struct {
 	ContainerID      string
 	ContainerName    string
 	ContainerImageID string
+	ContainerEnvs    []string
 	ContainerLabels  map[string]string
 	ContainerRootDir string
 
@@ -42,4 +46,65 @@ func (i *Info) ImageID() string {
 // ImageFullID returns the container's image ID.
 func (i *Info) ImageFullID() string {
 	return i.ContainerImageID
+}
+
+// ExtraAttributes returns the user-defined extra attributes (labels, environment
+// variables) in key-value format.
+//
+// NOTE: This can be used by log-driver which support metadata in log file.
+func (i *Info) ExtraAttributes(keyMod func(string) string) (map[string]string, error) {
+	extra := make(map[string]string)
+
+	// extra specific labels from container labels
+	labels, ok := i.LogConfig["labels"]
+	if ok && len(labels) > 0 {
+		for _, l := range strings.Split(labels, ",") {
+			if v, ok := i.ContainerLabels[l]; ok {
+				if keyMod != nil {
+					l = keyMod(l)
+				}
+				extra[l] = v
+			}
+		}
+	}
+
+	containerEnvs := make(map[string]string)
+	for _, e := range i.ContainerEnvs {
+		if kv := strings.SplitN(e, "=", 2); len(kv) == 2 {
+			containerEnvs[kv[0]] = kv[1]
+		}
+	}
+
+	// extra specific envs from container envs
+	env, ok := i.LogConfig["env"]
+	if ok && len(env) > 0 {
+		for _, l := range strings.Split(env, ",") {
+			if v, ok := containerEnvs[l]; ok {
+				if keyMod != nil {
+					l = keyMod(l)
+				}
+				extra[l] = v
+			}
+		}
+	}
+
+	// extra specific envs from container envs by regex
+	envRegex, ok := i.LogConfig["env-regex"]
+	if ok && len(envRegex) > 0 {
+		re, err := regexp.Compile(envRegex)
+		if err != nil {
+			return nil, err
+		}
+
+		for k, v := range containerEnvs {
+			if re.MatchString(k) {
+				if keyMod != nil {
+					k = keyMod(k)
+				}
+				extra[k] = v
+			}
+		}
+	}
+
+	return extra, nil
 }

--- a/daemon/logger/info_test.go
+++ b/daemon/logger/info_test.go
@@ -1,0 +1,52 @@
+package logger
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestInfoExtractAttributes(t *testing.T) {
+	info := Info{
+		LogConfig: map[string]string{
+			"env":    "app",
+			"labels": "VERSION",
+		},
+		ContainerEnvs:   []string{"app=pouchcontainer"},
+		ContainerLabels: map[string]string{"VERSION": "unknown-oops"},
+	}
+
+	for idx, tc := range []struct {
+		keyMod   func(string) string
+		expected map[string]string
+	}{
+		{
+			keyMod: nil,
+			expected: map[string]string{
+				"app":     "pouchcontainer",
+				"VERSION": "unknown-oops",
+			},
+		}, {
+			keyMod: strings.Title,
+			expected: map[string]string{
+				"App":     "pouchcontainer",
+				"VERSION": "unknown-oops",
+			},
+		}, {
+			keyMod: strings.ToUpper,
+			expected: map[string]string{
+				"APP":     "pouchcontainer",
+				"VERSION": "unknown-oops",
+			},
+		},
+	} {
+		got, err := info.ExtraAttributes(tc.keyMod)
+		if err != nil {
+			t.Fatalf("[%d case] expect no error here, but got error: %v", idx, err)
+		}
+
+		if !reflect.DeepEqual(got, tc.expected) {
+			t.Fatalf("[%d case] expect %v, but got %v", idx, tc.expected, got)
+		}
+	}
+}

--- a/daemon/mgr/container_logger.go
+++ b/daemon/mgr/container_logger.go
@@ -43,6 +43,7 @@ func (mgr *ContainerManager) convContainerToLoggerInfo(c *Container) logger.Info
 		ContainerName:    c.Name,
 		ContainerImageID: c.Image,
 		ContainerLabels:  c.Config.Labels,
+		ContainerEnvs:    c.Config.Env,
 		ContainerRootDir: mgr.Store.Path(c.ID),
 		DaemonName:       "pouchd",
 	}


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Allow user to consume container's labels and envs data in log file.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

Add `ExtraAttributes` function for `Info` so that we can use template to consume the data from container.

### Ⅳ. Describe how to verify it

```
pouch run -it \
     --env VERSION=unknown-oops \
     --label from=me \
     --log-driver syslog \
     --log-opt env=VERSION \
     --log-opt labels=from \
     --log-opt "tag={{with .ExtraAttributes nil}}version is {{.VERSION}} from {{.from}}{{end}}" \
     busybox echo hello
```

We will get the log data in `/var/log/syslog`

```
Jul 11 18:00:59 ubuntu-xenial version is unknown-oops from me[6609]: hello
```

### Ⅴ. Special notes for reviews


