### PR TITLE
bug: fix judgement for SetRootfsDiskQuota

### DIFF
--- a/storage/quota/quota.go
+++ b/storage/quota/quota.go
@@ -149,8 +149,12 @@ func GetDefaultQuota(quotas map[string]string) string {
 // SetRootfsDiskQuota is to set container rootfs dir disk quota.
 func SetRootfsDiskQuota(basefs, size string, quotaID uint32) error {
 	overlayfs, err := getOverlay(basefs)
-	if err != nil || overlayfs == nil {
+	if err != nil {
 		return fmt.Errorf("failed to get lowerdir: %v", err)
+	}
+	if overlayfs == nil || (*overlayfs) == (OverlayMount{}) ||
+		overlayfs.Upper == "" || overlayfs.Work == "" {
+		return fmt.Errorf("failed to get overlay mount for %s: %+v", basefs, overlayfs)
 	}
 
 	for _, dir := range []string{overlayfs.Upper, overlayfs.Work} {


### PR DESCRIPTION
Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
```
if err != nil || overlayfs == nil 
```
overlayfs can never be non-null, since it have been initialled in `getoverlay`.
The other fix is if directory is empty, set-quota will fail.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


