### PR TITLE
bugfix: record logpath to container mata

### DIFF
--- a/cri/v1alpha1/cri_types.go
+++ b/cri/v1alpha1/cri_types.go
@@ -23,3 +23,17 @@ type SandboxMeta struct {
 func (meta *SandboxMeta) Key() string {
 	return meta.ID
 }
+
+// ContainerMeta reprensets the cri container's meta data.
+type ContainerMeta struct {
+	// ID is the id of cri container.
+	ID string
+
+	// LogPath is the log path of the cri container.
+	LogPath string
+}
+
+// Key returns container's id.
+func (meta *ContainerMeta) Key() string {
+	return meta.ID
+}

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -108,6 +108,13 @@ type CriManager struct {
 	// SandboxStore stores the configuration of sandboxes.
 	SandboxStore *meta.Store
 
+	// ContainerStore stores the configuration of containers.
+	// NOTE: The ContainerStore is only used to store the log path
+	// of container right now. Actually we should let the container
+	// manager handle the log stuff for CRI container, then we could
+	// remove the ContainerStore.
+	ContainerStore *meta.Store
+
 	// SnapshotStore stores information of all snapshots.
 	SnapshotStore *mgr.SnapshotStore
 
@@ -144,6 +151,20 @@ func NewCriManager(config *config.Config, ctrMgr mgr.ContainerMgr, imgMgr mgr.Im
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sandbox meta store: %v", err)
+	}
+
+	c.ContainerStore, err = meta.NewStore(meta.Config{
+		Driver:  "local",
+		BaseDir: path.Join(config.HomeDir, "containers-meta"),
+		Buckets: []meta.Bucket{
+			{
+				Name: meta.MetaJSONFile,
+				Type: reflect.TypeOf(ContainerMeta{}),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create container meta store: %v", err)
 	}
 
 	c.imageFSPath = imageFSPath(path.Join(config.HomeDir, "containerd/root"), defaultSnapshotterName)
@@ -548,13 +569,22 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	containerID := createResp.ID
 
 	// Get container log.
+	// TODO: let the container manager handle the log stuff for CRI.
+	var logPath string
 	if config.GetLogPath() != "" {
-		logPath := filepath.Join(sandboxConfig.GetLogDirectory(), config.GetLogPath())
+		logPath = filepath.Join(sandboxConfig.GetLogDirectory(), config.GetLogPath())
 		err := c.attachLog(logPath, containerID)
 		if err != nil {
 			return nil, err
 		}
 	}
+
+	containerMeta := &ContainerMeta{
+		ID:      containerID,
+		LogPath: logPath,
+	}
+	c.ContainerStore.Put(containerMeta)
+
 	return &runtime.CreateContainerResponse{ContainerId: containerID}, nil
 }
 
@@ -589,6 +619,11 @@ func (c *CriManager) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 	err := c.ContainerMgr.Remove(ctx, containerID, &apitypes.ContainerRemoveOptions{Volumes: true, Force: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to remove container %q: %v", containerID, err)
+	}
+
+	err = c.ContainerStore.Remove(containerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove meta %q: %v", containerID, err)
 	}
 
 	return &runtime.RemoveContainerResponse{}, nil
@@ -713,8 +748,15 @@ func (c *CriManager) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 		imageRef = imageInfo.RepoDigests[0]
 	}
 
+	res, err := c.ContainerStore.Get(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get metadata of %q from ContainerStore: %v", id, err)
+	}
+	containerMeta := res.(*ContainerMeta)
+
 	resources := container.HostConfig.Resources
 	diskQuota := container.Config.DiskQuota
+
 	status := &runtime.ContainerStatus{
 		Id:          container.ID,
 		Metadata:    metadata,
@@ -730,9 +772,9 @@ func (c *CriManager) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 		Message:     message,
 		Labels:      labels,
 		Annotations: annotations,
-		LogPath:     container.LogPath,
 		Volumes:     parseVolumesFromPouch(container.Config.Volumes),
 		Resources:   parseResourcesFromPouch(resources, diskQuota),
+		LogPath:     containerMeta.LogPath,
 	}
 
 	return &runtime.ContainerStatusResponse{Status: status}, nil

--- a/cri/v1alpha2/cri_types.go
+++ b/cri/v1alpha2/cri_types.go
@@ -23,3 +23,17 @@ type SandboxMeta struct {
 func (meta *SandboxMeta) Key() string {
 	return meta.ID
 }
+
+// ContainerMeta reprensets the cri container's meta data.
+type ContainerMeta struct {
+	// ID is the id of cri container.
+	ID string
+
+	// LogPath is the log path of the cri container.
+	LogPath string
+}
+
+// Key returns container's id.
+func (meta *ContainerMeta) Key() string {
+	return meta.ID
+}


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

We should get the `LogPath` information when we get the status of the container.

But now CRI Manager handle the log stuff of the CRI container by itself.

So we should store the `LogPath` as meta data when we create container, then we could get the log information when we return the status of container.

It is what this PR do.

However I think we should let the container manager handle the log stuff for all containers including the CRI container or non-CRI container. Then we could get all the container-related information from container manager other then maintaining an extra container meta data store in CRI manager.

@fuweid If you are free, please let the log driver in container manager to support the CRI format log file 😄 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


