### PR TITLE
refactor: make the API case clear and stable

### DIFF
--- a/test/api_container_attach_test.go
+++ b/test/api_container_attach_test.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"net/url"
-
 	"github.com/alibaba/pouch/test/environment"
-	"github.com/alibaba/pouch/test/request"
 
 	"github.com/go-check/check"
 )
@@ -19,28 +16,16 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerAttachSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
-
-	PullImage(c, busyboxImage)
 }
 
 // TestContainerAttachStdin tests attaching stdin is OK.
 func (suite *APIContainerAttachSuite) TestContainerAttachStdin(c *check.C) {
-	// TODO
-	// path := "/containers/{name:.*}/attach"
+	// TODO: missing case
+	helpwantedForMissingCase(c, "container api attach 200 case")
 }
 
 // TestContainerAttachNotFound
 func (suite *APIContainerAttachSuite) TestContainerAttachNotFound(c *check.C) {
-	cname := "TestContainerAttachNotFound"
-
-	q := url.Values{}
-	q.Set("stdin", "1")
-	query := request.WithQuery(q)
-	header := request.WithHeader("Content-Type", "text/plain")
-
-	resp, err := request.Post("/containers/"+cname+"/attach", query, header)
-	c.Assert(err, check.IsNil)
-
-	// TODO: return 404 when issue 470 is fixed.
-	CheckRespStatus(c, resp, 200)
+	// TODO: missing case
+	helpwantedForMissingCase(c, "container api attach 404 case")
 }

--- a/test/api_container_create_test.go
+++ b/test/api_container_create_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/url"
+	"sort"
 
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/environment"
@@ -20,39 +21,117 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerCreateSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
 	PullImage(c, busyboxImage)
 }
 
