### PR TITLE
bugfix: convert container err into pouchd manager error

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -515,6 +515,10 @@ paths:
           description: "no error"
         404:
           $ref: "#/responses/404ErrorResponse"
+        409:
+          description: "container is paused"
+          schema:
+            $ref: "#/definitions/Error"
         500:
           $ref: "#/responses/500ErrorResponse"
       tags: ["Container"]

--- a/ctrd/image.go
+++ b/ctrd/image.go
@@ -25,6 +25,15 @@ import (
 
 // CreateImageReference creates the image in the meta data in the containerd.
 func (c *Client) CreateImageReference(ctx context.Context, img ctrdmetaimages.Image) (ctrdmetaimages.Image, error) {
+	image, err := c.createImageReference(ctx, img)
+	if err != nil {
+		return image, convertCtrdErr(err)
+	}
+	return image, nil
+}
+
+// createImageReference creates the image in the meta data in the containerd.
+func (c *Client) createImageReference(ctx context.Context, img ctrdmetaimages.Image) (ctrdmetaimages.Image, error) {
 	wrapperCli, err := c.Get(ctx)
 	if err != nil {
 		return ctrdmetaimages.Image{}, fmt.Errorf("failed to get a containerd grpc client: %v", err)
@@ -35,6 +44,15 @@ func (c *Client) CreateImageReference(ctx context.Context, img ctrdmetaimages.Im
 
 // GetImage returns the containerd's Image.
 func (c *Client) GetImage(ctx context.Context, ref string) (containerd.Image, error) {
+	img, err := c.getImage(ctx, ref)
+	if err != nil {
+		return img, convertCtrdErr(err)
+	}
+	return img, nil
+}
+
+// getImage returns the containerd's Image.
+func (c *Client) getImage(ctx context.Context, ref string) (containerd.Image, error) {
 	wrapperCli, err := c.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get a containerd grpc client: %v", err)
@@ -45,6 +63,15 @@ func (c *Client) GetImage(ctx context.Context, ref string) (containerd.Image, er
 
 // ListImages lists all images.
 func (c *Client) ListImages(ctx context.Context, filter ...string) ([]containerd.Image, error) {
+	imgs, err := c.listImages(ctx, filter...)
+	if err != nil {
+		return imgs, convertCtrdErr(err)
+	}
+	return imgs, nil
+}
+
+// listImages lists all images.
+func (c *Client) listImages(ctx context.Context, filter ...string) ([]containerd.Image, error) {
 	wrapperCli, err := c.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get a containerd grpc client: %v", err)
@@ -55,6 +82,14 @@ func (c *Client) ListImages(ctx context.Context, filter ...string) ([]containerd
 
 // RemoveImage deletes an image.
 func (c *Client) RemoveImage(ctx context.Context, ref string) error {
+	if err := c.removeImage(ctx, ref); err != nil {
+		return convertCtrdErr(err)
+	}
+	return nil
+}
+
+// removeImage deletes an image.
+func (c *Client) removeImage(ctx context.Context, ref string) error {
 	wrapperCli, err := c.Get(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get a containerd grpc client: %v", err)
@@ -68,6 +103,15 @@ func (c *Client) RemoveImage(ctx context.Context, ref string) error {
 
 // SaveImage saves image to tarstream
 func (c *Client) SaveImage(ctx context.Context, exporter ctrdmetaimages.Exporter, ref string) (io.ReadCloser, error) {
+	r, err := c.saveImage(ctx, exporter, ref)
+	if err != nil {
+		return r, convertCtrdErr(err)
+	}
+	return r, nil
+}
+
+// saveImage saves image to tarstream
+func (c *Client) saveImage(ctx context.Context, exporter ctrdmetaimages.Exporter, ref string) (io.ReadCloser, error) {
 	wrapperCli, err := c.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get a containerd grpc client: %v", err)
@@ -94,18 +138,24 @@ func (c *Client) SaveImage(ctx context.Context, exporter ctrdmetaimages.Exporter
 		}
 	}
 
-	exportedStream, err := wrapperCli.client.Export(ctx, exporter, desc)
-	if err != nil {
-		return nil, err
-	}
-
-	return exportedStream, nil
+	return wrapperCli.client.Export(ctx, exporter, desc)
 }
 
 // ImportImage creates a set of images by tarstream.
 //
 // NOTE: One tar may have several manifests.
 func (c *Client) ImportImage(ctx context.Context, importer ctrdmetaimages.Importer, reader io.Reader) ([]containerd.Image, error) {
+	imgs, err := c.importImage(ctx, importer, reader)
+	if err != nil {
+		return imgs, convertCtrdErr(err)
+	}
+	return imgs, nil
+}
+
+// importImage creates a set of images by tarstream.
+//
+// NOTE: One tar may have several manifests.
+func (c *Client) importImage(ctx context.Context, importer ctrdmetaimages.Importer, reader io.Reader) ([]containerd.Image, error) {
 	wrapperCli, err := c.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get a containerd grpc client: %v", err)

--- a/ctrd/utils.go
+++ b/ctrd/utils.go
@@ -9,9 +9,11 @@ import (
 	"time"
 
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/pkg/errtypes"
 	"github.com/alibaba/pouch/pkg/utils"
 
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/remotes"
@@ -19,6 +21,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 // NewDefaultSpec new a template spec with default.
@@ -165,4 +168,32 @@ func toLinuxResources(resources types.Resources) (*specs.LinuxResources, error) 
 	// TODO: add more fields.
 
 	return r, nil
+}
+
+// convertCtrdErr converts containerd client error into a pouchd manager error.
+// containerd client error converts GRPC code from containerd API to containerd client error.
+// pouchd manager error is used in the whole managers and API layers to construct status code for API.
+// there should be a way convert the previous to the latter one.
+func convertCtrdErr(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if errdefs.IsNotFound(err) {
+		return errors.Wrap(errtypes.ErrNotfound, err.Error())
+	}
+
+	if errdefs.IsAlreadyExists(err) {
+		return errors.Wrap(errtypes.ErrAlreadyExisted, err.Error())
+	}
+
+	if errdefs.IsInvalidArgument(err) {
+		return errors.Wrap(errtypes.ErrInvalidParam, err.Error())
+	}
+
+	if errdefs.IsNotImplemented(err) {
+		return errors.Wrap(errtypes.ErrNotImplemented, err.Error())
+	}
+
+	return err
 }

--- a/ctrd/utils_test.go
+++ b/ctrd/utils_test.go
@@ -1,0 +1,83 @@
+package ctrd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/alibaba/pouch/pkg/errtypes"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/pkg/errors"
+)
+
+func Test_convertCtrdErr(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		returnedErr error
+	}{
+		{
+			name: "nil",
+			args: args{
+				err: nil,
+			},
+			wantErr:     false,
+			returnedErr: nil,
+		},
+		{
+			name: "not found",
+			args: args{
+				err: errors.Wrap(errdefs.ErrNotFound, "container asdfghjk"),
+			},
+			wantErr:     true,
+			returnedErr: errors.Wrap(errtypes.ErrNotfound, errors.Wrap(errdefs.ErrNotFound, "container asdfghjk").Error()),
+		},
+		{
+			name: "invalid params",
+			args: args{
+				err: errors.Wrap(errdefs.ErrInvalidArgument, "container asdfghjk"),
+			},
+			wantErr:     true,
+			returnedErr: errors.Wrap(errtypes.ErrInvalidParam, errors.Wrap(errdefs.ErrInvalidArgument, "container asdfghjk").Error()),
+		},
+		{
+			name: "already exists",
+			args: args{
+				err: errors.Wrap(errdefs.ErrAlreadyExists, "container asdfghjk"),
+			},
+			wantErr:     true,
+			returnedErr: errors.Wrap(errtypes.ErrAlreadyExisted, errors.Wrap(errdefs.ErrAlreadyExists, "container asdfghjk").Error()),
+		},
+		{
+			name: "not implemented",
+			args: args{
+				err: errors.Wrap(errdefs.ErrNotImplemented, "container asdfghjk"),
+			},
+			wantErr:     true,
+			returnedErr: errors.Wrap(errtypes.ErrNotImplemented, errors.Wrap(errdefs.ErrNotImplemented, "container asdfghjk").Error()),
+		},
+		{
+			name: "normal error",
+			args: args{
+				err: fmt.Errorf("this is a normal error"),
+			},
+			wantErr:     true,
+			returnedErr: fmt.Errorf("this is a normal error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := convertCtrdErr(tt.args.err)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("convertCtrdErr() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && (err.Error() != tt.returnedErr.Error()) {
+				t.Errorf("convertCtrdErr() error = %v, wantErr %v, returnedErr: %v", err, tt.wantErr, tt.returnedErr)
+			}
+		})
+	}
+}

--- a/test/api_container_start_test.go
+++ b/test/api_container_start_test.go
@@ -64,7 +64,7 @@ func (suite *APIContainerStartSuite) TestStartPausedContainer(c *check.C) {
 
 	resp, err := request.Post("/containers/" + cname + "/start")
 	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 500)
+	CheckRespStatus(c, resp, 409)
 }
 
 // TestStartDetachKeyWork test detatch-keys works.


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This pull request converts the error from containerd side to pouch manager side.

For the error part, we have the following part:

* the containerd's part which returns grpc code;
* containerd client part, which wraps the grpc code to be error in `github.com/containerd/containerd/errdefs`
* mgrs's error types from `github.com/alibaba/pouch/pkg/errtypes`, this is used for API layers to construct http status code in `./apis/server/routes.go`

So if we need to make use of error returned from containerd client which is `ctrd`, then we should convert those errors into errtypes which could be used in mgrs. This will transfer errors from containerd correctly to mgrs and API layers.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Describe how you did it
none

### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

