### PR TITLE
bugfix: deb package build failed

### DIFF
--- a/hack/package/deb/Makefile
+++ b/hack/package/deb/Makefile
@@ -38,7 +38,6 @@ clean:
 
 #.PHONY: modules
 modules:
-	@./hack/module --add-volume=github.com/alibaba/pouch/storage/volume/modules/ceph
 	@./hack/module --add-volume=github.com/alibaba/pouch/storage/volume/modules/tmpfs
 	@./hack/module --add-volume=github.com/alibaba/pouch/storage/volume/modules/local
 


### PR DESCRIPTION
As we remove the ceph volume modules, the deb package building failed.
We will remove the ceph dependency in Makefile

Signed-off-by: Eric Li <lcy041536@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

As we remove the ceph volume modules, the deb package building failed. We will remove the ceph dependency in Makefile


### Ⅱ. Does this pull request fix one issue?

fixes #1726 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


