### PR TITLE
test: fix incorrect error judging in core_test.go

### DIFF
--- a/storage/volume/core_test.go
+++ b/storage/volume/core_test.go
@@ -199,7 +199,7 @@ func TestRemoveVolume(t *testing.T) {
 	defer driver.Unregister(driverName1)
 
 	v1, err1 := core.CreateVolume(volid1)
-	if err != nil {
+	if err1 != nil {
 		t.Fatalf("create volume error: %v", err1)
 	}
 	if v1.Name != volName1 {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
correct a mistake in storage/volume/core_test.go, located on line 202, function TestRemoveVolume. After calling core.CreateVolume, we should judge err1, instead of err:
```
v1, err1 := core.CreateVolume(volid1)
if err != nil {
	t.Fatalf("create volume error: %v", err1)
}
```
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1820 

### Ⅲ. Describe how you did it
modified the variable from `err` to `err1`

### Ⅳ. Describe how to verify it
None

### Ⅴ. Special notes for reviews
None

