### PR TITLE
Unit test added for 'getConflictCongigurations' method in daemon/conf…

### DIFF
--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -4,6 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/spf13/pflag"
+
+	// "fmt"
+
+	// "strings"
+
 )
 
 func TestIterateConfig(t *testing.T) {
@@ -49,7 +56,55 @@ func TestConfigValidate(t *testing.T) {
 }
 
 func TestGetConflictConfigurations(t *testing.T) {
-	// TODO
+	// 'Baiji' Group 1, Zeyu Sun
+	assert := assert.New(t)
+	// Command Line Flags
+	commandLineFlags := pflag.NewFlagSet("commandLineFlags", pflag.ContinueOnError)
+	// Adding Flags
+	commandLineFlags.String("f1", "1", "first String Flag")
+	commandLineFlags.String("f2", "", "second String Flag")
+	commandLineFlags.IntSlice("f3", []int{}, "slice Type Flag")
+
+	// Config File
+	configFileFlags := map[string]interface{}{
+		// "f1" : "2",
+	}
+
+	// commandLineFlags.Visit(func(f *pflag.Flag) {
+	// 	flagType := f.Value.Type()
+	// 	if strings.Contains(flagType, "Slice") {
+	// 		fmt.Println("SLICE")
+	// 		return
+	// 	}
+
+	// })
+
+	/* 4. If commandLineFlagsSet contains 'Slice' type */
+	commandLineFlags.Set("f3", "[]")
+	configFileFlags["f3"] = "1"
+	assert.Equal(nil, getConflictConfigurations(commandLineFlags, configFileFlags))
+
+	commandLineFlags.Set("f1", "2")
+	configFileFlags["f1"] = "2"
+	// fmt.Println(commandLineFlags.Lookup("f1").Value.Type())
+	/* 1. With Same Flag name(Same Value), Conflict */
+	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
+	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
+	"found conflict flags in command line and config file: from flag: 2 and from config file: 2")
+
+	/* 2. With Same Flag name(Different Value), Conflict */
+	commandLineFlags.Set("f1", "1")
+	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
+	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
+	"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
+
+	/* 3. Two Configs's flag Intersects */
+	commandLineFlags.Set("f2", "0")
+	configFileFlags["f4"] = "3"
+	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
+	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
+	"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
+	
 }
 
 func TestGetUnknownFlags(t *testing.T) {

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -6,11 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/spf13/pflag"
-
 	// "fmt"
-
 	// "strings"
-
 )
 
 func TestIterateConfig(t *testing.T) {
@@ -67,7 +64,7 @@ func TestGetConflictConfigurations(t *testing.T) {
 
 	// Config File
 	configFileFlags := map[string]interface{}{
-		// "f1" : "2",
+	// "f1" : "2",
 	}
 
 	// commandLineFlags.Visit(func(f *pflag.Flag) {
@@ -90,21 +87,21 @@ func TestGetConflictConfigurations(t *testing.T) {
 	/* 1. With Same Flag name(Same Value), Conflict */
 	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
 	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
-	"found conflict flags in command line and config file: from flag: 2 and from config file: 2")
+		"found conflict flags in command line and config file: from flag: 2 and from config file: 2")
 
 	/* 2. With Same Flag name(Different Value), Conflict */
 	commandLineFlags.Set("f1", "1")
 	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
 	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
-	"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
+		"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
 
 	/* 3. Two Configs's flag Intersects */
 	commandLineFlags.Set("f2", "0")
 	configFileFlags["f4"] = "3"
 	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
 	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
-	"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
-	
+		"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
+
 }
 
 func TestGetUnknownFlags(t *testing.T) {

--- a/storage/volume/core_test.go
+++ b/storage/volume/core_test.go
@@ -229,5 +229,38 @@ func TestAttachVolume(t *testing.T) {
 }
 
 func TestDetachVolume(t *testing.T) {
-	// TODO
+	// Create A Volume For Test
+	volName0 := "vol0"
+	driverName := "fake_dirver"
+	volid0 := types.VolumeID{Name: volName0, Driver: driverName}
+	dir, err := ioutil.TempDir("", "TestVolumePath")
+	if err != nil {
+			t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	core, err := createVolumeCore(dir)
+	if err != nil {
+			t.Fatal(err)
+	}
+
+	driver.Register(driver.NewFakeDriver(driverName))
+	defer driver.Unregister(driverName)
+
+	v, err1 := core.CreateVolume(volid0)
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+
+	/* 1. Reference Not Null */
+	v.Spec.Extra = map[string]string{}
+	v.SetOption(types.OptionRef, "withRef")
+
+	v_ret, err := core.DetachVolume(volid0, nil)
+	if err != nil {
+			t.Fatal(err)
+	}
+	if v_ret.Name != volName0 {
+		t.Fatalf("Expect the returned volume name %s equals the input volume name %s", v_ret.Name, volName0)
+	}
 }


### PR DESCRIPTION
…ig package

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Unit test added for 'getConflictCongigurations' method in daemon/config package

### Ⅱ. Does this pull request fix one issue?
fixes #1759 

### Ⅲ. Describe how you did it	
	/* 1. With Same Flag name(Same Value), Conflict */
	/* 2. With Same Flag name(Different Value), Conflict */
	/* 3. Two Configs's flag Intersects */
        /* 4. If commandLineFlagsSet contains 'Slice' type */

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews

### ⅤI. Anything else we need to know?
'Baiji' Group one
