### PR TITLE
bugfix: add ErrorMessage in jsonstream

### DIFF
--- a/ctrd/image.go
+++ b/ctrd/image.go
@@ -185,6 +185,7 @@ func (c *Client) PullImage(ctx context.Context, ref string, authConfig *types.Au
 				Code:    http.StatusInternalServerError,
 				Message: err.Error(),
 			},
+			ErrorMessage: err.Error(),
 		}
 		stream.WriteObject(message)
 		return nil, err

--- a/pkg/jsonstream/types.go
+++ b/pkg/jsonstream/types.go
@@ -24,10 +24,11 @@ type ProgressDetail struct {
 // JSONMessage defines a message struct for jsonstream.
 // It describes id, status, progress detail, started and updated.
 type JSONMessage struct {
-	ID     string          `json:"id,omitempty"`
-	Status string          `json:"status,omitempty"`
-	Detail *ProgressDetail `json:"progressDetail,omitempty"`
-	Error  *JSONError      `json:"errorDetail,omitempty"`
+	ID           string          `json:"id,omitempty"`
+	Status       string          `json:"status,omitempty"`
+	Detail       *ProgressDetail `json:"progressDetail,omitempty"`
+	Error        *JSONError      `json:"errorDetail,omitempty"`
+	ErrorMessage string          `json:"error,omitempty"`
 
 	StartedAt time.Time `json:"started_at,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitempty"`


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In order to compatible with lower version of docker client, need to add
the `ErrorMessage` converted into `error` in jsonstream.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

NONE

### Ⅳ. Describe how to verify it

Add failure in the local and test it pass. But hard to add failure right now.

### Ⅴ. Special notes for reviews


