### PR TITLE
feature: add CriEnabled field in api and show this in cli

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1524,6 +1524,13 @@ definitions:
         x-nullable: false
         default: false
         example: false
+      CriEnabled:
+        description: |
+          Indicates if pouchd has accepted flag --enable-cri and enables cri part.
+        type: "boolean"
+        x-nullable: false
+        default: false
+        example: false
       ContainerdCommit:
         $ref: "#/definitions/Commit"
       RuncCommit:

--- a/apis/types/system_info.go
+++ b/apis/types/system_info.go
@@ -49,6 +49,10 @@ type SystemInfo struct {
 	//
 	ContainersStopped int64 `json:"ContainersStopped,omitempty"`
 
+	// Indicates if pouchd has accepted flag --enable-cri and enables cri part.
+	//
+	CriEnabled bool `json:"CriEnabled,omitempty"`
+
 	// Indicates if the daemon is running in debug-mode / with debug-level logging enabled.
 	Debug bool `json:"Debug,omitempty"`
 
@@ -226,6 +230,8 @@ type SystemInfo struct {
 /* polymorph SystemInfo ContainersRunning false */
 
 /* polymorph SystemInfo ContainersStopped false */
+
+/* polymorph SystemInfo CriEnabled false */
 
 /* polymorph SystemInfo Debug false */
 

--- a/cli/info.go
+++ b/cli/info.go
@@ -55,56 +55,57 @@ func (v *InfoCommand) runInfo() error {
 }
 
 func prettyPrintInfo(cli *Cli, info *types.SystemInfo) error {
-	fmt.Fprintln(os.Stdout, "Containers:", info.Containers)
-	fmt.Fprintln(os.Stdout, " Running:", info.ContainersRunning)
-	fmt.Fprintln(os.Stdout, " Paused:", info.ContainersPaused)
-	fmt.Fprintln(os.Stdout, " Stopped:", info.ContainersStopped)
+	fmt.Fprintln(os.Stdout, "Containers: ", info.Containers)
+	fmt.Fprintln(os.Stdout, " Running: ", info.ContainersRunning)
+	fmt.Fprintln(os.Stdout, " Paused: ", info.ContainersPaused)
+	fmt.Fprintln(os.Stdout, " Stopped: ", info.ContainersStopped)
 	fmt.Fprintln(os.Stdout, "Images: ", info.Images)
-	fmt.Fprintln(os.Stdout, "ID:", info.ID)
-	fmt.Fprintln(os.Stdout, "Name:", info.Name)
-	fmt.Fprintln(os.Stdout, "Server Version:", info.ServerVersion)
-	fmt.Fprintln(os.Stdout, "Storage Driver:", info.Driver)
-	fmt.Fprintln(os.Stdout, "Driver Status:", info.DriverStatus)
-	fmt.Fprintln(os.Stdout, "Logging Driver:", info.LoggingDriver)
-	fmt.Fprintln(os.Stdout, "Volume Drivers:", info.VolumeDrivers)
-	fmt.Fprintln(os.Stdout, "Cgroup Driver:", info.CgroupDriver)
-	fmt.Fprintln(os.Stdout, "Default Runtime:", info.DefaultRuntime)
+	fmt.Fprintln(os.Stdout, "ID: ", info.ID)
+	fmt.Fprintln(os.Stdout, "Name: ", info.Name)
+	fmt.Fprintln(os.Stdout, "Server Version: ", info.ServerVersion)
+	fmt.Fprintln(os.Stdout, "Storage Driver: ", info.Driver)
+	fmt.Fprintln(os.Stdout, "Driver Status: ", info.DriverStatus)
+	fmt.Fprintln(os.Stdout, "Logging Driver: ", info.LoggingDriver)
+	fmt.Fprintln(os.Stdout, "Volume Drivers: ", info.VolumeDrivers)
+	fmt.Fprintln(os.Stdout, "Cgroup Driver: ", info.CgroupDriver)
+	fmt.Fprintln(os.Stdout, "Default Runtime: ", info.DefaultRuntime)
 	if len(info.Runtimes) > 0 {
-		fmt.Fprintf(os.Stdout, "Runtimes:")
+		fmt.Fprintf(os.Stdout, "Runtimes: ")
 		for name := range info.Runtimes {
 			fmt.Fprintf(os.Stdout, " %s", name)
 		}
 		fmt.Fprint(os.Stdout, "\n")
 	}
-	fmt.Fprintln(os.Stdout, "runc:", info.RuncCommit)
-	fmt.Fprintln(os.Stdout, "containerd:", info.ContainerdCommit)
+	fmt.Fprintln(os.Stdout, "runc: ", info.RuncCommit)
+	fmt.Fprintln(os.Stdout, "containerd: ", info.ContainerdCommit)
 
 	// Kernel info
-	fmt.Fprintln(os.Stdout, "Security Options:", info.SecurityOptions)
-	fmt.Fprintln(os.Stdout, "Kernel Version:", info.KernelVersion)
-	fmt.Fprintln(os.Stdout, "Operating System:", info.OperatingSystem)
-	fmt.Fprintln(os.Stdout, "OSType:", info.OSType)
-	fmt.Fprintln(os.Stdout, "Architecture:", info.Architecture)
+	fmt.Fprintln(os.Stdout, "Security Options: ", info.SecurityOptions)
+	fmt.Fprintln(os.Stdout, "Kernel Version: ", info.KernelVersion)
+	fmt.Fprintln(os.Stdout, "Operating System: ", info.OperatingSystem)
+	fmt.Fprintln(os.Stdout, "OSType: ", info.OSType)
+	fmt.Fprintln(os.Stdout, "Architecture: ", info.Architecture)
 
-	fmt.Fprintln(os.Stdout, "HTTP Proxy:", info.HTTPProxy)
-	fmt.Fprintln(os.Stdout, "HTTPS Proxy:", info.HTTPSProxy)
-	fmt.Fprintln(os.Stdout, "Registry:", info.IndexServerAddress)
-	fmt.Fprintln(os.Stdout, "Experimental:", info.ExperimentalBuild)
-	fmt.Fprintln(os.Stdout, "Debug:", info.Debug)
+	fmt.Fprintln(os.Stdout, "HTTP Proxy: ", info.HTTPProxy)
+	fmt.Fprintln(os.Stdout, "HTTPS Proxy: ", info.HTTPSProxy)
+	fmt.Fprintln(os.Stdout, "Registry: ", info.IndexServerAddress)
+	fmt.Fprintln(os.Stdout, "Experimental: ", info.ExperimentalBuild)
+	fmt.Fprintln(os.Stdout, "Debug: ", info.Debug)
 	if len(info.Labels) != 0 {
-		fmt.Fprintln(os.Stdout, "Labels:")
+		fmt.Fprintln(os.Stdout, "Labels: ")
 		for _, label := range info.Labels {
 			fmt.Fprintf(os.Stdout, "  %s\n", label)
 		}
 	}
 
-	fmt.Fprintln(os.Stdout, "CPUs:", info.NCPU)
+	fmt.Fprintln(os.Stdout, "CPUs: ", info.NCPU)
 	fmt.Fprintln(os.Stdout, "Total Memory: "+units.BytesSize(float64(info.MemTotal)))
-	fmt.Fprintln(os.Stdout, "Pouch Root Dir:", info.PouchRootDir)
-	fmt.Fprintln(os.Stdout, "LiveRestoreEnabled:", info.LiveRestoreEnabled)
-	fmt.Fprintln(os.Stdout, "LxcfsEnabled:", info.LxcfsEnabled)
+	fmt.Fprintln(os.Stdout, "Pouch Root Dir: ", info.PouchRootDir)
+	fmt.Fprintln(os.Stdout, "LiveRestoreEnabled: ", info.LiveRestoreEnabled)
+	fmt.Fprintln(os.Stdout, "LxcfsEnabled: ", info.LxcfsEnabled)
+	fmt.Fprintln(os.Stdout, "CriEnabled: ", info.CriEnabled)
 	if info.RegistryConfig != nil && (len(info.RegistryConfig.InsecureRegistryCIDRs) > 0 || len(info.RegistryConfig.IndexConfigs) > 0) {
-		fmt.Fprintln(os.Stdout, "Insecure Registries:")
+		fmt.Fprintln(os.Stdout, "Insecure Registries: ")
 		for _, registry := range info.RegistryConfig.IndexConfigs {
 			if !registry.Secure {
 				fmt.Fprintln(os.Stdout, " "+registry.Name)
@@ -117,13 +118,13 @@ func prettyPrintInfo(cli *Cli, info *types.SystemInfo) error {
 	}
 
 	if info.RegistryConfig != nil && len(info.RegistryConfig.Mirrors) > 0 {
-		fmt.Fprintln(os.Stdout, "Registry Mirrors:")
+		fmt.Fprintln(os.Stdout, "Registry Mirrors: ")
 		for _, mirror := range info.RegistryConfig.Mirrors {
 			fmt.Fprintln(os.Stdout, " "+mirror)
 		}
 	}
 
-	fmt.Fprintln(os.Stdout, "Daemon Listen Addresses:", info.ListenAddresses)
+	fmt.Fprintln(os.Stdout, "Daemon Listen Addresses: ", info.ListenAddresses)
 
 	return nil
 }

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -132,6 +132,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		LoggingDriver:      mgr.config.DefaultLogConfig.LogDriver,
 		VolumeDrivers:      volumeDrivers,
 		LxcfsEnabled:       mgr.config.IsLxcfsEnabled,
+		CriEnabled:         mgr.config.IsCriEnabled,
 		MemTotal:           totalMem,
 		Name:               hostname,
 		NCPU:               int64(runtime.NumCPU()),

--- a/test/api_system_test.go
+++ b/test/api_system_test.go
@@ -51,6 +51,7 @@ func (suite *APISystemSuite) TestInfo(c *check.C) {
 	c.Assert(got.ServerVersion, check.Equals, version.Version)
 	c.Assert(got.Driver, check.Equals, "overlayfs")
 	c.Assert(got.NCPU, check.Equals, int64(runtime.NumCPU()))
+	c.Assert(got.CriEnabled, check.Equals, false)
 
 	// Check the volume drivers
 	c.Assert(len(got.VolumeDrivers), check.Equals, 3)

--- a/test/z_cli_daemon_test.go
+++ b/test/z_cli_daemon_test.go
@@ -389,6 +389,19 @@ func (suite *PouchDaemonSuite) TestDaemonDefaultRegistry(c *check.C) {
 	defer dcfg.KillDaemon()
 }
 
+// TestDaemonCriEnbaled tests enabling cri part in pouchd.
+func (suite *PouchDaemonSuite) TestDaemonCriEnbaled(c *check.C) {
+	dcfg, err := StartDefaultDaemonDebug(
+		"--enable-cri")
+	c.Assert(err, check.IsNil)
+
+	result := RunWithSpecifiedDaemon(dcfg, "info")
+	err = util.PartialEqual(result.Combined(), "CriEnabled: true")
+	c.Assert(err, check.IsNil)
+
+	defer dcfg.KillDaemon()
+}
+
 // TestDaemonTlsVerify tests start daemon with TLS verification enabled.
 func (suite *PouchDaemonSuite) TestDaemonTlsVerify(c *check.C) {
 	SkipIfFalse(c, IsTLSExist)


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
In daemon's API side, we need to provide a user-friendly way for user to check if the pouchd is opening for CRI part.

Otherwise, user can only use `ps aux | grep pouchd | grep cri-enable` to check, which is quite inconvenient. In addition, if a pouch client can only access pouchd remotely, no info can be gotten with this way. So, I think we need to add CriEnabled field in api and show this in cli.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes https://github.com/alibaba/pouch/issues/1908

### Ⅲ. Describe how you did it
1. Add in swagger.yml
2. return in daemon side;
3. show in cli side

### Ⅳ. Describe how to verify it

execute `pouch info`, you will see `CriEnabled: false` if no cri-enabled, otherwise, true.

### Ⅴ. Special notes for reviews
none