-// TestCreateOk test create api is ok with default parameters.
-func (suite *APIContainerCreateSuite) TestCreateOk(c *check.C) {
-	cname := "TestCreateOk"
+// TestBasic test create api is ok.
+func (suite *APIContainerCreateSuite) TestBasic(c *check.C) {
+	cname := "CreateBasic"
+
+	defaultLxcfsBinds := []string{
+		"/var/lib:/var/lib/lxc:shared",
+		"/var/lib/lxcfs/proc/uptime:/proc/uptime",
+		"/var/lib/lxcfs/proc/swaps:/proc/swaps",
+		"/var/lib/lxcfs/proc/stat:/proc/stat",
+		"/var/lib/lxcfs/proc/diskstats:/proc/diskstats",
+		"/var/lib/lxcfs/proc/meminfo:/proc/meminfo",
+		"/var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo",
+	}
 
 	q := url.Values{}
 	q.Add("name", cname)
 
 	obj := map[string]interface{}{
-		"Image":      busyboxImage,
-		"HostConfig": map[string]interface{}{},
+		"HostConfig": map[string]interface{}{
+			// volume related
+			"Binds": []string{
+				"/tmp:/tmp",
+			},
+
+			// runtime
+			// NOTE: please make sure the daemon has added runv
+			"Runtime": "runv",
+
+			// policy
+			"RestartPolicy": map[string]interface{}{
+				"Name": "always",
+			},
+
+			// isolation options
+			"EnableLxcfs":         true,
+			"MemoryWmarkRatio":    int64(30),
+			"MemoryExtra":         int64(50),
+			"MemoryForceEmptyCtl": 0,
+			"ScheLatSwitch":       0,
+
+			// oom setting
+			"OomScoreAdj":    100,
+			"OomKillDisable": true,
+		},
+		"Image": busyboxImage,
+		"Tty":   true,
 	}
 
 	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
 	resp, err := request.Post("/containers/create", query, body)
+	defer DelContainerForceMultyTime(c, cname)
 	c.Assert(err, check.IsNil)
-
 	CheckRespStatus(c, resp, 201)
 
-	// Decode response
-	got := types.ContainerCreateResp{}
-	request.DecodeBody(&got, resp.Body)
-	c.Assert(err, check.IsNil)
-	c.Assert(got.ID, check.NotNil)
+	// decode response
+	{
+		got := types.ContainerCreateResp{}
+		c.Assert(request.DecodeBody(&got, resp.Body), check.IsNil)
+		c.Assert(got.ID, check.NotNil)
+		c.Assert(got.Name, check.Equals, cname)
+	}
 
-	DelContainerForceMultyTime(c, cname)
+	// check inspect result
+	{
+		resp, err := request.Get("/containers/" + cname + "/json")
+		c.Assert(err, check.IsNil)
+		CheckRespStatus(c, resp, 200)
+		got := types.ContainerJSON{}
+		c.Assert(request.DecodeBody(&got, resp.Body), check.IsNil)
+
+		// isolation related check
+		c.Assert(got.HostConfig.EnableLxcfs, check.Equals, true)
+		c.Assert(*got.HostConfig.MemoryWmarkRatio, check.Equals, int64(30))
+		c.Assert(*got.HostConfig.MemoryExtra, check.Equals, int64(50))
+		c.Assert(got.HostConfig.MemoryForceEmptyCtl, check.Equals, int64(0))
+		c.Assert(got.HostConfig.ScheLatSwitch, check.Equals, int64(0))
+
+		// runtime check
+		c.Assert(got.HostConfig.Runtime, check.Equals, "runv")
+
+		// io related check
+		c.Assert(got.Config.Tty, check.Equals, true)
+
+		// oom related check
+		c.Assert(got.HostConfig.OomScoreAdj, check.Equals, int64(100))
+		c.Assert(*got.HostConfig.OomKillDisable, check.Equals, true)
+
+		// policy
+		c.Assert(got.HostConfig.RestartPolicy.Name, check.Equals, "always")
+		c.Assert(got.HostConfig.RestartPolicy.MaximumRetryCount, check.Equals, int64(0))
+
+		// volume related
+		expectedBinds := []string{"/tmp:/tmp"}
+		if environment.IsLxcfsEnabled() {
+			expectedBinds = append(expectedBinds, defaultLxcfsBinds...)
+		}
+
+		// sort the string before match
+		sort.Strings(got.HostConfig.Binds)
+		sort.Strings(expectedBinds)
+		c.Assert(got.HostConfig.Binds, check.DeepEquals, expectedBinds)
+	}
 }
 
-// TestNilName tests creating container without giving name should succeed.
-func (suite *APIContainerCreateSuite) TestNilName(c *check.C) {
+// TestBasicWithoutName tests creating container without giving name should succeed.
+func (suite *APIContainerCreateSuite) TestBasicWithoutName(c *check.C) {
 	obj := map[string]interface{}{
 		"Image":      busyboxImage,
 		"HostConfig": map[string]interface{}{},
@@ -65,53 +144,46 @@ func (suite *APIContainerCreateSuite) TestNilName(c *check.C) {
 
 	// Decode response
 	got := types.ContainerCreateResp{}
-	request.DecodeBody(&got, resp.Body)
-	c.Assert(err, check.IsNil)
+	c.Assert(request.DecodeBody(&got, resp.Body), check.IsNil)
 	c.Assert(got.ID, check.NotNil)
 	c.Assert(got.Name, check.NotNil)
 
 	DelContainerForceMultyTime(c, got.Name)
 }
 
-// TestDupContainer tests create a duplicate container, return 409.
+// TestDupContainer tests create a duplicate container, should return 409.
 func (suite *APIContainerCreateSuite) TestDupContainer(c *check.C) {
-	cname := "TestDupContainer"
+	cname := "CreateDuplicateContainer"
+
 	q := url.Values{}
 	q.Add("name", cname)
 	obj := map[string]interface{}{
 		"Image":      busyboxImage,
 		"HostConfig": map[string]interface{}{},
 	}
+
 	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
-
 	resp, err := request.Post("/containers/create", query, body)
 	c.Assert(err, check.IsNil)
-
 	CheckRespStatus(c, resp, 201)
+	defer DelContainerForceMultyTime(c, cname)
 
 	// Create a duplicate container
 	resp, err = request.Post("/containers/create", query, body)
 	c.Assert(err, check.IsNil)
-
 	CheckRespStatus(c, resp, 409)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestNonExistingImg tests using non-existing image return 404.
 func (suite *APIContainerCreateSuite) TestNonExistingImg(c *check.C) {
-	cname := "TestNonExistingImg"
-	q := url.Values{}
-	q.Add("name", cname)
 	obj := map[string]interface{}{
 		"Image":      "non-existing",
 		"HostConfig": map[string]interface{}{},
 	}
-	query := request.WithQuery(q)
 	body := request.WithJSONBody(obj)
 
-	resp, err := request.Post("/containers/create", query, body)
+	resp, err := request.Post("/containers/create", body)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 404)
 }
@@ -122,201 +194,5 @@ func (suite *APIContainerCreateSuite) TestBadParam(c *check.C) {
 	// TODO:
 	// 1. Invalid container name, for example length too large, illegal letter.
 	// 2. Invalid Parameters
-}
-
-// TestAllocateTTY tests allocating tty is OK.
-func (suite *APIContainerCreateSuite) TestAllocateTTY(c *check.C) {
-	cname := "TestAllocateTTY"
-	q := url.Values{}
-	q.Add("name", cname)
-	query := request.WithQuery(q)
-
-	// HostConfig is nil.
-	obj := map[string]interface{}{
-		"Image":      busyboxImage,
-		"Tty":        true,
-		"HostConfig": map[string]interface{}{},
-	}
-
-	body := request.WithJSONBody(obj)
-
-	resp, err := request.Post("/containers/create", query, body)
-	c.Assert(err, check.IsNil)
-
-	CheckRespStatus(c, resp, 201)
-
-	// TODO: verify TTY works?
-	DelContainerForceMultyTime(c, cname)
-}
-
-// TestAddVolume tests add volume is OK.
-func (suite *APIContainerCreateSuite) TestAddVolume(c *check.C) {
-	cname := "TestAddVolume"
-	q := url.Values{}
-	q.Add("name", cname)
-	query := request.WithQuery(q)
-
-	// HostConfig is nil.
-	obj := map[string]interface{}{
-		"Image": busyboxImage,
-		"Tty":   true,
-		"HostConfig": map[string]interface{}{
-			"Binds": [1]string{"/tmp:/tmp"},
-		},
-	}
-
-	body := request.WithJSONBody(obj)
-
-	resp, err := request.Post("/containers/create", query, body)
-	c.Assert(err, check.IsNil)
-
-	CheckRespStatus(c, resp, 201)
-
-	// TODO: verify volume
-	DelContainerForceMultyTime(c, cname)
-}
-
-// TestRuntime tests specify a different runtime, e.g. runv could work.
-func (suite *APIContainerCreateSuite) TestRuntime(c *check.C) {
-	cname := "TestRuntime"
-	q := url.Values{}
-	q.Add("name", cname)
-	query := request.WithQuery(q)
-
-	// HostConfig is nil.
-	obj := map[string]interface{}{
-		"Image": busyboxImage,
-		"Tty":   true,
-		"HostConfig": map[string]interface{}{
-			"Runtime": "runv",
-		},
-	}
-
-	body := request.WithJSONBody(obj)
-
-	resp, err := request.Post("/containers/create", query, body)
-	c.Assert(err, check.IsNil)
-
-	CheckRespStatus(c, resp, 201)
-
-	// TODO: verify runtime
-	DelContainerForceMultyTime(c, cname)
-}
-
-// TestLxcfsEnable is OK.
-func (suite *APIContainerCreateSuite) TestLxcfsEnable(c *check.C) {
-	cname := "TestLxcfsEnable"
-	q := url.Values{}
-	q.Add("name", cname)
-	query := request.WithQuery(q)
-
-	isEnable := true
-
-	obj := map[string]interface{}{
-		"Image": busyboxImage,
-		"HostConfig": map[string]interface{}{
-			"EnableLxcfs": isEnable,
-		},
-	}
-
-	body := request.WithJSONBody(obj)
-
-	resp, err := request.Post("/containers/create", query, body)
-	c.Assert(err, check.IsNil)
-
-	CheckRespStatus(c, resp, 201)
-
-	resp, err = request.Get("/containers/" + cname + "/json")
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 200)
-
-	got := types.ContainerJSON{}
-	err = request.DecodeBody(&got, resp.Body)
-	c.Assert(err, check.IsNil)
-
-	c.Assert(got.HostConfig.EnableLxcfs, check.Equals, isEnable)
-
-	DelContainerForceMultyTime(c, cname)
-}
-
-// TestRestartPolicyAlways tests create container with restartpolicy is always could work.
-func (suite *APIContainerCreateSuite) TestRestartPolicyAlways(c *check.C) {
-	cname := "TestRestartPolicyAlways"
-	q := url.Values{}
-	q.Add("name", cname)
-	query := request.WithQuery(q)
-
-	isEnable := true
-
-	obj := map[string]interface{}{
-		"Image": busyboxImage,
-		"HostConfig": map[string]interface{}{
-			"EnableLxcfs": isEnable,
-			"RestartPolicy": map[string]interface{}{
-				"Name": "always",
-			},
-		},
-	}
-
-	body := request.WithJSONBody(obj)
-
-	resp, err := request.Post("/containers/create", query, body)
-	c.Assert(err, check.IsNil)
-
-	CheckRespStatus(c, resp, 201)
-
-	resp, err = request.Get("/containers/" + cname + "/json")
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 200)
-
-	got := types.ContainerJSON{}
-	err = request.DecodeBody(&got, resp.Body)
-	c.Assert(err, check.IsNil)
-
-	c.Assert(got.HostConfig.RestartPolicy.Name, check.Equals, "always")
-
-	DelContainerForceMultyTime(c, cname)
-}
-
-// TestAliOSOptions tests create container with alios related container isolation options.
-func (suite *APIContainerCreateSuite) TestAliOSOptions(c *check.C) {
-	cname := "TestAliOSOptions"
-	q := url.Values{}
-	q.Add("name", cname)
-	query := request.WithQuery(q)
-
-	obj := map[string]interface{}{
-		"Image": busyboxImage,
-		"HostConfig": map[string]interface{}{
-			"MemoryWmarkRatio":    int64(30),
-			"MemoryExtra":         int64(50),
-			"MemoryForceEmptyCtl": 0,
-			"ScheLatSwitch":       0,
-		},
-	}
-	body := request.WithJSONBody(obj)
-
-	resp, err := request.Post("/containers/create", query, body)
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 201)
-}
-
-func (suite *APIContainerCreateSuite) TestCreateOOMOption(c *check.C) {
-	cname := "TestCreateOOMOption"
-	q := url.Values{}
-	q.Add("name", cname)
-	query := request.WithQuery(q)
-
-	obj := map[string]interface{}{
-		"Image": busyboxImage,
-		"HostConfig": map[string]interface{}{
-			"OomScoreAdj":    100,
-			"OomKillDisable": true,
-		},
-	}
-	body := request.WithJSONBody(obj)
-
-	resp, err := request.Post("/containers/create", query, body)
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 201)
+	helpwantedForMissingCase(c, "container api create with bad request")
 }

