### PR TITLE
test: Add unit-test for updateCreateConfig method 

### DIFF
--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -917,7 +917,6 @@ func Test_getAppArmorSecurityOpts(t *testing.T) {
 			},
 			want: result{[]string{fmt.Sprintf("apparmor=%s", strings.TrimPrefix(prefixProfile.ApparmorProfile, namePrefix))}, nil},
 		},
-
 	}
 
 	// executes test
@@ -1011,7 +1010,6 @@ func Test_getSeccompSecurityOpts(t *testing.T) {
 			},
 			want: result{[]string{fmt.Sprintf("seccomp=%s", strings.TrimPrefix(prefixProfile.SeccompProfilePath, namePrefix))}, nil},
 		},
-
 	}
 
 	// executes test

--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -728,7 +728,125 @@ func Test_imageToCriImage(t *testing.T) {
 		want    *runtime.Image
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		{
+			name: "test_username_1",
+			args: args{
+				image: &apitypes.ImageInfo{
+					Config: &apitypes.ContainerConfig{
+						User: "",
+					},
+					Size: 11,
+				},
+			},
+			want: &runtime.Image{
+				Id:          "",
+				RepoTags:    nil,
+				RepoDigests: nil,
+				Size_:       11,
+				Uid:         &runtime.Int64Value{Value: 0},
+				Username:    "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_username_2",
+			args: args{
+				image: &apitypes.ImageInfo{
+					Config: &apitypes.ContainerConfig{
+						User: ":",
+					},
+					Size: 11,
+				},
+			},
+			want: &runtime.Image{
+				Id:          "",
+				RepoTags:    nil,
+				RepoDigests: nil,
+				Size_:       11,
+				Uid:         &runtime.Int64Value{Value: 0},
+				Username:    "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_username_3",
+			args: args{
+				image: &apitypes.ImageInfo{
+					Config: &apitypes.ContainerConfig{
+						User: "eeeeeeeeee",
+					},
+					Size: 11,
+				},
+			},
+			want: &runtime.Image{
+				Id:          "",
+				RepoTags:    nil,
+				RepoDigests: nil,
+				Size_:       11,
+				Uid:         &runtime.Int64Value{Value: 0},
+				Username:    "eeeeeeeeee",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_username_4",
+			args: args{
+				image: &apitypes.ImageInfo{
+					Config: &apitypes.ContainerConfig{
+						User: "22222222222222222222",
+					},
+					Size: 11,
+				},
+			},
+			want: &runtime.Image{
+				Id:          "",
+				RepoTags:    nil,
+				RepoDigests: nil,
+				Size_:       11,
+				Uid:         &runtime.Int64Value{Value: 0},
+				Username:    "22222222222222222222",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_uid_1",
+			args: args{
+				image: &apitypes.ImageInfo{
+					Config: &apitypes.ContainerConfig{
+						User: "222",
+					},
+					Size: 11,
+				},
+			},
+			want: &runtime.Image{
+				Id:          "",
+				RepoTags:    nil,
+				RepoDigests: nil,
+				Size_:       11,
+				Uid:         &runtime.Int64Value{Value: 222},
+				Username:    "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_uid_2",
+			args: args{
+				image: &apitypes.ImageInfo{
+					Config: &apitypes.ContainerConfig{
+						User: "222:",
+					},
+					Size: 11,
+				},
+			},
+			want: &runtime.Image{
+				Id:          "",
+				RepoTags:    nil,
+				RepoDigests: nil,
+				Size_:       11,
+				Uid:         &runtime.Int64Value{Value: 222},
+				Username:    "",
+			}, wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -821,3 +821,206 @@ func Test_parseResourcesFromCRI(t *testing.T) {
 		})
 	}
 }
+
+// common result structure
+type result struct {
+	// returned result of target func
+	res []string
+
+	// returned error of target func
+	err error
+}
+
+// Test_getAppArmorSecurityOpts executes a test for func getAppArmorSecurityOpts
+func Test_getAppArmorSecurityOpts(t *testing.T) {
+	// special values in conditions
+	var runtimeDefault = mgr.ProfileRuntimeDefault
+	var namePrefix = mgr.ProfileNamePrefix
+	var nameUnconfined = mgr.ProfileNameUnconfined
+
+	// conditional coverage
+	var (
+		// test input of empty profile in condition
+		emptyProfile1 = runtime.LinuxContainerSecurityContext{
+			ApparmorProfile: "",
+		}
+
+		// test input of runtime default profile in condition
+		emptyProfile2 = runtime.LinuxContainerSecurityContext{
+			ApparmorProfile: runtimeDefault,
+		}
+
+		// test input of un-confined profile in condition
+		unConfinedProfile = runtime.LinuxContainerSecurityContext{
+			ApparmorProfile: nameUnconfined,
+		}
+
+		// test input of profile without expected prefix
+		unPrefixProfile = runtime.LinuxContainerSecurityContext{
+			ApparmorProfile: "alibaba-inc.com/test",
+		}
+
+		// test input of profile with expected prefix
+		prefixProfile = runtime.LinuxContainerSecurityContext{
+			ApparmorProfile: namePrefix + "test",
+		}
+	)
+
+	// args of function
+	type args struct {
+		sc *runtime.LinuxContainerSecurityContext
+	}
+
+	tests := []struct {
+		// name of test case
+		name string
+
+		// args required by func
+		args args
+
+		// expected return result
+		want result
+	}{
+		{
+			name: "condition test 1 -> 2(1)",
+			args: args{
+				sc: &emptyProfile1,
+			},
+			want: result{nil, nil},
+		},
+		{
+			name: "condition test 1 -> 2(2)",
+			args: args{
+				sc: &emptyProfile2,
+			},
+			want: result{nil, nil},
+		},
+		{
+			name: "condition test 1->4",
+			args: args{
+				sc: &unConfinedProfile,
+			},
+			want: result{[]string{fmt.Sprintf("apparmor=%s", unConfinedProfile.ApparmorProfile)}, nil},
+		},
+		{
+			name: "condition test 1->6",
+			args: args{
+				sc: &unPrefixProfile,
+			},
+			want: result{nil, fmt.Errorf("undefault profile name should prefix with %q", namePrefix)},
+		},
+
+		{
+			name: "condition test",
+			args: args{
+				sc: &prefixProfile,
+			},
+			want: result{[]string{fmt.Sprintf("apparmor=%s", strings.TrimPrefix(prefixProfile.ApparmorProfile, namePrefix))}, nil},
+		},
+
+	}
+
+	// executes test
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getAppArmorSecurityOpts(tt.args.sc)
+			if !reflect.DeepEqual(result{got, err}, tt.want) {
+				t.Errorf("getAppArmorSecurityOpts() = %v, want %v", result{got, err}, tt.want)
+			}
+		})
+	}
+}
+
+// Test_getSeccompSecurityOpts executes a test for func getSeccompSecurityOpts
+func Test_getSeccompSecurityOpts(t *testing.T) {
+	// special values in conditions
+	var dockerDefault = mgr.ProfileDockerDefault
+	var namePrefix = mgr.ProfileNamePrefix
+	var nameUnconfined = mgr.ProfileNameUnconfined
+
+	// conditional coverage
+	var (
+		// test input of empty profile in condition
+		emptyProfile1 = runtime.LinuxContainerSecurityContext{
+			SeccompProfilePath: "",
+		}
+
+		// test input of runtime default profile in condition
+		emptyProfile2 = runtime.LinuxContainerSecurityContext{
+			SeccompProfilePath: nameUnconfined,
+		}
+
+		// test input of un-confined profile in condition
+		defaultProfile = runtime.LinuxContainerSecurityContext{
+			SeccompProfilePath: dockerDefault,
+		}
+
+		// test input of profile without expected prefix
+		unPrefixProfile = runtime.LinuxContainerSecurityContext{
+			SeccompProfilePath: "alibaba-inc.com/test",
+		}
+
+		// test input of profile with expected prefix
+		prefixProfile = runtime.LinuxContainerSecurityContext{
+			SeccompProfilePath: namePrefix + "test",
+		}
+	)
+
+	type args struct {
+		sc *runtime.LinuxContainerSecurityContext
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want result
+	}{
+		{
+			name: "condition test 1 -> 2(1)",
+			args: args{
+				sc: &emptyProfile1,
+			},
+			want: result{[]string{fmt.Sprintf("seccomp=%s", nameUnconfined)}, nil},
+		},
+		{
+			name: "condition test 1 -> 2(2)",
+			args: args{
+				sc: &emptyProfile2,
+			},
+			want: result{[]string{fmt.Sprintf("seccomp=%s", nameUnconfined)}, nil},
+		},
+		{
+			name: "condition test 1->4",
+			args: args{
+				sc: &defaultProfile,
+			},
+			want: result{nil, nil},
+		},
+		{
+			name: "condition test 1->6",
+			args: args{
+				sc: &unPrefixProfile,
+			},
+			want: result{nil, fmt.Errorf("undefault profile %q should prefix with %q", unPrefixProfile.SeccompProfilePath, namePrefix)},
+		},
+
+		{
+			name: "normal test",
+			args: args{
+				sc: &prefixProfile,
+			},
+			want: result{[]string{fmt.Sprintf("seccomp=%s", strings.TrimPrefix(prefixProfile.SeccompProfilePath, namePrefix))}, nil},
+		},
+
+	}
+
+	// executes test
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := getSeccompSecurityOpts(tt.args.sc); !reflect.DeepEqual(result{got, err}, tt.want) {
+				t.Errorf("getSeccompSecurityOpts() = %v, want %v", result{got, err}, tt.want)
+			}
+		})
+	}
+
+}

