### PR TITLE
Unit test added for 'getConflictCongigurations' method

### DIFF
--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -4,6 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/spf13/pflag"
+
+	// "fmt"
+
+	// "strings"
+
 )
 
 func TestIterateConfig(t *testing.T) {
@@ -49,7 +56,55 @@ func TestConfigValidate(t *testing.T) {
 }
 
 func TestGetConflictConfigurations(t *testing.T) {
-	// TODO
+	// 'Baiji' Group 1, Zeyu Sun
+	assert := assert.New(t)
+	// Command Line Flags
+	commandLineFlags := pflag.NewFlagSet("commandLineFlags", pflag.ContinueOnError)
+	// Adding Flags
+	commandLineFlags.String("f1", "1", "first String Flag")
+	commandLineFlags.String("f2", "", "second String Flag")
+	commandLineFlags.IntSlice("f3", []int{}, "slice Type Flag")
+
+	// Config File
+	configFileFlags := map[string]interface{}{
+		// "f1" : "2",
+	}
+
+	// commandLineFlags.Visit(func(f *pflag.Flag) {
+	// 	flagType := f.Value.Type()
+	// 	if strings.Contains(flagType, "Slice") {
+	// 		fmt.Println("SLICE")
+	// 		return
+	// 	}
+
+	// })
+
+	/* 4. If commandLineFlagsSet contains 'Slice' type */
+	commandLineFlags.Set("f3", "[]")
+	configFileFlags["f3"] = "1"
+	assert.Equal(nil, getConflictConfigurations(commandLineFlags, configFileFlags))
+
+	commandLineFlags.Set("f1", "2")
+	configFileFlags["f1"] = "2"
+	// fmt.Println(commandLineFlags.Lookup("f1").Value.Type())
+	/* 1. With Same Flag name(Same Value), Conflict */
+	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
+	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
+	"found conflict flags in command line and config file: from flag: 2 and from config file: 2")
+
+	/* 2. With Same Flag name(Different Value), Conflict */
+	commandLineFlags.Set("f1", "1")
+	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
+	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
+	"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
+
+	/* 3. Two Configs's flag Intersects */
+	commandLineFlags.Set("f2", "0")
+	configFileFlags["f4"] = "3"
+	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
+	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
+	"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
+	
 }
 
 func TestGetUnknownFlags(t *testing.T) {

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -6,11 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/spf13/pflag"
-
 	// "fmt"
-
 	// "strings"
-
 )
 
 func TestIterateConfig(t *testing.T) {
@@ -67,7 +64,7 @@ func TestGetConflictConfigurations(t *testing.T) {
 
 	// Config File
 	configFileFlags := map[string]interface{}{
-		// "f1" : "2",
+	// "f1" : "2",
 	}
 
 	// commandLineFlags.Visit(func(f *pflag.Flag) {
@@ -90,21 +87,21 @@ func TestGetConflictConfigurations(t *testing.T) {
 	/* 1. With Same Flag name(Same Value), Conflict */
 	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
 	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
-	"found conflict flags in command line and config file: from flag: 2 and from config file: 2")
+		"found conflict flags in command line and config file: from flag: 2 and from config file: 2")
 
 	/* 2. With Same Flag name(Different Value), Conflict */
 	commandLineFlags.Set("f1", "1")
 	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
 	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
-	"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
+		"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
 
 	/* 3. Two Configs's flag Intersects */
 	commandLineFlags.Set("f2", "0")
 	configFileFlags["f4"] = "3"
 	assert.Error(getConflictConfigurations(commandLineFlags, configFileFlags))
 	assert.Equal(getConflictConfigurations(commandLineFlags, configFileFlags).Error(),
-	"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
-	
+		"found conflict flags in command line and config file: from flag: 1 and from config file: 2")
+
 }
 
 func TestGetUnknownFlags(t *testing.T) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Unit test added for 'getConflictCongigurations' method in daemon/config package

### Ⅱ. Does this pull request fix one issue?
fixes #1759

### Ⅲ. Describe how you did it
/* 1. With Same Flag name(Same Value), Conflict */
/* 2. With Same Flag name(Different Value), Conflict */
/* 3. Two Configs's flag Intersects */
/* 4. If commandLineFlagsSet contains 'Slice' type */

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
'Baiji' Group 1 (Another PR to fix pre PR under issue #1759)

