### PR TITLE
fix: ensure daemon start successfully after update damon offline

### DIFF
--- a/cli/update_daemon.go
+++ b/cli/update_daemon.go
@@ -117,8 +117,9 @@ func (udc *DaemonUpdateCommand) updateDaemonConfigFile() error {
 	}
 
 	daemonConfig := &config.Config{}
-	if err = json.NewDecoder(bytes.NewReader(contents)).Decode(daemonConfig); err != nil {
-		return errors.Wrap(err, "failed to decode json: %s")
+	// do not return error if config file is empty
+	if err := json.NewDecoder(bytes.NewReader(contents)).Decode(daemonConfig); err != nil && err != io.EOF {
+		return errors.Wrapf(err, "failed to decode json: %s", udc.configFile)
 	}
 
 	flagSet := udc.cmd.Flags()

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -114,8 +114,9 @@ type Config struct {
 	// add a resolution later if it needed.
 	Runtimes map[string]types.Runtime `json:"add-runtime,omitempty"`
 
-	// Namespace is passed to containerd
-	Namespace string
+	// Namespace is passed to containerd, Namespace is not a daemon flag,
+	// do not marshal this field to config file.
+	Namespace string `json:"-"`
 }
 
 // Validate validates the user input config.

--- a/test/z_cli_daemon_test.go
+++ b/test/z_cli_daemon_test.go
@@ -470,6 +470,7 @@ func (suite *PouchDaemonSuite) TestDaemonWithMultiRuntimes(c *check.C) {
 	dcfg2.KillDaemon()
 }
 
+// TestUpdateDaemonWithLabels tests update daemon online with labels updated
 func (suite *PouchDaemonSuite) TestUpdateDaemonWithLabels(c *check.C) {
 	cfg := daemon.NewConfig()
 	err := cfg.StartDaemon()
@@ -484,4 +485,24 @@ func (suite *PouchDaemonSuite) TestUpdateDaemonWithLabels(c *check.C) {
 
 	updated := strings.Contains(ret.Stdout(), "aaa=bbb")
 	c.Assert(updated, check.Equals, true)
+}
+
+// TestUpdateDaemonWithLabels tests update daemon offline
+func (suite *PouchDaemonSuite) TestUpdateDaemonOffline(c *check.C) {
+	path := "/tmp/pouchconfig.json"
+	fd, err := os.Create(path)
+	c.Assert(err, check.IsNil)
+	fd.Close()
+	defer os.Remove(path)
+
+	cfg := daemon.NewConfig()
+	err = cfg.StartDaemon()
+	c.Assert(err, check.IsNil)
+
+	defer cfg.KillDaemon()
+
+	RunWithSpecifiedDaemon(&cfg, "updatedaemon", "--config-file", path, "--offline=true").Assert(c, icmd.Success)
+
+	ret := RunWithSpecifiedDaemon(&cfg, "info")
+	ret.Assert(c, icmd.Success)
 }


### PR DESCRIPTION
Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

1. make Namespace field not marshal to config file to ensure daemon
restart successful after update daemon offline.
2. add update daemon offline test.
3. fix update daemon error when config file is not exist.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


