### PR TITLE
refactor: split container env and add unit test

### DIFF
--- a/daemon/mgr/container_envs.go
+++ b/daemon/mgr/container_envs.go
@@ -1,0 +1,180 @@
+package mgr
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/alibaba/pouch/pkg/utils"
+
+	"github.com/magiconair/properties"
+	"github.com/sirupsen/logrus"
+)
+
+// container env is used to manage environment variables in container.
+// In original ways, processes in container can only accepted env when startup.
+// And container engine would store those data in container.json which is persistent on local disk.
+// There is no env ralated data in container or image.
+//
+// While for rich container mode, env management in container is a little bit complicated.
+// First, introduce some scenarios in practice:
+// * init process in rich container will not pass envs to user-specific CMD process if user switched from root;
+// * newly created shell command should herit all envs of the container, so all envs should be stored in dir
+// /etc/profild.d/*.sh (here is pouchenv.sh). After that a process execed from outside would take env of init process,
+// then such action like reload of detailed user application could share the env.
+const (
+	// containerInstanceInfo is file in the container image.
+	// row in this file has content like `env_appDeployType = taoJavaWeb`
+	containerInstanceInfo = "/etc/instanceInfo"
+	// pouchEnvDir =
+	pouchEnvDir = "/etc/profile.d"
+	// this filepath is used in PouchContainer to store user input env via persistent file
+	pouchEnvFile = "/etc/profile.d/pouchenv.sh"
+)
+
+// updateContainerEnv update the container's envs in
+// /etc/instanceInfo and /etc/profile.d/pouchenv.sh
+// Env used by rich container.
+func updateContainerEnv(inputRawEnv []string, baseFs string) error {
+	var (
+		envPropertiesPath = path.Join(baseFs, containerInstanceInfo)
+		envShPath         = path.Join(baseFs, pouchEnvFile)
+	)
+
+	// check the existence of related files.
+	// if dir of pouch.sh is not exist, it's unnecessary to update that files.
+	if _, err := os.Stat(path.Join(baseFs, pouchEnvDir)); err != nil {
+		return nil
+	}
+	if _, err := os.Stat(envPropertiesPath); err != nil {
+		//if etc/instanceInfo is not exist, it's unnecessary to update that file.
+		return nil
+	}
+	if _, err := os.Stat(envShPath); err != nil {
+		return fmt.Errorf("failed to stat container's env file /etc/profile.d/pouchenv.sh: %v", err)
+	}
+
+	inputEnv := utils.ConvertKVStrToMapWithNoErr(inputRawEnv)
+
+	localEnv, err := getLocalEnv(envShPath)
+	if err != nil {
+		return fmt.Errorf("failed to get local env from file %s: %v", envShPath, err)
+	}
+
+	newEnv := combineLocalAndInputEnv(inputEnv, localEnv)
+
+	// start to construct new content for file pouchenv.sh after combining
+	// original local envs extracted from pouchenv.sh and input envs.
+	var str string
+	for key, value := range newEnv {
+		str += fmt.Sprintf("export %s=\"%s\"\n", key, value)
+	}
+	ioutil.WriteFile(envShPath, []byte(str), 0755)
+
+	p, err := properties.LoadFile(envPropertiesPath, properties.ISO_8859_1)
+	if err != nil {
+		return fmt.Errorf("failed to properties load container's environment variable file(/etc/instanceInfo): %v", err)
+	}
+
+	for key, val := range newEnv {
+		if v, ok := p.Get("env_" + key); ok {
+			if key == "PATH" {
+				val = val + ":$PATH"
+			}
+			if v == val {
+				continue
+			}
+			_, _, err := p.Set("env_"+key, val)
+			if err != nil {
+				return fmt.Errorf("failed to properties set value key=%s, value=%s: %v", "env_"+key, val, err)
+			}
+			logrus.Infof("the environment variable exist and the value is not same, key=%s, old value=%s, new value=%s", "env_"+key, v, val)
+		} else {
+			_, _, err := p.Set("env_"+key, val)
+			if err != nil {
+				return fmt.Errorf("failed to properties set value key=%s, value=%s: %v", "env_"+key, val, err)
+			}
+			logrus.Infof("the environment variable not exist and set the new key value pair, key=%s, value=%s", "env_"+key, val)
+		}
+	}
+
+	f, err := os.Create(envPropertiesPath)
+	if err != nil {
+		return fmt.Errorf("failed to create container's environment variable file(properties): %v", err)
+	}
+	defer f.Close()
+
+	_, err = p.Write(f, properties.ISO_8859_1)
+	if err != nil {
+		return fmt.Errorf("failed to write to container's environment variable file(properties): %v", err)
+	}
+
+	return nil
+}
+
+// getLocalEnv gets local ENV from specified env shell files.
+// Currently this is file /etc/profile.d/pouchenv.sh in the container.
+// And every row of this file has a format of `export AAA="BBB"`.
+func getLocalEnv(filename string) (map[string]string, error) {
+	envMap := make(map[string]string)
+
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read env file %s: %v", filename, err)
+	}
+
+	rawData := string(b)
+	envsh := strings.Trim(rawData, "\n")
+	envs := strings.Split(envsh, "\n")
+	for _, env := range envs {
+		env = strings.TrimPrefix(env, "export ")
+		key, value, err := utils.ConvertStrToKV(env)
+		if err != nil {
+			// TODO: just ignore the error or return err?
+			return envMap, err
+		}
+		// FIXME: do we need to string.Trim(value, "\"")
+		envMap[key] = value
+	}
+
+	return envMap, nil
+}
+
+// combineLocalAndInputEnv combines local envs extracted from pouchenv.sh and input envs.
+// traverse env(key, value) from local file, and replace it if key also exists in input env.
+// traverse env(key, value) from input env, if it does not exist in local env, just append it.
+// FIXME: why not just only traverse input env?
+func combineLocalAndInputEnv(inputEnv, localEnv map[string]string) map[string]string {
+	for key, valueInLocal := range localEnv {
+		valueInInput, exist := inputEnv[key]
+		if !exist {
+			// if key in the local env does not exist in input env,
+			// it means this key will never be updated by input env.
+			continue
+		}
+		// key in local env exists in input env.
+		// TODO: explain this part by ziren
+		s := strings.Replace(valueInInput, "\"", "\\\"", -1)
+		valueInInput = strings.Replace(s, "$", "\\$", -1)
+
+		if key == "PATH" {
+			// FIXME: how to do if there is already a substr of `:$PATH` in itself.
+			valueInInput = valueInInput + ":$PATH"
+		}
+		// two values are not equal, use the input one.
+		if valueInInput != valueInLocal {
+			logrus.Infof("env exists and the value is not same, key=%s, old value=%s, new value=%s", key, valueInLocal, valueInInput)
+			localEnv[key] = valueInInput
+		}
+	}
+	// append the brand new input env to local env map.
+	for key, value := range inputEnv {
+		if _, ok := localEnv[key]; !ok {
+			logrus.Infof("env does not exist, set new key value pair, new key=%s, new value=%s", key, value)
+			localEnv[key] = value
+		}
+	}
+	return localEnv
+}

