### PR TITLE
add unit-test for Volume Core's VolumePath method

### DIFF
--- a/storage/volume/core_test.go
+++ b/storage/volume/core_test.go
@@ -221,7 +221,43 @@ func TestRemoveVolume(t *testing.T) {
 }
 
 func TestVolumePath(t *testing.T) {
-	// TODO
+	volName1 := "vol3"
+	driverName1 := "fake_dirver"
+	volid1 := types.VolumeID{Name: volName1, Driver: driverName1}
+
+	expectPath := path.Join("/fake/", volName1) //keep consist with the path API in fake_driver.go
+	dir, err := ioutil.TempDir("", "TestVolumePath")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	core, err := createVolumeCore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	driver.Register(driver.NewFakeDriver(driverName1))
+	defer driver.Unregister(driverName1)
+
+	path1, err := core.VolumePath(volid1)
+	if err == nil {
+		t.Fatalf("expect volume not found err when get volume path from empty volume, but get path: %s", path1)
+	}
+
+	_, err1 := core.CreateVolume(volid1)
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+
+	path2, err := core.VolumePath(volid1)
+	if err != nil {
+		t.Fatalf("get volume path error: %v", err)
+	}
+
+	if path2 != expectPath {
+		t.Fatalf("expect volume path is %s, but got %s", expectPath, path2)
+	}
 }
 
 func TestAttachVolume(t *testing.T) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add unit-test for Volume Core's VolumePath method

### Ⅱ. Does this pull request fix one issue?

fix #1762 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it

run
`go test ./storage/volume/core_test.go ./storage/volume/core.go ./storage/volume/core_util.go ./storage/volume/config.go
`
### Ⅴ. Special notes for reviews

baiji group 1

