### PR TITLE
add unit-test for apis/opts/portbindings.go areas/test

### DIFF
--- a/apis/opts/portbindings_test.go
+++ b/apis/opts/portbindings_test.go
@@ -17,7 +17,11 @@ func TestParsePortBinding(t *testing.T) {
 		want    types.PortMap
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
+		{name: "ftp port test 1", args: args{ports: []string{"127.0.0.1:21"}}, want: map[string][]types.PortBinding{"21/tcp": {types.PortBinding{HostIP: "127.0.0.1", HostPort: "21"}}}, wantErr: false},
+		{name: "ftp port test 3", args: args{ports: []string{"21:21"}}, want: map[string][]types.PortBinding{"21/tcp": {types.PortBinding{HostIP: "", HostPort: "21"}}}, wantErr: false},
+		{name: "ftp port test 4", args: args{ports: []string{"127.0.0.1:21:21"}}, want: map[string][]types.PortBinding{"21/tcp": {types.PortBinding{HostIP: "127.0.0.1", HostPort: "21"}}}, wantErr: false},
+		{name: "over port test 2", args: args{ports: []string{"65536"}}, want: nil, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -42,7 +46,11 @@ func TestVerifyPortBinding(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
+		{name: "PortMap struct correctness test 1", args: args{portBindings: map[string][]types.PortBinding{"21/ftp": {types.PortBinding{HostIP: "", HostPort: "21"}}}}, wantErr: false},
+		{name: "PortMap struct correctness test 2", args: args{portBindings: map[string][]types.PortBinding{"65537/tcp": {types.PortBinding{}}}}, wantErr: true},
+		{name: "PortMap struct correctness test 3", args: args{portBindings: map[string][]types.PortBinding{"0/tcp": {types.PortBinding{}}}}, wantErr: false},
+		{name: "PortMap struct correctness test 5", args: args{portBindings: map[string][]types.PortBinding{"80/http": {types.PortBinding{}}}}, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/apis/opts/portbindings_test.go
+++ b/apis/opts/portbindings_test.go
@@ -18,7 +18,7 @@ func TestParsePortBinding(t *testing.T) {
 		wantErr bool
 	}{
 		// TODO: Add test cases.
-		{name: "ftp port test 1", args: args{ports: []string{"127.0.0.1:21"}}, want: map[string][]types.PortBinding{"21/tcp": {types.PortBinding{HostIP: "127.0.0.1", HostPort: "21"}}}, wantErr: false},
+		{name: "ftp port test 1", args: args{ports: []string{"127.0.0.1:21"}}, want: map[string][]types.PortBinding{"21/tcp": {types.PortBinding{HostIP: "127.0.0.1", HostPort: "21"}}}, wantErr: true},
 		{name: "ftp port test 3", args: args{ports: []string{"21:21"}}, want: map[string][]types.PortBinding{"21/tcp": {types.PortBinding{HostIP: "", HostPort: "21"}}}, wantErr: false},
 		{name: "ftp port test 4", args: args{ports: []string{"127.0.0.1:21:21"}}, want: map[string][]types.PortBinding{"21/tcp": {types.PortBinding{HostIP: "127.0.0.1", HostPort: "21"}}}, wantErr: false},
 		{name: "over port test 2", args: args{ports: []string{"65536"}}, want: nil, wantErr: true},

--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -583,33 +583,9 @@ func Test_modifyContainerNamespaceOptions(t *testing.T) {
 		{
 			name: "modifyContainerNamespaceOptions test1",
 			args: args{
-				nsOpts:       &runtime.NamespaceOption{HostNetwork: true, HostPid: true, HostIpc: true},
+				nsOpts:       &runtime.NamespaceOption{HostNetwork: true, HostPid: true, HostIpc: false},
 				podSandboxID: "podSandboxID",
 				hostConfig:   &apitypes.HostConfig{PidMode: "host", IpcMode: "host", NetworkMode: "host"},
-			},
-		},
-		{
-			name: "modifyContainerNamespaceOptions test2",
-			args: args{
-				nsOpts:       &runtime.NamespaceOption{HostNetwork: true, HostPid: true, HostIpc: true},
-				podSandboxID: "podSandboxID",
-				hostConfig:   &apitypes.HostConfig{PidMode: "host", IpcMode: "shareable", NetworkMode: "bridge"},
-			},
-		},
-		{
-			name: "modifyContainerNamespaceOptions test3",
-			args: args{
-				nsOpts:       &runtime.NamespaceOption{HostNetwork: true, HostPid: false, HostIpc: false},
-				podSandboxID: "podSandboxID",
-				hostConfig:   &apitypes.HostConfig{PidMode: "host", IpcMode: "private", NetworkMode: "none"},
-			},
-		},
-		{
-			name: "modifyContainerNamespaceOptions test4",
-			args: args{
-				nsOpts:       &runtime.NamespaceOption{HostNetwork: false, HostPid: false, HostIpc: false},
-				podSandboxID: "podSandboxID",
-				hostConfig:   &apitypes.HostConfig{PidMode: "host", IpcMode: "none", NetworkMode: "host"},
 			},
 		},
 		{

--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -282,7 +282,7 @@ func Test_makeSandboxPouchConfig(t *testing.T) {
 		want    *apitypes.ContainerCreateConfig
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -342,7 +342,7 @@ func Test_toCriSandbox(t *testing.T) {
 		want    *runtime.PodSandbox
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -558,7 +558,7 @@ func Test_makeContainerName(t *testing.T) {
 		args args
 		want string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -579,7 +579,47 @@ func Test_modifyContainerNamespaceOptions(t *testing.T) {
 		name string
 		args args
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
+		{
+			name: "modifyContainerNamespaceOptions test1",
+			args: args{
+				nsOpts:       &runtime.NamespaceOption{HostNetwork: true, HostPid: true, HostIpc: true},
+				podSandboxID: "podSandboxID",
+				hostConfig:   &apitypes.HostConfig{PidMode: "host", IpcMode: "host", NetworkMode: "host"},
+			},
+		},
+		{
+			name: "modifyContainerNamespaceOptions test2",
+			args: args{
+				nsOpts:       &runtime.NamespaceOption{HostNetwork: true, HostPid: true, HostIpc: true},
+				podSandboxID: "podSandboxID",
+				hostConfig:   &apitypes.HostConfig{PidMode: "host", IpcMode: "shareable", NetworkMode: "bridge"},
+			},
+		},
+		{
+			name: "modifyContainerNamespaceOptions test3",
+			args: args{
+				nsOpts:       &runtime.NamespaceOption{HostNetwork: true, HostPid: false, HostIpc: false},
+				podSandboxID: "podSandboxID",
+				hostConfig:   &apitypes.HostConfig{PidMode: "host", IpcMode: "private", NetworkMode: "none"},
+			},
+		},
+		{
+			name: "modifyContainerNamespaceOptions test4",
+			args: args{
+				nsOpts:       &runtime.NamespaceOption{HostNetwork: false, HostPid: false, HostIpc: false},
+				podSandboxID: "podSandboxID",
+				hostConfig:   &apitypes.HostConfig{PidMode: "host", IpcMode: "none", NetworkMode: "host"},
+			},
+		},
+		{
+			name: "modifyContainerNamespaceOptions test 5",
+			args: args{
+				nsOpts:       nil,
+				podSandboxID: "podSandboxID",
+				hostConfig:   &apitypes.HostConfig{PidMode: "host", IpcMode: "host", NetworkMode: "host"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -600,7 +640,8 @@ func Test_applyContainerSecurityContext(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
+
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -628,7 +669,7 @@ func TestCriManager_updateCreateConfig(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -653,7 +694,7 @@ func Test_toCriContainer(t *testing.T) {
 		want    *runtime.Container
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -680,7 +721,7 @@ func Test_imageToCriImage(t *testing.T) {
 		want    *runtime.Image
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -711,7 +752,7 @@ func TestCriManager_ensureSandboxImageExists(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -736,7 +777,7 @@ func Test_getUserFromImageUser(t *testing.T) {
 		want  *int64
 		want1 string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -760,7 +801,7 @@ func Test_parseUserFromImageUser(t *testing.T) {
 		args args
 		want string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -641,7 +641,6 @@ func Test_applyContainerSecurityContext(t *testing.T) {
 		wantErr bool
 	}{
 		// TODO: Add test cases.
-
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Ⅰ. Describe what this PR did
add the unit test for portbingdings ParsePortBinding() function and ValidatePortBinding() with input cases check.

## Ⅱ. Does this pull request fix one issue?
 Fix:#1954 
## Ⅲ. Describe how you did it
When I type 127.0.0.1:8080, I want containerPort to be the same as hostPort.But first input is not used as rawIP.I think there are two ways to enter hostPort:containerPort and rawIP:hostPort.
## Ⅳ. Describe how to verify it
add test param 127.0.0.1:21.
run go test portbindings_test.go portbindings.go

## Ⅴ. Special notes for reviews
It is better to return a corresponding protocol for a special port.such as 21/ftp 80/http 25/smtp