--- a/test/api_container_delete_test.go
+++ b/test/api_container_delete_test.go
@@ -17,6 +17,7 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerDeleteSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
 	PullImage(c, busyboxImage)
 }
 
@@ -26,42 +27,32 @@ func (suite *APIContainerDeleteSuite) TestDeleteNonExisting(c *check.C) {
 
 	resp, err := request.Delete("/containers/" + cname)
 	c.Assert(err, check.IsNil)
-
 	CheckRespStatus(c, resp, 404)
 }
 
-// TestDeleteRunningCon test deleting running container return 500.
+// TestDeleteRunningCon test deleting running container, should return 500.
 func (suite *APIContainerDeleteSuite) TestDeleteRunningCon(c *check.C) {
-	cname := "TestDeleteRunningCon"
+	cname := "TestDeleteRunningContainer"
 
 	CreateBusyboxContainerOk(c, cname)
-
 	StartContainerOk(c, cname)
 
 	resp, err := request.Delete("/containers/" + cname)
 	c.Assert(err, check.IsNil)
-
 	CheckRespStatus(c, resp, 500)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
-// TestDeletePausedCon test deleting paused container return 500.
+// TestDeletePausedCon test deleting paused container, should return 500.
 func (suite *APIContainerDeleteSuite) TestDeletePausedCon(c *check.C) {
-	cname := "TestDeletePausedCon"
+	cname := "TestDeletePausedContainer"
 
 	CreateBusyboxContainerOk(c, cname)
-
 	StartContainerOk(c, cname)
-
 	PauseContainerOk(c, cname)
 
 	resp, err := request.Delete("/containers/" + cname)
 	c.Assert(err, check.IsNil)
-
 	CheckRespStatus(c, resp, 500)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestDeleteStoppedCon test deleting stopped container return 204.
@@ -69,14 +60,11 @@ func (suite *APIContainerDeleteSuite) TestDeleteStoppedCon(c *check.C) {
 	cname := "TestDeleteStoppedCon"
 
 	CreateBusyboxContainerOk(c, cname)
-
 	StartContainerOk(c, cname)
-
 	StopContainerOk(c, cname)
 
 	resp, err := request.Delete("/containers/" + cname)
 	c.Assert(err, check.IsNil)
-
 	CheckRespStatus(c, resp, 204)
 }
 
@@ -88,6 +76,5 @@ func (suite *APIContainerDeleteSuite) TestDeleteCreatedCon(c *check.C) {
 
 	resp, err := request.Delete("/containers/" + cname)
 	c.Assert(err, check.IsNil)
-
 	CheckRespStatus(c, resp, 204)
 }

--- a/test/api_container_exec_create_test.go
+++ b/test/api_container_exec_create_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/environment"
 	"github.com/alibaba/pouch/test/request"
 
@@ -18,15 +17,16 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerExecSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
 	PullImage(c, busyboxImage)
 }
 
 // TestContainerCreateExecOk tests execing containers is OK.
 func (suite *APIContainerExecSuite) TestContainerCreateExecOk(c *check.C) {
-	// TODO:
 	cname := "TestContainerCreateExecOk"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
 	StartContainerOk(c, cname)
 
@@ -34,16 +34,11 @@ func (suite *APIContainerExecSuite) TestContainerCreateExecOk(c *check.C) {
 		"Cmd":    []string{"echo", "test"},
 		"Detach": true,
 	}
+
 	body := request.WithJSONBody(obj)
 	resp, err := request.Post("/containers/"+cname+"/exec", body)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 201)
-
-	var execCreateResp types.ExecCreateResp
-	request.DecodeBody(&execCreateResp, resp.Body)
-	c.Logf("ExecID is %s", execCreateResp.ID)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestContainerCreateExecNoCmd tests execing containers is OK.
@@ -51,39 +46,36 @@ func (suite *APIContainerExecSuite) TestContainerCreateExecNoCmd(c *check.C) {
 	cname := "TestContainerCreateExecNoCmd"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
 	StartContainerOk(c, cname)
 
-	// TODO: also test "Cmd":nil
 	obj := map[string]interface{}{
-		"Cmd":    []string{""},
 		"Detach": true,
 	}
 	body := request.WithJSONBody(obj)
+
 	resp, err := request.Post("/containers/"+cname+"/exec", body)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 201)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestExecCreatedContainer tests creating exec on created container return error.
 func (suite *APIContainerExecSuite) TestExecCreatedContainer(c *check.C) {
-	// TODO:
 	cname := "TestExecCreatedContainer"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
 	obj := map[string]interface{}{
 		"Cmd":    []string{"echo", "test"},
 		"Detach": true,
 	}
+
 	body := request.WithJSONBody(obj)
 	resp, err := request.Post("/containers/"+cname+"/exec", body)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 500)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestExecPausedContainer tests creating exec on paused container return error.
@@ -91,9 +83,9 @@ func (suite *APIContainerExecSuite) TestExecPausedContainer(c *check.C) {
 	cname := "TestExecPausedContainer"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
 	StartContainerOk(c, cname)
-
 	PauseContainerOk(c, cname)
 
 	obj := map[string]interface{}{
@@ -104,8 +96,6 @@ func (suite *APIContainerExecSuite) TestExecPausedContainer(c *check.C) {
 	resp, err := request.Post("/containers/"+cname+"/exec", body)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 500)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestExecStoppedContainer tests creating exec on stopped container return error.
@@ -113,9 +103,9 @@ func (suite *APIContainerExecSuite) TestExecStoppedContainer(c *check.C) {
 	cname := "TestExecStoppedContainer"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
 	StartContainerOk(c, cname)
-
 	StopContainerOk(c, cname)
 
 	obj := map[string]interface{}{
@@ -126,6 +116,4 @@ func (suite *APIContainerExecSuite) TestExecStoppedContainer(c *check.C) {
 	resp, err := request.Post("/containers/"+cname+"/exec", body)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 500)
-
-	DelContainerForceMultyTime(c, cname)
 }

--- a/test/api_container_exec_inspect_test.go
+++ b/test/api_container_exec_inspect_test.go
@@ -20,6 +20,7 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerExecInspectSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
 	PullImage(c, busyboxImage)
 }
 

--- a/test/api_container_exec_start_test.go
+++ b/test/api_container_exec_start_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/alibaba/pouch/test/environment"
 	"github.com/alibaba/pouch/test/request"
-	"github.com/docker/docker/pkg/stdcopy"
 
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/go-check/check"
 )
 
@@ -24,6 +24,7 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerExecStartSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
 	PullImage(c, busyboxImage)
 }
 
@@ -48,49 +49,44 @@ func checkEchoSuccess(c *check.C, tty bool, conn net.Conn, br *bufio.Reader, exp
 // TestContainerExecStartWithoutUpgrade tests start exec without upgrade which will return 200 OK.
 func (suite *APIContainerExecStartSuite) TestContainerExecStartWithoutUpgrade(c *check.C) {
 	cname := "TestContainerCreateExecStartWithoutUpgrade"
+	content := "hi pouch"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
 	StartContainerOk(c, cname)
-
-	execid := CreateExecEchoOk(c, cname)
+	execid := CreateExecEchoOk(c, cname, content)
 
 	obj := map[string]interface{}{}
 	resp, conn, br, err := request.Hijack("/exec/"+execid+"/start", request.WithJSONBody(obj))
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 200)
-
-	checkEchoSuccess(c, false, conn, br, "test")
-
-	DelContainerForceMultyTime(c, cname)
+	checkEchoSuccess(c, false, conn, br, content)
 }
 
 // TestContainerExecStartOk tests start exec.
 func (suite *APIContainerExecStartSuite) TestContainerExecStart(c *check.C) {
 	cname := "TestContainerCreateExecStart"
+	content := "test"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
 	StartContainerOk(c, cname)
 
-	execid := CreateExecEchoOk(c, cname)
+	execid := CreateExecEchoOk(c, cname, content)
 
 	resp, conn, reader, err := StartContainerExec(c, execid, false, false)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 101)
-
-	checkEchoSuccess(c, false, conn, reader, "test")
-
-	DelContainerForceMultyTime(c, cname)
+	checkEchoSuccess(c, false, conn, reader, content)
 }
 
 // TestContainerExecStartNotFound tests starting an non-existing execID return error.
 func (suite *APIContainerExecStartSuite) TestContainerExecStartNotFound(c *check.C) {
-	obj := map[string]interface{}{
-		"Detach": false,
-		"Tty":    false,
-	}
+	obj := map[string]interface{}{}
 	body := request.WithJSONBody(obj)
+
 	resp, err := request.Post("/exec/TestContainerExecStartNotFound/start", body)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 404)
