### PR TITLE
add unit-test for VolumePath team 7

### DIFF
--- a/storage/volume/core_test.go
+++ b/storage/volume/core_test.go
@@ -221,7 +221,55 @@ func TestRemoveVolume(t *testing.T) {
 }
 
 func TestVolumePath(t *testing.T) {
-	// TODO
+
+	dir, err := ioutil.TempDir("", "TestVolumePath")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// create createVolumeCore
+	core, err := createVolumeCore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add test data
+	driverName1 := "fake_8"
+	volumeName1 := "test_path_volume"
+	vID1 := types.VolumeID{Name: volumeName1, Driver: driverName1}
+	driver.Register(driver.NewFakeDriver(driverName1))
+	defer driver.Unregister(driverName1)
+
+	//test CreateVolume
+	v1, err1 := core.CreateVolume(vID1)
+	if err != nil {
+		t.Fatalf("create volume error: %v", err1)
+	}
+	if v1.Name != volumeName1 {
+		t.Fatalf("expect volume name is %s, but got %s", volumeName1, v1.Name)
+	}
+	if v1.Driver() != driverName1 {
+		t.Fatalf("expect volume driver is %s, but got %s", driverName1, v1.Driver())
+	}
+
+	//get v,dv of volumeDriver
+	v2, _, err2 := core.getVolumeDriver(vID1)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+
+	//get path from test method
+	path, err3 := core.VolumePath(vID1)
+	if err3 != nil {
+		t.Fatal(err2)
+	}
+
+	//case 1: path of method is different from real path
+	if v2.Status.MountPoint != path {
+		t.Fatalf("expect a right path but got a wrong path")
+	}
+
 }
 
 func TestAttachVolume(t *testing.T) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Add unit-test for Volume Core's VolumePath method which locate on storage/volume/core.go.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes  #1762 

### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