--- a/daemon/mgr/container_envs_test.go
+++ b/daemon/mgr/container_envs_test.go
@@ -1,0 +1,195 @@
+package mgr
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func Test_updateContainerEnv(t *testing.T) {
+	type args struct {
+		inputRawEnv []string
+		baseFs      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+	// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := updateContainerEnv(tt.args.inputRawEnv, tt.args.baseFs); (err != nil) != tt.wantErr {
+				t.Errorf("updateContainerEnv() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_combineLocalAndInputEnv(t *testing.T) {
+	type args struct {
+		inputEnv map[string]string
+		localEnv map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "normal test case",
+			args: args{
+				inputEnv: map[string]string{
+					"A": "B",
+					"C": "D",
+				},
+				localEnv: map[string]string{
+					"AA": "BB",
+					"CC": "DD",
+				},
+			},
+			want: map[string]string{
+				"A":  "B",
+				"C":  "D",
+				"AA": "BB",
+				"CC": "DD",
+			},
+		},
+		{
+			name: "normal test case with input env exists in local env, so to replace",
+			args: args{
+				inputEnv: map[string]string{
+					"A": "B",
+					"B": "C",
+					"C": "D",
+				},
+				localEnv: map[string]string{
+					"A": "C",
+					"B": "C",
+				},
+			},
+			want: map[string]string{
+				"A": "B",
+				"B": "C",
+				"C": "D",
+			},
+		},
+		{
+			name: "normal test case with PATH both in input and local",
+			args: args{
+				inputEnv: map[string]string{
+					"PATH": "/sbin",
+					"key":  "value",
+				},
+				localEnv: map[string]string{
+					"PATH": "/usr/local/bin:$PATH",
+					"A":    "B",
+				},
+			},
+			want: map[string]string{
+				"PATH": "/sbin:$PATH",
+				"key":  "value",
+				"A":    "B",
+			},
+		},
+		{
+			name: "normal test case with no PATH in input",
+			args: args{
+				inputEnv: map[string]string{
+					"key": "value",
+				},
+				localEnv: map[string]string{
+					"PATH": "/usr/local/bin:$PATH",
+					"A":    "B",
+				},
+			},
+			want: map[string]string{
+				"PATH": "/usr/local/bin:$PATH",
+				"key":  "value",
+				"A":    "B",
+			},
+		},
+		{
+			name: "normal test case with no PATH in local",
+			args: args{
+				inputEnv: map[string]string{
+					"PATH": "/usr/local/bin:$PATH",
+					"key":  "value",
+				},
+				localEnv: map[string]string{
+					"A": "B",
+				},
+			},
+			want: map[string]string{
+				"PATH": "/usr/local/bin:$PATH",
+				"key":  "value",
+				"A":    "B",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := combineLocalAndInputEnv(tt.args.inputEnv, tt.args.localEnv); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("combineLocalAndInputEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getLocalEnv(t *testing.T) {
+	file1, err := ioutil.TempFile("", "file1")
+	if err != nil {
+		t.Fatalf("failed to to create tmpfile file1 %v", err)
+	}
+	defer os.Remove(file1.Name())
+
+	content := `
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+export SYSCONF_COMM="java"
+export MAX_PROCESSORS_LIMIT="4"
+export MAX_CPU_QUOTA="400"
+export appDeployType="JavaWeb"
+export exec_scm_hook="yes"
+`
+	if _, err := file1.Write([]byte(content)); err != nil {
+		t.Fatalf("failed to write content to temp file")
+	}
+
+	type args struct {
+		filename string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "normal test case",
+			args: args{filename: file1.Name()},
+			want: map[string]string{
+				"PATH":                 "\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH\"",
+				"SYSCONF_COMM":         "\"java\"",
+				"MAX_PROCESSORS_LIMIT": "\"4\"",
+				"MAX_CPU_QUOTA":        "\"400\"",
+				"appDeployType":        "\"JavaWeb\"",
+				"exec_scm_hook":        "\"yes\"",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getLocalEnv(tt.args.filename)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getLocalEnv() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getLocalEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -568,3 +568,102 @@ func TestConvertKVStringsToMap(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertKVStrToMapWithNoErr(t *testing.T) {
+	type args struct {
+		values []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "normal case",
+			args: args{[]string{"a=b", "c=d"}},
+			want: map[string]string{"a": "b", "c": "d"},
+		},
+		{
+			name: "normal case with empty string",
+			args: args{[]string{"a=b", ""}},
+			want: map[string]string{"a": "b"},
+		},
+		{
+			name: "normal case with duplicated key but with different value",
+			args: args{[]string{"a=b", "a==bb"}},
+			want: map[string]string{"a": "=bb"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConvertKVStrToMapWithNoErr(tt.args.values); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ConvertKVStrToMapWithNoErr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertStrToKV(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   string
+		wantErr bool
+	}{
+		{
+			name: "normal case",
+			args: args{
+				input: "a=b",
+			},
+			want:    "a",
+			want1:   "b",
+			wantErr: false,
+		},
+		{
+			name: "normal case",
+			args: args{
+				input: "a=b===",
+			},
+			want:    "a",
+			want1:   "b===",
+			wantErr: false,
+		},
+		{
+			name: "empty failure case",
+			args: args{
+				input: "",
+			},
+			want:    "",
+			want1:   "",
+			wantErr: true,
+		},
+		{
+			name: "no equal mark failure case",
+			args: args{
+				input: "asdfghjk",
+			},
+			want:    "",
+			want1:   "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := ConvertStrToKV(tt.args.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertStrToKV() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ConvertStrToKV() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("ConvertStrToKV() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This PR tried to refactor code of updateContainerEnv function:

* split the function from container.go to be decoupled in container_env.go;
* split some detailed implementation to be encapsulated in some functions, like getLocalEnv, like combineLocalAndInputEnv.

This pr also adds some unit tests.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Describe how you did it
none


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews
@HusterWan 


