### PR TITLE
bugfix: failed to start container when /etc/mtab is symbol link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 script: |
   if [[ "${TEST_SUITE}" = "unittest" ]]; then
     hack/install/install_ci_related.sh
-    make unit-test
+    make unit-test || travis_terminate 1
     make coverage
   elif [[ "${TEST_SUITE}" = "integrationtest" ]]; then
     make build
@@ -32,7 +32,7 @@ script: |
     sudo env "PATH=$PATH" make install
 
     sudo env "PATH=$PATH" make download_dependencies
-    sudo env "PATH=$PATH" make integration-test
+    sudo env "PATH=$PATH" make integration-test || travis_terminate 1
     make coverage
   elif [[ "${TEST_SUITE}" = "criv1alpha1test" ]]; then
     make build
@@ -40,7 +40,7 @@ script: |
     sudo env "PATH=$PATH" make install
 
     sudo env "PATH=$PATH" make download_dependencies
-    sudo env "PATH=$PATH" make cri-v1alpha1-test
+    sudo env "PATH=$PATH" make cri-v1alpha1-test || travis_terminate 1
     make coverage
   else
     make build
@@ -48,7 +48,7 @@ script: |
     sudo env "PATH=$PATH" make install
 
     sudo env "PATH=$PATH" make download_dependencies
-    sudo env "PATH=$PATH" make cri-v1alpha2-test
+    sudo env "PATH=$PATH" make cri-v1alpha2-test || travis_terminate 1
     make coverage
   fi
   

--- a/daemon/mgr/spec_hook.go
+++ b/daemon/mgr/spec_hook.go
@@ -145,7 +145,7 @@ func setMountTab(ctx context.Context, c *Container, spec *SpecWrapper) error {
 
 	mtabPrestart := specs.Hook{
 		Path: "/bin/cp",
-		Args: []string{"-f", hostmtabPath, mtabPath},
+		Args: []string{"-f", "--remove-destination", hostmtabPath, mtabPath},
 	}
 	spec.s.Hooks.Prestart = append(spec.s.Hooks.Prestart, mtabPrestart)
 

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -422,3 +422,24 @@ func (suite *PouchRunSuite) TestRunSetRunningFlag(c *check.C) {
 	}
 	c.Assert(result[0].State.Running, check.Equals, true)
 }
+
+func (suite *PouchRunSuite) TestRunWithMtab(c *check.C) {
+	cname := "TestRunWithMtab"
+	volumeName := "TestRunWithMtabVolume"
+	dest := "/mnt/" + volumeName
+
+	command.PouchRun("volume", "create", "--name", volumeName).Assert(c, icmd.Success)
+	defer command.PouchRun("volume", "rm", volumeName).Assert(c, icmd.Success)
+
+	ret := command.PouchRun("run", "--rm", "--name", cname, "-v", volumeName+":"+dest, busyboxImage, "cat", "/etc/mtab").Assert(c, icmd.Success)
+	ret.Assert(c, icmd.Success)
+
+	found := false
+	for _, line := range strings.Split(ret.Stdout(), "\n") {
+		if strings.Contains(line, dest) {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, check.Equals, true)
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
In some images, `/etc/mtab` is symbol link file, such as:
`/etc/mtab -> /proc/mounts`, when use `/bin/cp -f` to overwrite
`/etc/mtab`, it will cause error, because it will link to `/proc/mounts`
file on the host.

So we use the option of `--remove-destination` to remove the symbol file
before overwrite it.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it
run testcase `TestRunWithMtab`

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