@@ -98,12 +94,18 @@ func (suite *APIContainerExecStartSuite) TestContainerExecStartNotFound(c *check
 
 // TestContainerExecStartStopped tests start a process in a stopped container return error.
 func (suite *APIContainerExecStartSuite) TestContainerExecStartStopped(c *check.C) {
+	// TODO: missing case
+	helpwantedForMissingCase(c, "container api exec start stoped case")
 }
 
 // TestContainerExecStartPaused tests start a process in a paused container return error.
 func (suite *APIContainerExecStartSuite) TestContainerExecStartPaused(c *check.C) {
+	// TODO: missing case
+	helpwantedForMissingCase(c, "container api exec start paused case")
 }
 
 // TestContainerExecStartDup tests start a process twice return error.
 func (suite *APIContainerExecStartSuite) TestContainerExecStartDup(c *check.C) {
+	// TODO: missing case
+	helpwantedForMissingCase(c, "container api exec start twice case")
 }

--- a/test/api_container_list_test.go
+++ b/test/api_container_list_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/alibaba/pouch/test/environment"
-	"github.com/alibaba/pouch/test/request"
 
 	"github.com/go-check/check"
 )
@@ -17,12 +16,10 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerListSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
-	PullImage(c, busyboxImage)
 }
 
 // TestListOk test api is ok with default parameters.
 func (suite *APIContainerListSuite) TestListOk(c *check.C) {
-	resp, err := request.Get("/containers/json")
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 200)
+	// TODO: missing case
+	helpwantedForMissingCase(c, "container api list 200 case")
 }

--- a/test/api_container_logs_test.go
+++ b/test/api_container_logs_test.go
@@ -37,6 +37,7 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerLogsSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
 	PullImage(c, busyboxImage)
 }
 

--- a/test/api_container_rename_test.go
+++ b/test/api_container_rename_test.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"net/url"
 
-	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/environment"
 	"github.com/alibaba/pouch/test/request"
 
