### PR TITLE
style: alert the name of struct context to streamContext 

### DIFF
--- a/cri/stream/portforward/httpstream.go
+++ b/cri/stream/portforward/httpstream.go
@@ -1,7 +1,7 @@
 package portforward
 
 import (
-	gocontext "context"
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -49,7 +49,7 @@ func httpStreamReceived(streams chan httpstream.Stream) func(httpstream.Stream, 
 	}
 }
 
-func handleHTTPStreams(goctx gocontext.Context, w http.ResponseWriter, req *http.Request, portForwarder PortForwarder, podName string, idleTimeout, streamCreationTimeout time.Duration, supportedPortForwardProtocols []string) error {
+func handleHTTPStreams(ctx context.Context, w http.ResponseWriter, req *http.Request, portForwarder PortForwarder, podName string, idleTimeout, streamCreationTimeout time.Duration, supportedPortForwardProtocols []string) error {
 	_, err := httpstream.Handshake(w, req, supportedPortForwardProtocols)
 	// Negotiated protocol isn't currently used server side, but could be in the future.
 	if err != nil {
@@ -77,7 +77,7 @@ func handleHTTPStreams(goctx gocontext.Context, w http.ResponseWriter, req *http
 		pod:       podName,
 		forwarder: portForwarder,
 	}
-	h.run(goctx)
+	h.run(ctx)
 
 	return nil
 }
@@ -151,7 +151,7 @@ func (h *httpStreamHandler) requestID(stream httpstream.Stream) string {
 // run is the main loop for the httpStreamHandler. It process new streams,
 // invoking portForward for each complete stream pair. The loop exits
 // when the httpstream.Connection is closed.
-func (h *httpStreamHandler) run(goctx gocontext.Context) {
+func (h *httpStreamHandler) run(ctx context.Context) {
 	logrus.Infof("(conn=%p) waiting for port forward streams", h.conn)
 
 	for {
@@ -172,7 +172,7 @@ func (h *httpStreamHandler) run(goctx gocontext.Context) {
 				msg := fmt.Sprintf("error processing stream for request %s: %v", requestID, err)
 				p.printError(msg)
 			} else if complete {
-				go h.portForward(goctx, p)
+				go h.portForward(ctx, p)
 			}
 		}
 	}
@@ -180,7 +180,7 @@ func (h *httpStreamHandler) run(goctx gocontext.Context) {
 
 // portForward invokes the httpStreamHandler's forwarder.PortForward
 // function for the given stream pair.
-func (h *httpStreamHandler) portForward(goctx gocontext.Context, p *httpStreamPair) {
+func (h *httpStreamHandler) portForward(ctx context.Context, p *httpStreamPair) {
 	defer p.dataStream.Close()
 	defer p.errorStream.Close()
 
@@ -188,7 +188,7 @@ func (h *httpStreamHandler) portForward(goctx gocontext.Context, p *httpStreamPa
 	port, _ := strconv.ParseInt(portString, 10, 32)
 
 	logrus.Infof("(conn=%p, request=%s) invoking forwarder.PortForward for port %s", h.conn, p.requestID, portString)
-	err := h.forwarder.PortForward(goctx, h.pod, int32(port), p.dataStream)
+	err := h.forwarder.PortForward(ctx, h.pod, int32(port), p.dataStream)
 	logrus.Infof("(conn=%p, request=%s) done invoking forwarder.PortForward for port %s", h.conn, p.requestID, portString)
 
 	if err != nil {

--- a/cri/stream/portforward/portforward.go
+++ b/cri/stream/portforward/portforward.go
@@ -1,7 +1,7 @@
 package portforward
 
 import (
-	gocontext "context"
+	"context"
 	"io"
 	"net/http"
 	"time"
@@ -13,7 +13,7 @@ import (
 // in a pod.
 type PortForwarder interface {
 	// PortForwarder copies data between a data stream and a port in a pod.
-	PortForward(goctx gocontext.Context, name string, port int32, stream io.ReadWriteCloser) error
+	PortForward(ctx context.Context, name string, port int32, stream io.ReadWriteCloser) error
 }
 
 // ServePortForward handles a port forwarding request. A single request is
@@ -21,9 +21,9 @@ type PortForwarder interface {
 // been timed out due to idleness. This function handles multiple forwarded
 // connections; i.e., multiple `curl http://localhost:8888/` requests will be
 // handled by a single invocation of ServePortForward.
-func ServePortForward(goctx gocontext.Context, w http.ResponseWriter, req *http.Request, portForwarder PortForwarder, podName string, idleTimeout time.Duration, streamCreationTimeout time.Duration, supportedProtocols []string) {
+func ServePortForward(ctx context.Context, w http.ResponseWriter, req *http.Request, portForwarder PortForwarder, podName string, idleTimeout time.Duration, streamCreationTimeout time.Duration, supportedProtocols []string) {
 	// TODO: support web socket stream.
-	err := handleHTTPStreams(goctx, w, req, portForwarder, podName, idleTimeout, streamCreationTimeout, supportedProtocols)
+	err := handleHTTPStreams(ctx, w, req, portForwarder, podName, idleTimeout, streamCreationTimeout, supportedProtocols)
 	if err != nil {
 		logrus.Errorf("failed to serve port forward: %v", err)
 		return

--- a/cri/stream/remotecommand/exec.go
+++ b/cri/stream/remotecommand/exec.go
@@ -1,7 +1,7 @@
 package remotecommand
 
 import (
-	gocontext "context"
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -10,30 +10,30 @@ import (
 // Executor knows how to execute a command in a container of the pod.
 type Executor interface {
 	// Exec executes a command in a container of the pod.
-	Exec(goctx gocontext.Context, containerID string, cmd []string, streamOpts *Options, streams *Streams) (uint32, error)
+	Exec(ctx context.Context, containerID string, cmd []string, streamOpts *Options, streams *Streams) (uint32, error)
 }
 
 // ServeExec handles requests to execute a command in a container. After
 // creating/receiving the required streams, it delegates the actual execution
 // to the executor.
-func ServeExec(goctx gocontext.Context, w http.ResponseWriter, req *http.Request, executor Executor, container string, cmd []string, streamOpts *Options, supportedProtocols []string, idleTimeout time.Duration, streamCreationTimeout time.Duration) {
-	ctx, ok := createStreams(w, req, streamOpts, supportedProtocols, idleTimeout, streamCreationTimeout)
+func ServeExec(ctx context.Context, w http.ResponseWriter, req *http.Request, executor Executor, container string, cmd []string, streamOpts *Options, supportedProtocols []string, idleTimeout time.Duration, streamCreationTimeout time.Duration) {
+	streamCtx, ok := createStreams(w, req, streamOpts, supportedProtocols, idleTimeout, streamCreationTimeout)
 	if !ok {
 		// Error is handled by createStreams.
 		return
 	}
-	defer ctx.conn.Close()
+	defer streamCtx.conn.Close()
 
-	exitCode, err := executor.Exec(goctx, container, cmd, streamOpts, &Streams{
-		StdinStream:  ctx.stdinStream,
-		StdoutStream: ctx.stdoutStream,
-		StderrStream: ctx.stderrStream,
+	exitCode, err := executor.Exec(ctx, container, cmd, streamOpts, &Streams{
+		StdinStream:  streamCtx.stdinStream,
+		StdoutStream: streamCtx.stdoutStream,
+		StderrStream: streamCtx.stderrStream,
 	})
 	if err != nil {
 		err = fmt.Errorf("error executing command in container: %v", err)
-		ctx.writeStatus(NewInternalError(err))
+		streamCtx.writeStatus(NewInternalError(err))
 	} else if exitCode != 0 {
-		ctx.writeStatus(&StatusError{ErrStatus: Status{
+		streamCtx.writeStatus(&StatusError{ErrStatus: Status{
 			Status: StatusFailure,
 			Reason: NonZeroExitCodeReason,
 			Details: &StatusDetails{
@@ -47,7 +47,7 @@ func ServeExec(goctx gocontext.Context, w http.ResponseWriter, req *http.Request
 			Message: fmt.Sprintf("command terminated with non-zero exit code"),
 		}})
 	} else {
-		ctx.writeStatus(&StatusError{ErrStatus: Status{
+		streamCtx.writeStatus(&StatusError{ErrStatus: Status{
 			Status: StatusSuccess,
 		}})
 	}

--- a/cri/stream/remotecommand/websocket.go
+++ b/cri/stream/remotecommand/websocket.go
@@ -53,7 +53,7 @@ func writeChannel(real bool) wsstream.ChannelType {
 
 // createWebSocketStreams returns a context containing the websocket connection and
 // streams needed to perform an exec or an attach.
-func createWebSocketStreams(w http.ResponseWriter, req *http.Request, opts *Options, idleTimeout time.Duration) (*context, bool) {
+func createWebSocketStreams(w http.ResponseWriter, req *http.Request, opts *Options, idleTimeout time.Duration) (*streamContext, bool) {
 	channels := createChannels(opts)
 	conn := wsstream.NewConn(map[string]wsstream.ChannelProtocolConfig{
 		"": {
@@ -95,7 +95,7 @@ func createWebSocketStreams(w http.ResponseWriter, req *http.Request, opts *Opti
 		streams[errorChannel].Write([]byte{})
 	}
 
-	ctx := &context{
+	ctx := &streamContext{
 		conn:         conn,
 		stdinStream:  streams[stdinChannel],
 		stdoutStream: streams[stdoutChannel],


### PR DESCRIPTION

Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Alert the name remotecommand.context to remotecommand.streamContext in CRI Stream Manager.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


