### PR TITLE
test: add a unit-test for method getSELinuxSecurityOpts in cri_utils.go

### DIFF
--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -51,6 +51,66 @@ func Test_parseUint32(t *testing.T) {
 	}
 }
 
+func Test_getSELinuxSecurityOpts(t *testing.T) {
+ 	var (
+		// test input of empty profile in condition
+		emptyProfile1 = runtime.LinuxContainerSecurityContext{
+			SelinuxOptions: &runtime.SELinuxOption{
+				User:  "",
+				Role:  "",
+				Type:  "",
+				Level: "",
+			},
+		}
+ 		emptyProfile2 = runtime.LinuxContainerSecurityContext{
+			SelinuxOptions: &runtime.SELinuxOption{
+				User:  "05",
+				Role:  "player",
+				Type:  "person",
+				Level: "high",
+			},
+		}
+	)
+ 	type args struct {
+		sc *runtime.LinuxContainerSecurityContext
+	}
+ 	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "emptyProfile1",
+			args: args{
+				sc: &emptyProfile1,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "emptyProfile2",
+			args: args{
+				sc: &emptyProfile2,
+			},
+			want:    []string{"label=user:05", "label=role:player", "label=type:person", "label=level:high"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getSELinuxSecurityOpts(tt.args.sc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getSELinuxSecurityOpts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getSELinuxSecurityOpts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+ }
+
 func Test_toCriTimestamp(t *testing.T) {
 	type args struct {
 		t string

--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -52,7 +52,7 @@ func Test_parseUint32(t *testing.T) {
 }
 
 func Test_getSELinuxSecurityOpts(t *testing.T) {
- 	var (
+	var (
 		// test input of empty profile in condition
 		emptyProfile1 = runtime.LinuxContainerSecurityContext{
 			SelinuxOptions: &runtime.SELinuxOption{
@@ -62,7 +62,7 @@ func Test_getSELinuxSecurityOpts(t *testing.T) {
 				Level: "",
 			},
 		}
- 		emptyProfile2 = runtime.LinuxContainerSecurityContext{
+		emptyProfile2 = runtime.LinuxContainerSecurityContext{
 			SelinuxOptions: &runtime.SELinuxOption{
 				User:  "05",
 				Role:  "player",
@@ -71,10 +71,10 @@ func Test_getSELinuxSecurityOpts(t *testing.T) {
 			},
 		}
 	)
- 	type args struct {
+	type args struct {
 		sc *runtime.LinuxContainerSecurityContext
 	}
- 	tests := []struct {
+	tests := []struct {
 		name    string
 		args    args
 		want    []string
@@ -109,7 +109,7 @@ func Test_getSELinuxSecurityOpts(t *testing.T) {
 			}
 		})
 	}
- }
+}
 
 func Test_toCriTimestamp(t *testing.T) {
 	type args struct {


### PR DESCRIPTION

### Ⅰ. Describe what this PR did
add a unit-test for method getSELinuxSecurityOpts in cri_utils.go

### Ⅱ. Does this pull request fix one issue?
fix issues #1912


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
group 5