@@ -21,12 +19,12 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerRenameSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
 	PullImage(c, busyboxImage)
 }
 
 // TestRenameOk test create api is ok with default parameters.
 func (suite *APIContainerRenameSuite) TestRenameOk(c *check.C) {
-
 	// must required
 	oldname := "TestRenameOk"
 	newname := "NewTestRenameOk"
@@ -47,35 +45,22 @@ func (suite *APIContainerRenameSuite) TestRenameById(c *check.C) {
 	oldname := "TestRenameOk"
 	newname := "NewTestRenameOk"
 
-	resp, err := CreateBusyboxContainer(c, oldname, "top")
-	c.Assert(err, check.IsNil)
-	defer resp.Body.Close()
+	// create container by oldname and change it into newname by container id
+	{
+		cid := CreateBusyboxContainerOk(c, oldname, "top")
+		newq := url.Values{}
+		newq.Add("name", newname)
+		resp, err := request.Post("/containers/"+cid+"/rename", request.WithQuery(newq))
+		c.Assert(err, check.IsNil)
+		defer resp.Body.Close()
+		CheckRespStatus(c, resp, 204)
 
-	ccr := types.ContainerCreateResp{}
-	err = json.NewDecoder(resp.Body).Decode(&ccr)
-	c.Assert(err, check.IsNil)
-	cid := ccr.ID
+		defer DelContainerForceMultyTime(c, newname)
+	}
 
-	newq := url.Values{}
-	newq.Add("name", newname)
-	resp2, err := request.Post("/containers/"+cid+"/rename", request.WithQuery(newq))
-	c.Assert(err, check.IsNil)
-	defer resp2.Body.Close()
-	CheckRespStatus(c, resp2, 204)
-
-	DelContainerForceMultyTime(c, newname)
-
-	resp3, err := CreateBusyboxContainer(c, oldname, "top")
-	c.Assert(err, check.IsNil)
-	defer resp3.Body.Close()
-
-	ccr = types.ContainerCreateResp{}
-	err = json.NewDecoder(resp3.Body).Decode(&ccr)
-	c.Assert(err, check.IsNil)
-
-	DelContainerForceMultyTime(c, oldname)
-
-	if ccr.ID == "" {
-		c.Errorf("container with old name %s create error. %v", oldname, ccr)
+	// after oldname release, the oldname is available so that create should OK
+	{
+		CreateBusyboxContainerOk(c, oldname, "top")
+		DelContainerForceMultyTime(c, oldname)
 	}
 }

--- a/test/api_container_resize_test.go
+++ b/test/api_container_resize_test.go
@@ -28,21 +28,18 @@ func (suite *APIContainerResizeSuite) TestContainerResizeOk(c *check.C) {
 	cname := "TestContainerResizeOk"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
-	resp, err := request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
+	StartContainerOk(c, cname)
 
 	q := url.Values{}
 	q.Add("h", "10")
 	q.Add("w", "10")
 	query := request.WithQuery(q)
 
-	resp, err = request.Post("/containers/"+cname+"/resize", query)
+	resp, err := request.Post("/containers/"+cname+"/resize", query)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 200)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestContainerResizeWithInvalidSize is to verify resize container with invalid size.
@@ -50,28 +47,26 @@ func (suite *APIContainerResizeSuite) TestContainerResizeWithInvalidSize(c *chec
 	cname := "TestContainerResizeWithInvalidSize"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
-	resp, err := request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
+	StartContainerOk(c, cname)
 
 	q := url.Values{}
 	q.Add("h", "hi")
 	q.Add("w", "wo")
 	query := request.WithQuery(q)
 
-	resp, err = request.Post("/containers/"+cname+"/resize", query)
+	resp, err := request.Post("/containers/"+cname+"/resize", query)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 400)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
-// TestResizeStoppedContainer is to verify resize a stopped container.
-func (suite *APIContainerResizeSuite) TestResizeStoppedContainer(c *check.C) {
-	cname := "TestResizeStoppedContainer"
+// TestResizeCreatedContainer is to verify resize a created container.
+func (suite *APIContainerResizeSuite) TestResizeCreatedContainer(c *check.C) {
+	cname := "TestResizeCreatedContainer"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
 	q := url.Values{}
 	q.Add("h", "10")
@@ -81,6 +76,24 @@ func (suite *APIContainerResizeSuite) TestResizeStoppedContainer(c *check.C) {
 	resp, err := request.Post("/containers/"+cname+"/resize", query)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 500)
+}
 
-	DelContainerForceMultyTime(c, cname)
+// TestResizeStoppedContainer is to verify resize a stoped container.
+func (suite *APIContainerResizeSuite) TestResizeStoppedContainer(c *check.C) {
+	cname := "TestResizeStoppedContainer"
+
+	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
+
+	StartContainerOk(c, cname)
+	StopContainerOk(c, cname)
+
+	q := url.Values{}
+	q.Add("h", "10")
+	q.Add("w", "10")
+	query := request.WithQuery(q)
+
+	resp, err := request.Post("/containers/"+cname+"/resize", query)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 500)
 }

--- a/test/api_container_restart_test.go
+++ b/test/api_container_restart_test.go
@@ -26,27 +26,9 @@ func (suite *APIContainerRestartSuite) TestAPIContainerRestart(c *check.C) {
 	cname := "TestAPIContainerRestart"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
-	resp, err := request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
-
-	q := url.Values{}
-	q.Add("t", "1")
-	query := request.WithQuery(q)
-
-	resp, err = request.Post("/containers/"+cname+"/restart", query)
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
-
-	DelContainerForceMultyTime(c, cname)
-}
-
-// TestAPIRestartStoppedContainer it to verify restarting a stopped container.
-func (suite *APIContainerRestartSuite) TestAPIRestartStoppedContainer(c *check.C) {
-	cname := "TestAPIRestartStoppedContainer"
-
-	CreateBusyboxContainerOk(c, cname)
+	StartContainerOk(c, cname)
 
 	q := url.Values{}
 	q.Add("t", "1")
@@ -55,8 +37,22 @@ func (suite *APIContainerRestartSuite) TestAPIRestartStoppedContainer(c *check.C
 	resp, err := request.Post("/containers/"+cname+"/restart", query)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 204)
+}
 
-	DelContainerForceMultyTime(c, cname)
+// TestAPIRestartStoppedContainer it to verify restarting a stopped container.
+func (suite *APIContainerRestartSuite) TestAPIRestartStoppedContainer(c *check.C) {
+	cname := "TestAPIRestartStoppedContainer"
+
+	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
+
+	q := url.Values{}
+	q.Add("t", "1")
+	query := request.WithQuery(q)
+
+	resp, err := request.Post("/containers/"+cname+"/restart", query)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 204)
 }
 
 // TestAPIRestartPausedContainer is to verify restarting a paused container.
@@ -64,6 +60,8 @@ func (suite *APIContainerRestartSuite) TestAPIRestartPausedContainer(c *check.C)
 	cname := "TestAPIRestartPauseContainer"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
+
 	StartContainerOk(c, cname)
 	PauseContainerOk(c, cname)
 
@@ -74,6 +72,4 @@ func (suite *APIContainerRestartSuite) TestAPIRestartPausedContainer(c *check.C)
 	resp, err := request.Post("/containers/"+cname+"/restart", query)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 204)
-
-	DelContainerForceMultyTime(c, cname)
 }

--- a/test/api_container_start_test.go
+++ b/test/api_container_start_test.go
@@ -19,6 +19,7 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerStartSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
 	PullImage(c, busyboxImage)
 }
 
