### PR TITLE
bugfix: avoid task exit channel exit unexpected

### DIFF
--- a/ctrd/watch.go
+++ b/ctrd/watch.go
@@ -76,6 +76,13 @@ func (w *watch) add(pack *containerPack) {
 			return
 		}
 
+		// isContainerdDead only take effect when contained stop normal, if containerd
+		// stop unexpected, judge exit time is zero, zero exit time means grpc connection
+		// is broken.
+		if status.ExitTime().IsZero() {
+			return
+		}
+
 		logrus.Infof("the task has quit, id: %s, err: %v, exitcode: %d, time: %v",
 			pack.id, status.Error(), status.ExitCode(), status.ExitTime())
 


### PR DESCRIPTION
when containerd stop unexpected, we should judge exit time is zero,
zero exit time means grpc connection is broken.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it

step to verify the patch
1. start a pouchd
2. create some containers
3. kill containerd, then you should not see log like
```
INFO[2018-07-23T21:18:54.972425728+08:00] the task has quit, id: 0bf3ba4b31438679c7905466afe15699fe85eb4dfac3e74e3b7ee4e0f823a99e, err: rpc error: code = Internal desc = transport is closing, exitcode: 255, time: 0001-01-01 00:00:00 +0000 UTC 
```

### Ⅴ. Special notes for reviews


