### PR TITLE
fix: check user/group in container start

### DIFF
--- a/daemon/mgr/container_exec.go
+++ b/daemon/mgr/container_exec.go
@@ -84,7 +84,8 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, attac
 		execConfig.User = c.Config.User
 	}
 
-	uid, gid, err := user.Get(c.BaseFS, execConfig.User)
+	uid, gid, additionalGids, err := user.Get(c.GetSpecificBasePath(user.PasswdFile),
+		c.GetSpecificBasePath(user.GroupFile), execConfig.User, c.HostConfig.GroupAdd)
 	if err != nil {
 		return err
 	}
@@ -97,7 +98,7 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, attac
 		User: specs.User{
 			UID:            uid,
 			GID:            gid,
-			AdditionalGids: user.GetAdditionalGids(c.HostConfig.GroupAdd),
+			AdditionalGids: additionalGids,
 		},
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -460,3 +460,12 @@ func ConvertStrToKV(input string) (string, string, error) {
 	}
 	return results[0], results[1], nil
 }
+
+// IsFileExist checks if file is exits on host.
+func IsFileExist(file string) bool {
+	if _, err := os.Stat(file); err == nil {
+		return true
+	}
+
+	return false
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -667,3 +667,58 @@ func TestConvertStrToKV(t *testing.T) {
 		})
 	}
 }
+
+func TestIsFileExist(t *testing.T) {
+	assert := assert.New(t)
+	tempDir, err := ioutil.TempDir("/tmp", "")
+	assert.NoError(err)
+	defer os.RemoveAll(tempDir)
+	existPath := make([]string, 0)
+	for _, v := range []string{
+		"a", "b", "c", "d", "e",
+	} {
+		path := filepath.Join(tempDir, v)
+		existPath = append(existPath, path)
+		os.Create(path)
+	}
+
+	for _, t := range []struct {
+		path  string
+		exist bool
+	}{
+		{
+			path:  existPath[0],
+			exist: true,
+		},
+		{
+			path:  existPath[1],
+			exist: true,
+		},
+		{
+			path:  existPath[2],
+			exist: true,
+		},
+		{
+			path:  existPath[3],
+			exist: true,
+		},
+		{
+			path:  existPath[4],
+			exist: true,
+		},
+		{
+			path:  filepath.Join(tempDir, "foo"),
+			exist: false,
+		},
+		{
+			path:  filepath.Join(tempDir, "bar"),
+			exist: false,
+		},
+		{
+			path:  filepath.Join(tempDir, "foo/bar"),
+			exist: false,
+		},
+	} {
+		assert.Equal(IsFileExist(t.path), t.exist)
+	}
+}


### PR DESCRIPTION
user parameter passed by pouch run --user is not validate in container
start process, since we just try to find file in BaseFS, but BaseFS is
created in containerd, so we pass the validate. Fix this by find file in
image container use.
Add function Get which has GetUser and GetAdditionalGids function as a
interface in pkg/user package.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