@@ -27,12 +28,8 @@ func (suite *APIContainerStartSuite) TestStartOk(c *check.C) {
 	cname := "TestStartOk"
 
 	CreateBusyboxContainerOk(c, cname)
-
-	resp, err := request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
-
-	DelContainerForceMultyTime(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
+	StartContainerOk(c, cname)
 }
 
 // TestNonExistingContainer tests start a non-existing container return 404.
@@ -49,16 +46,10 @@ func (suite *APIContainerStartSuite) TestStartStoppedContainer(c *check.C) {
 	cname := "TestStartStoppedContainer"
 
 	CreateBusyboxContainerOk(c, cname)
-
+	defer DelContainerForceMultyTime(c, cname)
 	StartContainerOk(c, cname)
-
 	StopContainerOk(c, cname)
-
-	resp, err := request.Post("/containers/" + cname + "/start")
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
-
-	DelContainerForceMultyTime(c, cname)
+	StartContainerOk(c, cname)
 }
 
 // TestStartPausedContainer tests start a contain in paused state will fail.
@@ -66,16 +57,14 @@ func (suite *APIContainerStartSuite) TestStartPausedContainer(c *check.C) {
 	cname := "TestStartPausedContainer"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
 	StartContainerOk(c, cname)
-
 	PauseContainerOk(c, cname)
 
 	resp, err := request.Post("/containers/" + cname + "/start")
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 500)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestStartDetachKeyWork test detatch-keys works.
@@ -83,6 +72,7 @@ func (suite *APIContainerStartSuite) TestStartDetachKeyWork(c *check.C) {
 	cname := "TestStartDetachKeyWork"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 
 	q := url.Values{}
 	q.Add("detachKeys", "EOF")
@@ -92,12 +82,13 @@ func (suite *APIContainerStartSuite) TestStartDetachKeyWork(c *check.C) {
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 204)
 
-	// TODO: check the "EOF" detatchkey really works.
-
-	DelContainerForceMultyTime(c, cname)
+	// TODO: missing case
+	//
+	//	check the "EOF" detatchkey really works.
 }
 
 // TestInvalidParam tests using invalid parameter return.
 func (suite *APIContainerStartSuite) TestInvalidParam(c *check.C) {
-	//TODO
+	// TODO: missing case
+	helpwantedForMissingCase(c, "container api start bad request")
 }

--- a/test/api_container_top_test.go
+++ b/test/api_container_top_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/alibaba/pouch/test/environment"
-	//"github.com/alibaba/pouch/test/request"
 
 	"github.com/go-check/check"
 )
@@ -18,5 +17,6 @@ func init() {
 func (suite *APIContainerTopSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
 
-	// TODO Add more
+	// TODO: missing code
+	helpwantedForMissingCase(c, "container api top cases")
 }

--- a/test/api_container_upgrade_test.go
+++ b/test/api_container_upgrade_test.go
@@ -16,4 +16,7 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerUpgradeSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
+	// TODO: missing case
+	helpwantedForMissingCase(c, "container api upgrade cases")
 }

--- a/test/api_container_wait_test.go
+++ b/test/api_container_wait_test.go
@@ -20,6 +20,7 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerWaitSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
 	PullImage(c, busyboxImage)
 }
 
@@ -28,14 +29,14 @@ func (suite *APIContainerWaitSuite) TestWaitOk(c *check.C) {
 	cname := "TestWaitOk"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
+
 	StartContainerOk(c, cname)
 	StopContainerOk(c, cname)
 
 	resp, err := request.Post("/containers/" + cname + "/wait")
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 200)
-
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestWaitRunningContainer tests waiting a running container to stop, then returns 200.
@@ -43,6 +44,7 @@ func (suite *APIContainerWaitSuite) TestWaitRunningContainer(c *check.C) {
 	cname := "TestWaitRunningContainer"
 
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 	StartContainerOk(c, cname)
 
 	var (
@@ -67,7 +69,6 @@ func (suite *APIContainerWaitSuite) TestWaitRunningContainer(c *check.C) {
 	case <-time.After(2 * time.Second):
 		c.Errorf("timeout waiting for `pouch wait` API to exit")
 	}
-	DelContainerForceMultyTime(c, cname)
 }
 
 // TestWaitNonExistingContainer tests waiting a non-existing container return 404.

--- a/test/api_daemon_update_test.go
+++ b/test/api_daemon_update_test.go
@@ -55,6 +55,8 @@ func (suite *APIDaemonUpdateSuite) TestUpdateDaemon(c *check.C) {
 			c.Fatalf("label %s should be in labels in info API", label)
 		}
 	}
-	//c.Assert(info.Labels, check.DeepEquals, labels)
-	// TODO: add checking image proxy
+
+	// TODO: missing case
+	//
+	//	add checking image proxy
 }

--- a/test/api_image_create_test.go
+++ b/test/api_image_create_test.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/alibaba/pouch/test/environment"
 	"github.com/alibaba/pouch/test/request"
 
-	"github.com/alibaba/pouch/test/util"
 	"github.com/go-check/check"
 )
 
@@ -28,24 +26,20 @@ func (suite *APIImageCreateSuite) TestImageCreateOk(c *check.C) {
 	q := url.Values{}
 	q.Add("fromImage", environment.HelloworldRepo)
 	q.Add("tag", "latest")
+
 	query := request.WithQuery(q)
 	resp, err := request.Post("/images/create", query)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 200)
+	c.Assert(discardPullStatus(resp.Body), check.IsNil)
 
-	// TODO: add a waituntil func to check the exsitence of image
-	time.Sleep(5000 * time.Millisecond)
-
-	resp, err = request.Delete("/images/" + environment.HelloworldRepo + ":latest")
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
+	DelImageForceOk(c, environment.HelloworldRepo+":latest")
 }
 
 // TestImageCreateNil tests fromImage is nil.
 func (suite *APIImageCreateSuite) TestImageCreateNil(c *check.C) {
 	q := url.Values{}
 	q.Add("fromImage", "")
-
 	query := request.WithQuery(q)
 
 	resp, err := request.Post("/images/create", query)
@@ -58,15 +52,13 @@ func (suite *APIImageCreateSuite) TestImageCreateWithoutTag(c *check.C) {
 	q := url.Values{}
 	q.Add("fromImage", environment.HelloworldRepo)
 	query := request.WithQuery(q)
+
 	resp, err := request.Post("/images/create", query)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 200)
+	c.Assert(discardPullStatus(resp.Body), check.IsNil)
 
-	time.Sleep(5000 * time.Millisecond)
-
-	resp, err = request.Delete("/images/" + environment.HelloworldRepo + ":latest")
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
+	DelImageForceOk(c, environment.HelloworldRepo)
 }
 
 // TestImageCreateWithoutRegistry tests creating an image only by name, will use "latest" by default.
@@ -74,18 +66,11 @@ func (suite *APIImageCreateSuite) TestImageCreateWithoutRegistry(c *check.C) {
 	q := url.Values{}
 	q.Add("fromImage", helloworldImageOnlyRepoName)
 	query := request.WithQuery(q)
+
 	resp, err := request.Post("/images/create", query)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 200)
+	c.Assert(discardPullStatus(resp.Body), check.IsNil)
 
-	ret := util.WaitTimeout(10*time.Second, DelHelloworldImage)
-	c.Assert(ret, check.Equals, true)
-}
-
-func DelHelloworldImage() bool {
-	resp, err := request.Delete("/images/" + helloworldImageOnlyRepoName + ":latest")
-	if err == nil && resp.StatusCode == 204 {
-		return true
-	}
-	return false
+	DelImageForceOk(c, helloworldImageOnlyRepoName+":latest")
 }

