### PR TITLE
group6: add unit-test for VolumePath #1762

### DIFF
--- a/storage/volume/core_test.go
+++ b/storage/volume/core_test.go
@@ -221,7 +221,58 @@ func TestRemoveVolume(t *testing.T) {
 }
 
 func TestVolumePath(t *testing.T) {
-	// TODO
+	volName1 := "vol1"
+	driverName1 := "fake_driver1"
+	volid1 := types.VolumeID{Name: volName1, Driver: driverName1}
+
+	volName2 := "vol2"
+	driverName2 := "fake_driver2"
+	volid2 := types.VolumeID{Name: volName2, Driver: driverName2}
+
+	dir, err := ioutil.TempDir("", "TestGetVolume")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	core, err := createVolumeCore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	driver.Register(driver.NewFakeDriver(driverName1))
+	defer driver.Unregister(driverName1)
+
+	v1, err1 := core.CreateVolume(volid1)
+	if err != nil {
+		t.Fatalf("create volume error: %v", err1)
+	}
+	if v1.Name != volName1 {
+		t.Fatalf("expect volume name is %s, but got %s", volName1, v1.Name)
+	}
+	if v1.Driver() != driverName1 {
+		t.Fatalf("expect volume driver is %s, but got %s", driverName1, v1.Driver())
+	}
+
+	// test mock1
+	expect1 := "fake_driver1/vol1"
+	volumePath1, err := core.VolumePath(volid1)
+	if err != nil {
+		t.Fatalf("get volume path id %v error: %v", volid1, err)
+	}
+	if volumePath1 != expect1 {
+		t.Fatalf("expect volume path is %s, but got %s", expect1, volumePath1)
+	}
+
+	// test mock2
+	expect2 := ""
+	volumePath2, err := core.VolumePath(volid2)
+	if err != nil {
+		t.Fatalf("get volume path id %v error: %v", volid2, err)
+	}
+	if volumePath2 != expect2 {
+		t.Fatalf("expect volume path is %s, but got %s", expect2, volumePath2)
+	}
 }
 
 func TestAttachVolume(t *testing.T) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Add unit test cases for volume.core.go func VolumePath()

### Ⅱ. Does this pull request fix one issue?

Yes, #1762 

### Ⅲ. Describe how you did it

Implement test cases for can get and can't get volume path.

### Ⅳ. Describe how to verify it

go test core_test.go

### Ⅴ. Special notes for reviews

Group6
