### PR TITLE
test: add unit-test for getSELinuxSecurityOpts method which locate on cri/v…

### DIFF
--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -14,6 +14,36 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
+func Test_getSELinuxSecurityOpts(t *testing.T) {
+	type args struct {
+		sc *runtime.LinuxContainerSecurityContext
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{"test1", args{&runtime.LinuxContainerSecurityContext{SelinuxOptions: &runtime.SELinuxOption{User: "", Role: "", Type: "", Level: ""}}}, nil, false},
+		{"test2", args{&runtime.LinuxContainerSecurityContext{SelinuxOptions: &runtime.SELinuxOption{User: "xzx", Role: "", Type: "", Level: ""}}}, nil, false},
+		{"test3", args{&runtime.LinuxContainerSecurityContext{SelinuxOptions: &runtime.SELinuxOption{User: "xzx", Role: "xzx", Type: "", Level: ""}}}, nil, false},
+		{"test4", args{&runtime.LinuxContainerSecurityContext{SelinuxOptions: &runtime.SELinuxOption{User: "xzx", Role: "xzx", Type: "xzx", Level: ""}}}, nil, false},
+		{"test5", args{&runtime.LinuxContainerSecurityContext{SelinuxOptions: &runtime.SELinuxOption{User: "xzx", Role: "xzx", Type: "xzx", Level: "xzx"}}}, []string{"label=user:xzx", "label=role:xzx", "label=type:xzx", "label=level:xzx"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getSELinuxSecurityOpts(tt.args.sc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getSELinuxSecurityOpts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getSELinuxSecurityOpts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_parseUint32(t *testing.T) {
 	type args struct {
 		s string


### PR DESCRIPTION
…1alpha1/cri_utils.go

Signed-off-by: Coordinate36 <2484652469@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Add unit-test for getSELinuxSecurityOpts method which locate on cri/v1alpha1/cri_utils.go.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1912 

### Ⅲ. Describe how you did it

Build unit test by condition combination coverage(ccc).
First, build program structure graph. According to the graph and the principle of ccc, we derive the test cases

### Ⅳ. Describe how to verify it

cd cri/v1alpha1; go test.

### Ⅴ. Special notes for reviews

no

