### PR TITLE
test: add unit test to getSELinuxSecurityOpts

### DIFF
--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -821,3 +821,42 @@ func Test_parseResourcesFromCRI(t *testing.T) {
 		})
 	}
 }
+
+func Test_getSELinuxSecurityOpts(t *testing.T) {
+	type args struct {
+		sc *runtime.LinuxContainerSecurityContext
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "normal test",
+			args: args{
+				sc: &runtime.LinuxContainerSecurityContext{
+					SelinuxOptions: &runtime.SELinuxOption{User: "system_u", Role: "object_r", Type: "type", Level: "s0:c123,c456"},
+				},
+			},
+			want: []string{"label=user:system_u", "label=role:object_r", "label=type:type", "label=level:s0:c123,c456"},
+		},
+		{
+			name: "incomplete test",
+			args: args{
+				sc: &runtime.LinuxContainerSecurityContext{
+					SelinuxOptions: &runtime.SELinuxOption{User: "user", Role: "", Type: "type", Level: ""},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if result, err := getSELinuxSecurityOpts(tt.args.sc); err != nil {
+				t.Errorf("getSELinuxSecurityOpts() error = %v", err)
+			} else if !reflect.DeepEqual(result, tt.want) {
+				t.Errorf("getSELinuxSecurityOpts() = %v, want %v", result, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add the unit test for criutils getSELinuxSecurityOpts() function, with input cases check.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1912 

### Ⅲ. Describe how you did it

add normal and nil input test cases to verify the function output
### Ⅳ. Describe how to verify it

run `go test -v run getSELinuxSecurityOpts` in package v1alpha1

### Ⅴ. Special notes for reviews

maybe it's better to further check the format of SELinux Options
