### PR TITLE
add unit-test for apis/opts/portbindings.go areas/test

### DIFF
--- a/apis/opts/portbindings_test.go
+++ b/apis/opts/portbindings_test.go
@@ -17,7 +17,12 @@ func TestParsePortBinding(t *testing.T) {
 		want    types.PortMap
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
+		{name: "ParsePortBinding test 1", args: args{ports: []string{"21"}}, want: map[string][]types.PortBinding{"21/tcp": {types.PortBinding{}}}, wantErr: false},
+		{name: "ParsePortBinding test 2", args: args{ports: []string{"127.0.0.1:21:21"}}, want: map[string][]types.PortBinding{"21/tcp": {types.PortBinding{HostIP: "127.0.0.1", HostPort: "21"}}}, wantErr: false},
+		{name: "ParsePortBinding test 3", args: args{ports: []string{"127.0.0.1:21"}}, want: nil, wantErr: true},
+		{name: "ParsePortBinding test 4", args: args{ports: []string{"21:21"}}, want: map[string][]types.PortBinding{"21/tcp": {types.PortBinding{HostPort: "21"}}}, wantErr: false},
+		{name: "ParsePortBinding test 2", args: args{ports: []string{"65536"}}, want: nil, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -42,7 +47,11 @@ func TestVerifyPortBinding(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
+		{name: "PortMap struct correctness test 1", args: args{portBindings: map[string][]types.PortBinding{"21/ftp": {types.PortBinding{HostIP: "", HostPort: "21"}}}}, wantErr: false},
+		{name: "PortMap struct correctness test 2", args: args{portBindings: map[string][]types.PortBinding{"65537/tcp": {types.PortBinding{}}}}, wantErr: true},
+		{name: "PortMap struct correctness test 3", args: args{portBindings: map[string][]types.PortBinding{"0/tcp": {types.PortBinding{}}}}, wantErr: false},
+		{name: "PortMap struct correctness test 5", args: args{portBindings: map[string][]types.PortBinding{"80/http": {types.PortBinding{}}}}, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
add the unit test for portbingdings ParsePortBinding() function and ValidatePortBinding() with input cases check.

### Ⅱ. Does this pull request fix one issue?
 Fix:#1954 
### Ⅲ. Describe how you did it
When I type 127.0.0.1:8080, I want containerPort to be the same as hostPort.But first input is not used as rawIP.I think there are two ways to enter hostPort:containerPort and rawIP:hostPort.
### Ⅳ. Describe how to verify it
add test param 127.0.0.1:21.
run go test portbindings_test.go portbindings.go

### Ⅴ. Special notes for reviews
It is better to return a corresponding protocol for a special port.such as 21/ftp 80/http 25/smtp