--- a/test/api_image_delete_test.go
+++ b/test/api_image_delete_test.go
@@ -43,11 +43,10 @@ func (suite *APIImageDeleteSuite) TestDeleteImageOk(c *check.C) {
 func (suite *APIImageDeleteSuite) TestDeleteUsingImage(c *check.C) {
 	cname := "TestDeleteUsingImage"
 	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
 	StartContainerOk(c, cname)
 
 	resp, err := request.Delete("/images/" + busyboxImage)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 500)
-
-	DelContainerForceMultyTime(c, cname)
 }

--- a/test/api_image_list_test.go
+++ b/test/api_image_list_test.go
@@ -38,7 +38,9 @@ func (suite *APIImageListSuite) TestImageListAll(c *check.C) {
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 200)
 
-	// TODO: Add more check
+	// TODO: missing case
+	//
+	//	check the fields
 }
 
 // TestImageListDigest tests listing images digest.
@@ -54,5 +56,6 @@ func (suite *APIImageListSuite) TestImageListDigest(c *check.C) {
 
 // TestImageListFilter tests listing images with filter.
 func (suite *APIImageListSuite) TestImageListFilter(c *check.C) {
-	// TODO
+	// TODO: missing case
+	helpwantedForMissingCase(c, "iamge api list filter cases")
 }

--- a/test/api_image_search_test.go
+++ b/test/api_image_search_test.go
@@ -16,10 +16,7 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIImageSearchSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
-}
 
-// TestImageSearchOk tests searching images is OK.
-func (suite *APIImageSearchSuite) TestImageSearchOk(c *check.C) {
-	// TODO
-	// path := "/images/search"
+	// TODO: missing case
+	helpwantedForMissingCase(c, "image api search cases")
 }

--- a/test/api_image_tag_test.go
+++ b/test/api_image_tag_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
 	"github.com/alibaba/pouch/test/request"
+
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
 )
@@ -34,7 +35,7 @@ func (suite *APIImageTagSuite) TestImageTagCreateWithTagOK(c *check.C) {
 	CheckRespStatus(c, resp, 201)
 
 	tagRef := fmt.Sprintf("%s:%s", repo, tag)
-	defer forceDeleteImage(c, tagRef)
+	defer DelImageForceOk(c, tagRef)
 	suite.checkTagReferenceExisting(c, tagRef, true)
 }
 
@@ -46,7 +47,7 @@ func (suite *APIImageTagSuite) TestImageTagCreateUsingDefaultTagOK(c *check.C) {
 	CheckRespStatus(c, resp, 201)
 
 	tagRef := fmt.Sprintf("%s:%s", repo, tag)
-	defer forceDeleteImage(c, tagRef)
+	defer DelImageForceOk(c, tagRef)
 	suite.checkTagReferenceExisting(c, tagRef, true)
 }
 
@@ -63,7 +64,7 @@ func (suite *APIImageTagSuite) TestImageTagFailToOverrideExistingPrimaryReferenc
 	repo, tag := "registry.hub.docker.com/library/busybox", "1.25"
 	tagRef := fmt.Sprintf("%s:%s", repo, tag)
 	command.PouchRun("pull", tagRef).Assert(c, icmd.Success)
-	defer forceDeleteImage(c, tagRef)
+	defer DelImageForceOk(c, tagRef)
 
 	resp, err := suite.sendRequest(busyboxImage, repo, tag)
 	c.Assert(err, check.IsNil)
@@ -75,7 +76,7 @@ func (suite *APIImageTagSuite) TestImageTagFailToOverrideExistingTag(c *check.C)
 	repo, tag := "registry.hub.docker.com/library/busybox", "1.25"
 	tagRef := fmt.Sprintf("%s:%s", repo, tag)
 	command.PouchRun("pull", tagRef).Assert(c, icmd.Success)
-	defer forceDeleteImage(c, tagRef)
+	defer DelImageForceOk(c, tagRef)
 
 	resp, err := suite.sendRequest(busyboxImage, repo, tag)
 	c.Assert(err, check.IsNil)
@@ -108,14 +109,4 @@ func (suite *APIImageTagSuite) checkTagReferenceExisting(c *check.C, tagRef stri
 		status = http.StatusNotFound
 	}
 	CheckRespStatus(c, resp, status)
-}
-
-func forceDeleteImage(c *check.C, idOrRef string) {
-	q := url.Values{}
-	q.Set("force", "1")
-
-	resp, err := request.Delete(fmt.Sprintf("/images/%s", idOrRef), request.WithQuery(q))
-	c.Assert(err, check.IsNil)
-
-	CheckRespStatus(c, resp, 204)
 }

--- a/test/api_network_create_test.go
+++ b/test/api_network_create_test.go
@@ -69,7 +69,7 @@ func (suite *APINetworkCreateSuite) TestNetworkCreateExistentName(c *check.C) {
 	CheckRespStatus(c, resp, 409)
 
 	// delete network TestNetworkCreateExistentName
-	resp, err = request.Delete("/networks/" + "TestNetworkCreateExistentName")
+	resp, err = request.Delete("/networks/" + nname)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 204)
 }

--- a/test/api_system_test.go
+++ b/test/api_system_test.go
@@ -44,7 +44,10 @@ func (suite *APISystemSuite) TestInfo(c *check.C) {
 	if Info, err := kernel.GetKernelVersion(); err == nil {
 		kernelInfo = Info.String()
 	}
-	// TODO more variables are to be checked.
+	// TODO: missing case
+	//
+	//	more variables are to be checked.
+
 	c.Assert(got.IndexServerAddress, check.Equals, "https://index.docker.io/v1/")
 	c.Assert(got.KernelVersion, check.Equals, kernelInfo)
 	c.Assert(got.OSType, check.Equals, runtime.GOOS)

--- a/test/api_volume_create_test.go
+++ b/test/api_volume_create_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/alibaba/pouch/test/environment"
-	"github.com/alibaba/pouch/test/request"
 
 	"github.com/go-check/check"
 )
@@ -23,41 +22,14 @@ func (suite *APIVolumeCreateSuite) SetUpTest(c *check.C) {
 func (suite *APIVolumeCreateSuite) TestVolumeCreateOk(c *check.C) {
 	vol := "TestVolumeCreateOk"
 
-	obj := map[string]interface{}{
-		"Driver": "local",
-		"Name":   vol,
-	}
-
-	path := "/volumes/create"
-	body := request.WithJSONBody(obj)
-	resp, err := request.Post(path, body)
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 201)
-
-	path = "/volumes/" + vol
-	resp, err = request.Delete(path)
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
+	CreateVolumeOK(c, vol, "local", nil)
+	RemoveVolumeOK(c, vol)
 }
 
 // TestPluginVolumeCreateOk tests creating a volume which created by volume plugin
 func (suite *APIVolumeCreateSuite) TestPluginVolumeCreateOk(c *check.C) {
 	vol := "TestPluginVolumeCreateOk"
 
-	obj := map[string]interface{}{
-		"Driver":     "local-persist",
-		"Name":       vol,
-		"DriverOpts": map[string]string{"mountpoint": "/data/images"},
-	}
-
-	path := "/volumes/create"
-	body := request.WithJSONBody(obj)
-	resp, err := request.Post(path, body)
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 201)
-
-	path = "/volumes/" + vol
-	resp, err = request.Delete(path)
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
+	CreateVolumeOK(c, vol, "local-persist", map[string]string{"mountpoint": "/data/images"})
+	RemoveVolumeOK(c, vol)
 }

