### PR TITLE
bugfix: Fix log-opt option parse fails if value contains comma

### DIFF
--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -46,7 +46,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 
 	// log driver and log options
 	flagSet.StringVar(&c.logDriver, "log-driver", types.LogConfigLogDriverJSONFile, "Logging driver for the container")
-	flagSet.StringSliceVar(&c.logOpts, "log-opt", nil, "Log driver options")
+	flagSet.StringArrayVar(&c.logOpts, "log-opt", nil, "Log driver options")
 
 	// memory
 

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func setupFlags(cmd *cobra.Command) {
 
 	// log config
 	flagSet.StringVar(&cfg.DefaultLogConfig.LogDriver, "log-driver", types.LogConfigLogDriverJSONFile, "Set default log driver")
-	flagSet.StringSliceVar(&logOpts, "log-opt", nil, "Set default log driver options")
+	flagSet.StringArrayVar(&logOpts, "log-opt", nil, "Set default log driver options")
 
 	// cgroup-path flag is to set parent cgroup for all containers, default is "default" staying with containerd's configuration.
 	flagSet.StringVar(&cfg.CgroupParent, "cgroup-parent", "default", "Set parent cgroup for all containers")


### PR DESCRIPTION
pflag.StringSliceVar will split the value into string array with
comma, instead pflag.StringArrayVar will pass the value as a whole
string, so we should use StringArrayVar if we intend to pass the
value into other component.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#1715 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


