### PR TITLE
add unit-test for Volume Core's VolumePath method GROUP 5 

### DIFF
--- a/storage/volume/core_test.go
+++ b/storage/volume/core_test.go
@@ -263,8 +263,8 @@ func TestVolumePath(t *testing.T) {
 
 	// find volume path
 	v1Path, err := core.VolumePath(volid1)
-	if v1Path == "" {
-		t.Fatalf("expect get volume path %s, but got a volume path ''", v1Path)
+	if v1Path != "/fake/vol1" {
+		t.Fatalf("expect get volume path '/fake/vol1', but got a volume path %s", v1Path)
 	}
 	if err != nil {
 		t.Fatalf("expect get volume path not found error, but found err")


### PR DESCRIPTION
Ⅰ. Describe what this PR did
add unit-test for Volume Core's VolumePath method which locate on storage/volume/core.go.

Ⅱ. Does this pull request fix one issue?
fix #1762

Ⅲ. Describe how you did it
Ⅳ. Describe how to verify it
run
`go test ./storage/volume/core_test.go`

Ⅴ. Special notes for reviews
baiji group 5