--- a/test/api_volume_inspect_test.go
+++ b/test/api_volume_inspect_test.go
@@ -23,27 +23,18 @@ func (suite *APIVolumeInspectSuite) SetUpTest(c *check.C) {
 func (suite *APIVolumeInspectSuite) TestVolumeInspectOk(c *check.C) {
 	// Create a volume with the name "TestVolume".
 	vol := "TestVolume"
-	obj := map[string]interface{}{
-		"Driver": "local",
-		"Name":   vol,
-	}
-	path := "/volumes/create"
-	body := request.WithJSONBody(obj)
-	resp, err := request.Post(path, body)
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 201)
+	CreateVolumeOK(c, vol, "local", nil)
+	defer RemoveVolumeOK(c, vol)
 
 	// Test volume inspect feature.
-	path = "/volumes/" + vol
-	resp, err = request.Get(path)
+	path := "/volumes/" + vol
+	resp, err := request.Get(path)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 200)
 
-	// Delete the volume.
-	path = "/volumes/" + vol
-	resp, err = request.Delete(path)
-	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 204)
+	// TODO: missing case
+	//
+	//	add field check
 }
 
 // TestVolumeInspectNotFound tests if inspecting a nonexistent volume returns error.
@@ -54,5 +45,4 @@ func (suite *APIVolumeInspectSuite) TestVolumeInspectNotFound(c *check.C) {
 	resp, err := request.Get(path)
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 404)
-
 }

--- a/test/api_volume_list_test.go
+++ b/test/api_volume_list_test.go
@@ -23,19 +23,17 @@ func (suite *APIVolumeListSuite) SetUpTest(c *check.C) {
 // TestVolumeListOk tests if list volumes is OK.
 func (suite *APIVolumeListSuite) TestVolumeListOk(c *check.C) {
 	// Create a volume with the name "TestVolume1".
-	err := CreateVolume(c, "TestVolume1", "local", nil)
-	c.Assert(err, check.IsNil)
-	defer RemoveVolume(c, "TestVolume1")
+	CreateVolumeOK(c, "TestVolume1", "local", nil)
+	defer RemoveVolumeOK(c, "TestVolume1")
 
 	// Create a volume with the name "TestVolume2".
-	err = CreateVolume(c, "TestVolume2", "local", nil)
-	c.Assert(err, check.IsNil)
-	defer RemoveVolume(c, "TestVolume2")
+	CreateVolumeOK(c, "TestVolume2", "local", nil)
+	defer RemoveVolumeOK(c, "TestVolume2")
 
 	// Create a volume with the name "TestVolume3".
 	options := map[string]string{"mountpoint": "/data/TestVolume3"}
-	err = CreateVolume(c, "TestVolume3", "local", options)
-	c.Assert(err, check.IsNil)
+	CreateVolumeOK(c, "TestVolume3", "local", options)
+	defer RemoveVolumeOK(c, "TestVolume3")
 
 	// Test volume list feature.
 	path := "/volumes"

--- a/test/cli_tag_test.go
+++ b/test/cli_tag_test.go
@@ -29,7 +29,7 @@ func (suite *PouchTagSuite) TestImageTagOKWithSourceImageName(c *check.C) {
 	repo, tag := "localhost:5000/testimagetagok/pouch", "source.name"
 	tagRef := fmt.Sprintf("%s:%s", repo, tag)
 	command.PouchRun("tag", busyboxImage125, tagRef).Assert(c, icmd.Success)
-	defer forceDeleteImage(c, tagRef)
+	defer DelImageForceOk(c, tagRef)
 
 	command.PouchRun("image", "inspect", tagRef).Assert(c, icmd.Success)
 }
@@ -40,7 +40,7 @@ func (suite *PouchTagSuite) TestImageTagOKWithSourceImageID(c *check.C) {
 	tagRef := fmt.Sprintf("%s:%s", repo, tag)
 
 	command.PouchRun("tag", busyboxImage125ID, tagRef).Assert(c, icmd.Success)
-	defer forceDeleteImage(c, tagRef)
+	defer DelImageForceOk(c, tagRef)
 
 	command.PouchRun("image", "inspect", tagRef).Assert(c, icmd.Success)
 }
@@ -51,7 +51,7 @@ func (suite *PouchTagSuite) TestImageTagOKTargetWithoutTag(c *check.C) {
 	tagRef := fmt.Sprintf("%s:%s", repo, tag)
 
 	command.PouchRun("tag", busyboxImage125, repo).Assert(c, icmd.Success)
-	defer forceDeleteImage(c, tagRef)
+	defer DelImageForceOk(c, tagRef)
 
 	command.PouchRun("image", "inspect", tagRef).Assert(c, icmd.Success)
 }

--- a/test/request/request.go
+++ b/test/request/request.go
@@ -76,7 +76,6 @@ func WithJSONBody(obj interface{}) Option {
 
 // DecodeBody decodes body to obj.
 func DecodeBody(obj interface{}, body io.ReadCloser) error {
-	// TODO: this fuction could only be called once
 	defer body.Close()
 	return json.NewDecoder(body).Decode(obj)
 }

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/alibaba/pouch/test/environment"
@@ -49,6 +50,15 @@ func init() {
 	GateWay = environment.GateWay
 	Subnet = environment.Subnet
 
+}
+
+type testingTB interface {
+	Fatalf(format string, args ...interface{})
+	Skip(string)
+}
+
+func helpwantedForMissingCase(t testingTB, name string) {
+	t.Skip(fmt.Sprintf("help wanted: %s", name))
 }
 
 // VerifyCondition is used to check the condition value.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

 make the API clear and stable

1. don't use wait style to wait for downloading image
2. use the util function to make the case clear
3. add missing case wanted

for missing case, we can use `helpwantedCase` to mark, like

```
PASS: api_container_start_test.go:71: APIContainerStartSuite.TestStartDetachKeyWork     1.339s
PASS: api_container_start_test.go:27: APIContainerStartSuite.TestStartOk        1.391s
PASS: api_container_start_test.go:56: APIContainerStartSuite.TestStartPausedContainer   1.391s
PASS: api_container_start_test.go:45: APIContainerStartSuite.TestStartStoppedContainer  1.979s
SKIP: api_container_stop_test.go:64: APIContainerStopSuite.TestInvalidParam (help wanted: container api stop bad request case)
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how you did it

refactor

### Ⅳ. Describe how to verify it

CI

### Ⅴ. Special notes for reviews