--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -8,7 +8,6 @@ import (
 
 	apitypes "github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/daemon/mgr"
-
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
@@ -342,7 +341,56 @@ func Test_toCriSandbox(t *testing.T) {
 		want    *runtime.PodSandbox
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		{
+			name: "condition test 1->2",
+			args: args{
+				c: &mgr.Container{
+					State: &apitypes.ContainerState{Status: apitypes.StatusRunning},
+					Name:  "1_2_3_4_5",
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "condition test 1->3->4",
+			args: args{
+				c: &mgr.Container{
+					State:   &apitypes.ContainerState{Status: apitypes.StatusRunning},
+					Name:    "k8s_2_3_4_5_6",
+					Config:  &apitypes.ContainerConfig{Labels: make(map[string]string)},
+					Created: "-1",
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "normal test",
+			args: args{
+				c: &mgr.Container{
+					ID:      "test_id",
+					State:   &apitypes.ContainerState{Status: apitypes.StatusRunning},
+					Name:    "k8s_2_3_4_5_6",
+					Config:  &apitypes.ContainerConfig{Labels: make(map[string]string)},
+					Created: "2017-07-20T15:04:05.999999999Z",
+				},
+			},
+			want: &runtime.PodSandbox{
+				Id: "test_id",
+				Metadata: &runtime.PodSandboxMetadata{
+					Name:      "3",
+					Namespace: "4",
+					Uid:       "5",
+					Attempt:   6,
+				},
+				State:       runtime.PodSandboxState_SANDBOX_READY,
+				CreatedAt:   1500563045999999999,
+				Labels:      make(map[string]string),
+				Annotations: make(map[string]string),
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
Add unit-test for updateCreateConfig method which locate on cri/v1alpha1/cri_utils.go.

### Ⅱ. Does this pull request fix one issue?
fix #1916

### Ⅲ. Describe how you did it
Build unit test by condition combination coverage(ccc).
First, build program structure graph. According to the graph and the principle of ccc, we derive the test cases

### Ⅳ. Describe how to verify it
By code review and walk-through

### Ⅴ. Special notes for reviews
Hidden danger of nil pointer is not covered in our test collections
Come from Group 5