### PR TITLE
add

### DIFF
--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -282,7 +282,7 @@ func Test_makeSandboxPouchConfig(t *testing.T) {
 		want    *apitypes.ContainerCreateConfig
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -342,7 +342,7 @@ func Test_toCriSandbox(t *testing.T) {
 		want    *runtime.PodSandbox
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -558,7 +558,7 @@ func Test_makeContainerName(t *testing.T) {
 		args args
 		want string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -579,7 +579,7 @@ func Test_modifyContainerNamespaceOptions(t *testing.T) {
 		name string
 		args args
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -600,7 +600,7 @@ func Test_applyContainerSecurityContext(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -628,7 +628,7 @@ func TestCriManager_updateCreateConfig(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -653,7 +653,7 @@ func Test_toCriContainer(t *testing.T) {
 		want    *runtime.Container
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -674,13 +674,31 @@ func Test_imageToCriImage(t *testing.T) {
 	type args struct {
 		image *apitypes.ImageInfo
 	}
+
 	tests := []struct {
 		name    string
 		args    args
 		want    *runtime.Image
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		{
+			name:    "test1",
+			args:    args{image: &apitypes.ImageInfo{Config: &apitypes.ContainerConfig{User: "ww"}, Size: 64}},
+			want:    &runtime.Image{Uid: &runtime.Int64Value{0}, Username: "ww", Size_: 64},
+			wantErr: false,
+		},
+		{
+			name:    "test2",
+			args:    args{image: &apitypes.ImageInfo{Config: &apitypes.ContainerConfig{User: "123"}}},
+			want:    &runtime.Image{Uid: &runtime.Int64Value{123}, Username: ""},
+			wantErr: false,
+		},
+		{
+			name:    "test3",
+			args:    args{image: &apitypes.ImageInfo{Config: &apitypes.ContainerConfig{User: "123:22"}}},
+			want:    &runtime.Image{Uid: &runtime.Int64Value{123}, Username: ""},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -711,7 +729,7 @@ func TestCriManager_ensureSandboxImageExists(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -736,7 +754,7 @@ func Test_getUserFromImageUser(t *testing.T) {
 		want  *int64
 		want1 string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -760,7 +778,7 @@ func Test_parseUserFromImageUser(t *testing.T) {
 		args args
 		want string
 	}{
-	// TODO: Add test cases.
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
run unit-test for method imageToCriImag(image *apitypes.ImageInfo) (*runtime.Image, error).
the method is designed for imageToCriImage to converts pouch image API to CRI image API
If user is numeric, it will be treated as uid; or else, it is treated as user nam

### Ⅱ. Does this pull request fix one issue?
fixes #1914 

### Ⅲ. Describe how you did it
verify three kind of inputs, {User : "ww"}, {User : "123"}, {User : "123:22"}

### Ⅳ. Describe how to verify it
run "go test -cover"
for User : "ww", Username is "ww", Uid is 0
for User: "123", Uid is 123, Username is null
for User: "123:22", Uid is 123, Username is null

### Ⅴ. Special notes for reviews
thanks for reviewing



