### PR TITLE
refactor: polish error construction and log format

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -259,9 +259,9 @@ func (c *Client) recoverContainer(ctx context.Context, id string, io *containeri
 	lc, err := wrapperCli.client.LoadContainer(ctx, id)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
-			return errors.Wrap(errtypes.ErrNotfound, "container")
+			return errors.Wrapf(errtypes.ErrNotfound, "container %s", id)
 		}
-		return errors.Wrap(err, "failed to load container")
+		return errors.Wrapf(err, "failed to load container(%s)", id)
 	}
 
 	task, err := lc.Task(ctx, containerio.WithAttach(io.Stdin, io.Stdout, io.Stderr))

--- a/daemon/mgr/container_exec.go
+++ b/daemon/mgr/container_exec.go
@@ -164,7 +164,7 @@ func (mgr *ContainerManager) InspectExec(ctx context.Context, execid string) (*t
 func (mgr *ContainerManager) GetExecConfig(ctx context.Context, execid string) (*ContainerExecConfig, error) {
 	v, ok := mgr.ExecProcesses.Get(execid).Result()
 	if !ok {
-		return nil, errors.Wrap(errtypes.ErrNotfound, "exec process "+execid)
+		return nil, errors.Wrapf(errtypes.ErrNotfound, "exec process %s", execid)
 	}
 	execConfig, ok := v.(*ContainerExecConfig)
 	if !ok {

--- a/daemon/mgr/container_logs.go
+++ b/daemon/mgr/container_logs.go
@@ -25,7 +25,7 @@ func (mgr *ContainerManager) Logs(ctx context.Context, name string, logOpt *type
 	}
 
 	if !(logOpt.ShowStdout || logOpt.ShowStderr) {
-		return nil, false, pkgerrors.Wrapf(errtypes.ErrInvalidParam, "you must choose at least one stream")
+		return nil, false, pkgerrors.Wrap(errtypes.ErrInvalidParam, "you must choose at least one stream")
 	}
 
 	if c.HostConfig.LogConfig.LogDriver != types.LogConfigLogDriverJSONFile {

--- a/daemon/mgr/container_storage.go
+++ b/daemon/mgr/container_storage.go
@@ -32,7 +32,7 @@ func (mgr *ContainerManager) attachVolume(ctx context.Context, name string, c *C
 			"backend": driver,
 		}
 		if _, err := mgr.VolumeMgr.Create(ctx, name, c.HostConfig.VolumeDriver, opts, nil); err != nil {
-			logrus.Errorf("failed to create volume: %s, err: %v", name, err)
+			logrus.Errorf("failed to create volume(%s): %v", name, err)
 			return "", "", errors.Wrap(err, "failed to create volume")
 		}
 	} else {
@@ -40,13 +40,13 @@ func (mgr *ContainerManager) attachVolume(ctx context.Context, name string, c *C
 	}
 
 	if _, err := mgr.VolumeMgr.Attach(ctx, name, map[string]string{volumetypes.OptionRef: c.ID}); err != nil {
-		logrus.Errorf("failed to attach volume: %s, err: %v", name, err)
+		logrus.Errorf("failed to attach volume(%s):: %v", name, err)
 		return "", "", errors.Wrap(err, "failed to attach volume")
 	}
 
 	mountPath, err := mgr.VolumeMgr.Path(ctx, name)
 	if err != nil {
-		logrus.Errorf("failed to get the mount path of volume: %s, err: %v", name, err)
+		logrus.Errorf("failed to get the mount path of volume(%s): %v", name, err)
 		return "", "", errors.Wrap(err, "failed to get volume mount path")
 	}
 
@@ -70,7 +70,7 @@ func (mgr *ContainerManager) generateMountPoints(ctx context.Context, c *Contain
 	defer func() {
 		if err != nil {
 			if err := mgr.detachVolumes(ctx, c, false); err != nil {
-				logrus.Errorf("failed to detach volume, err: %v", err)
+				logrus.Errorf("failed to detach volume: %v", err)
 			}
 		}
 	}()
@@ -165,7 +165,7 @@ func (mgr *ContainerManager) getMountPointFromBinds(ctx context.Context, c *Cont
 
 		err = opts.ParseBindMode(mp, mode)
 		if err != nil {
-			logrus.Errorf("failed to parse bind mode: %s, err: %v", mode, err)
+			logrus.Errorf("failed to parse bind mode(%s): %v", mode, err)
 			return err
 		}
 
@@ -176,7 +176,7 @@ func (mgr *ContainerManager) getMountPointFromBinds(ctx context.Context, c *Cont
 				mp.Name = name
 				mp.Source, mp.Driver, err = mgr.attachVolume(ctx, name, c)
 				if err != nil {
-					logrus.Errorf("failed to bind volume: %s, err: %v", name, err)
+					logrus.Errorf("failed to bind volume(%s): %v", name, err)
 					return errors.Wrap(err, "failed to bind volume")
 				}
 
@@ -241,13 +241,13 @@ func (mgr *ContainerManager) getMountPointFromVolumes(ctx context.Context, c *Co
 
 		mp.Source, mp.Driver, err = mgr.attachVolume(ctx, mp.Name, c)
 		if err != nil {
-			logrus.Errorf("failed to bind volume: %s, err: %v", mp.Name, err)
+			logrus.Errorf("failed to bind volume(%s): %v", mp.Name, err)
 			return errors.Wrap(err, "failed to bind volume")
 		}
 
 		err = opts.ParseBindMode(mp, "")
 		if err != nil {
-			logrus.Errorf("failed to parse mode, err: %v", err)
+			logrus.Errorf("failed to parse mode: %v", err)
 			return err
 		}
 
@@ -284,13 +284,13 @@ func (mgr *ContainerManager) getMountPointFromImage(ctx context.Context, c *Cont
 
 		mp.Source, mp.Driver, err = mgr.attachVolume(ctx, mp.Name, c)
 		if err != nil {
-			logrus.Errorf("failed to bind volume: %s, err: %v", mp.Name, err)
+			logrus.Errorf("failed to bind volume(%s): %v", mp.Name, err)
 			return errors.Wrap(err, "failed to bind volume")
 		}
 
 		err = opts.ParseBindMode(mp, "")
 		if err != nil {
-			logrus.Errorf("failed to parse mode, err: %v", err)
+			logrus.Errorf("failed to parse mode: %v", err)
 			return err
 		}
 
@@ -337,7 +337,7 @@ func (mgr *ContainerManager) getMountPointFromContainers(ctx context.Context, co
 				mp.Name = oldMountPoint.Name
 				mp.Source, mp.Driver, err = mgr.attachVolume(ctx, oldMountPoint.Name, container)
 				if err != nil {
-					logrus.Errorf("failed to bind volume: %s, err: %v", oldMountPoint.Name, err)
+					logrus.Errorf("failed to bind volume(%s): %v", oldMountPoint.Name, err)
 					return errors.Wrap(err, "failed to bind volume")
 				}
 
@@ -377,7 +377,7 @@ func (mgr *ContainerManager) populateVolumes(ctx context.Context, c *Container) 
 
 		err := copyImageContent(imagePath, mnt.Source)
 		if err != nil {
-			logrus.Errorf("failed to populate volume[name: %s, source: %s] err: %v", mnt.Name, mnt.Source, err)
+			logrus.Errorf("failed to populate volume[name: %s, source: %s]: %v", mnt.Name, mnt.Source, err)
 			return err
 		}
 	}

--- a/daemon/mgr/container_utils.go
+++ b/daemon/mgr/container_utils.go
@@ -31,13 +31,13 @@ func (mgr *ContainerManager) containerID(nameOrPrefix string) (string, error) {
 	// name is the container's prefix of the id.
 	objs, err := mgr.Store.GetWithPrefix(nameOrPrefix)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get container info with prefix: %s", nameOrPrefix)
+		return "", errors.Wrapf(err, "failed to get container info with prefix %s", nameOrPrefix)
 	}
 	if len(objs) > 1 {
-		return "", errors.Wrap(errtypes.ErrTooMany, "container: "+nameOrPrefix)
+		return "", errors.Wrapf(errtypes.ErrTooMany, "container %s", nameOrPrefix)
 	}
 	if len(objs) == 0 {
-		return "", errors.Wrap(errtypes.ErrNotfound, "container: "+nameOrPrefix)
+		return "", errors.Wrapf(errtypes.ErrNotfound, "container %s", nameOrPrefix)
 	}
 	obj = objs[0]
 
@@ -66,7 +66,7 @@ func (mgr *ContainerManager) container(nameOrPrefix string) (*Container, error) 
 		return res.(*Container), nil
 	}
 
-	return nil, errors.Wrap(errtypes.ErrNotfound, "container "+nameOrPrefix)
+	return nil, errors.Wrapf(errtypes.ErrNotfound, "container %s", nameOrPrefix)
 }
 
 // generateID generates an ID for newly created container. We must ensure that

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -417,11 +417,8 @@ func (mgr *ImageManager) CheckReference(ctx context.Context, idOrRef string) (ac
 		}
 
 		primaryRef = refs[0]
-	} else {
-		primaryRef, err = mgr.localStore.GetPrimaryReference(actualRef)
-		if err != nil {
-			return
-		}
+	} else if primaryRef, err = mgr.localStore.GetPrimaryReference(actualRef); err != nil {
+		return
 	}
 	return
 }
@@ -551,14 +548,12 @@ func (mgr *ImageManager) validateTagReference(ref reference.Named) error {
 	// NOTE: we don't allow to use tag to override the existing primary reference.
 	pRef, err := mgr.localStore.GetPrimaryReference(ref)
 	if err != nil {
+		// @fuweid: we should return nil instead of err.
 		return nil
 	}
 
 	if pRef.String() == ref.String() {
-		return pkgerrors.Wrap(
-			errtypes.ErrInvalidParam,
-			fmt.Sprintf("the tag reference (%s) has been used as reference", ref.String()),
-		)
+		return pkgerrors.Wrapf(errtypes.ErrInvalidParam, "the tag reference (%s) has been used as reference", ref.String())
 	}
 	return nil
 }

--- a/daemon/mgr/image_store.go
+++ b/daemon/mgr/image_store.go
@@ -115,7 +115,7 @@ func (store *imageStore) GetPrimaryReference(ref reference.Named) (reference.Nam
 	if p, ok := store.primaryRefIndexByRef[trimRef.String()]; ok {
 		return p, nil
 	}
-	return nil, errtypes.ErrNotfound
+	return nil, pkgerrors.Wrapf(errtypes.ErrNotfound, "image reference %s", ref.String())
 }
 
 // Search returns the imageID, reference.Named by the given reference.Named.
@@ -167,7 +167,7 @@ func (store *imageStore) searchIDs(refID string) (digest.Digest, error) {
 		}
 
 		if len(ids) > 1 {
-			return pkgerrors.Wrap(errtypes.ErrTooMany, "image: "+refID)
+			return pkgerrors.Wrapf(errtypes.ErrTooMany, "image %s", refID)
 		}
 		return nil
 	}
@@ -177,7 +177,7 @@ func (store *imageStore) searchIDs(refID string) (digest.Digest, error) {
 	}
 
 	if len(ids) == 0 {
-		return "", pkgerrors.Wrap(errtypes.ErrNotfound, "image: "+refID)
+		return "", pkgerrors.Wrapf(errtypes.ErrNotfound, "image %s", refID)
 	}
 	return ids[0], nil
 }

--- a/daemon/mgr/image_store_test.go
+++ b/daemon/mgr/image_store_test.go
@@ -1,6 +1,7 @@
 package mgr
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -198,7 +199,7 @@ func TestSearch(t *testing.T) {
 
 			_, _, err = store.Search(namedRef)
 			assert.Equal(t, errtypes.IsNotfound(err), true)
-			assert.Equal(t, err.Error(), "image: "+namedRef.String()+": not found")
+			assert.Equal(t, err.Error(), "image "+namedRef.String()+": not found")
 		}
 
 		// should return 404 if the reference is 123x
@@ -212,7 +213,7 @@ func TestSearch(t *testing.T) {
 
 			_, _, err = store.Search(namedRef)
 			assert.Equal(t, errtypes.IsNotfound(err), true)
-			assert.Equal(t, err.Error(), "image: "+namedRef.String()+": not found")
+			assert.Equal(t, err.Error(), fmt.Sprintf("image %s: not found", namedRef.String()))
 		}
 
 		// should return ErrTooMany if the reference is commonPart

--- a/daemon/mgr/snapshot.go
+++ b/daemon/mgr/snapshot.go
@@ -55,7 +55,7 @@ func (s *SnapshotStore) Get(key string) (Snapshot, error) {
 	if sn, ok := s.snapshots[key]; ok {
 		return sn, nil
 	}
-	return Snapshot{}, errors.Wrap(errtypes.ErrNotfound, "snapshot")
+	return Snapshot{}, errors.Wrapf(errtypes.ErrNotfound, "snapshot %s", key)
 }
 
 // List lists all snapshots.

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -2,7 +2,6 @@ package mgr
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -194,7 +193,7 @@ func (mgr *SystemManager) Auth(auth *types.AuthConfig) (string, error) {
 // UpdateDaemon updates config of daemon, only label and image proxy are allowed.
 func (mgr *SystemManager) UpdateDaemon(cfg *types.DaemonUpdateConfig) error {
 	if cfg == nil || (len(cfg.Labels) == 0 && cfg.ImageProxy == "") {
-		return errors.Wrap(errtypes.ErrInvalidParam, fmt.Sprintf("daemon update config cannot be empty"))
+		return errors.Wrap(errtypes.ErrInvalidParam, "daemon update config cannot be empty")
 	}
 
 	daemonCfg := mgr.config

--- a/daemon/mgr/volume.go
+++ b/daemon/mgr/volume.go
@@ -115,12 +115,12 @@ func (vm *VolumeManager) List(ctx context.Context, labels map[string]string) ([]
 func (vm *VolumeManager) Remove(ctx context.Context, name string) error {
 	vol, err := vm.Get(ctx, name)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get volume: %s", name)
+		return errors.Wrapf(err, "failed to get volume(%s)", name)
 	}
 
 	ref := vol.Option(types.OptionRef)
 	if ref != "" {
-		return errors.Wrapf(errtypes.ErrVolumeInUse, "failed to remove volume: %s", name)
+		return errors.Wrapf(errtypes.ErrVolumeInUse, "failed to remove volume(%s)", name)
 	}
 
 	id := types.VolumeID{
@@ -154,7 +154,7 @@ func (vm *VolumeManager) Attach(ctx context.Context, name string, options map[st
 
 	v, err := vm.Get(ctx, name)
 	if err != nil {
-		return nil, errors.Errorf("failed to get volume: %s", name)
+		return nil, errors.Errorf("failed to get volume(%s): %v", name, err)
 	}
 
 	if options == nil {
@@ -182,7 +182,7 @@ func (vm *VolumeManager) Detach(ctx context.Context, name string, options map[st
 
 	v, err := vm.Get(ctx, name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get volume: %s", name)
+		return nil, errors.Wrapf(err, "failed to get volume(%s)", name)
 	}
 
 	if options == nil {

--- a/pkg/errtypes/errors.go
+++ b/pkg/errtypes/errors.go
@@ -5,20 +5,20 @@ import (
 )
 
 var (
+	// ErrInvalidParam represents the parameters are invalid.
+	ErrInvalidParam = errorType{codeInvalidParam, "invalid param"}
+
 	// ErrNotfound represents the object is not found, not exist.
-	ErrNotfound = errorType{codeNotfound, "not found"}
+	ErrNotfound = errorType{codeNotFound, "not found"}
 
 	// ErrAlreadyExisted represents the object has already existed.
 	ErrAlreadyExisted = errorType{codeAlreadyExisted, "already existed"}
 
-	// ErrInvalidParam represents the parameters are invalid.
-	ErrInvalidParam = errorType{codeInvalidParam, "invalid param"}
+	// ErrConflict represents the parameters are invalid.
+	ErrConflict = errorType{codeConflict, "conflict"}
 
 	// ErrTooMany reprensents the objects are too many.
 	ErrTooMany = errorType{codeTooMany, "too many"}
-
-	// ErrInvalidType represents the object's type is invalid.
-	ErrInvalidType = errorType{codeInvalidType, "invalid type"}
 
 	// ErrTimeout represents the operation is time out.
 	ErrTimeout = errorType{codeTimeout, "time out"}
@@ -29,22 +29,19 @@ var (
 	// ErrNotImplemented represents that the function is not implemented.
 	ErrNotImplemented = errorType{codeNotImplemented, "not implemented"}
 
-	// ErrUsingbyContainers represents that object is used by containers.
-	ErrUsingbyContainers = errorType{codeInUse, "using by containers"}
-
 	// ErrVolumeInUse represents that volume in use.
 	ErrVolumeInUse = errorType{codeInUse, "volume is in use"}
 
 	// ErrVolumeNotFound represents that no such volume.
-	ErrVolumeNotFound = errorType{codeNotfound, "no such volume"}
+	ErrVolumeNotFound = errorType{codeNotFound, "no such volume"}
 )
 
 const (
-	codeNotfound = iota
+	codeInvalidParam = iota
+	codeNotFound
 	codeAlreadyExisted
-	codeInvalidParam
+	codeConflict
 	codeTooMany
-	codeInvalidType
 	codeTimeout
 	codeLockfailed
 	codeNotImplemented
@@ -62,7 +59,7 @@ func (e errorType) Error() string {
 
 // IsNotfound checks the error is object Notfound or not.
 func IsNotfound(err error) bool {
-	return checkError(err, codeNotfound)
+	return checkError(err, codeNotFound)
 }
 
 // IsAlreadyExisted checks the error is object AlreadyExisted or not.

--- a/pkg/errtypes/errors_test.go
+++ b/pkg/errtypes/errors_test.go
@@ -7,19 +7,19 @@ import (
 )
 
 func TestCheckError(t *testing.T) {
-	if !checkError(errors.Wrap(ErrNotfound, "test"), codeNotfound) {
+	if !checkError(errors.Wrap(ErrNotfound, "test"), codeNotFound) {
 		t.Error("check Wrap error")
 	}
 
-	if !checkError(errors.Wrapf(ErrNotfound, "test"), codeNotfound) {
+	if !checkError(errors.Wrapf(ErrNotfound, "test"), codeNotFound) {
 		t.Error("check Wrapf error")
 	}
 
-	if !checkError(errors.WithMessage(ErrNotfound, "test"), codeNotfound) {
+	if !checkError(errors.WithMessage(ErrNotfound, "test"), codeNotFound) {
 		t.Error("check WithMessage error")
 	}
 
-	if !checkError(errors.Wrap(errors.Wrap(ErrNotfound, "test"), "test2"), codeNotfound) {
+	if !checkError(errors.Wrap(errors.Wrap(ErrNotfound, "test"), "test2"), codeNotFound) {
 		t.Error("check Wrap error")
 	}
 }

--- a/test/cli_inspect_test.go
+++ b/test/cli_inspect_test.go
@@ -109,14 +109,14 @@ func (suite *PouchInspectSuite) TestMultiInspectErrors(c *check.C) {
 		{
 			containers: []string{},
 			args:       []string{"multi-inspect-print-1", "multi-inspect-print-2"},
-			expectedOutput: "\nError: Fetch object error: {\"message\":\"container: multi-inspect-print-1: not found\"}\n" +
-				"Error: Fetch object error: {\"message\":\"container: multi-inspect-print-2: not found\"}\n",
+			expectedOutput: "\nError: Fetch object error: {\"message\":\"container multi-inspect-print-1: not found\"}\n" +
+				"Error: Fetch object error: {\"message\":\"container multi-inspect-print-2: not found\"}\n",
 		},
 		{
 			containers: []string{"multi-inspect-print-1"},
 			args:       []string{"multi-inspect-print-1", "multi-inspect-print-2"},
 			expectedOutput: "multi-inspect-print-1\n" +
-				"Error: Fetch object error: {\"message\":\"container: multi-inspect-print-2: not found\"}\n",
+				"Error: Fetch object error: {\"message\":\"container multi-inspect-print-2: not found\"}\n",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

polish error construction and log format:

* use errors.Wrapf instead of `errors.Wrap` and contructing string
* use `failed to do get object %s: %v` to be unified
* add error code in errtypes to be more clear for API status code

and remove two unused err `ErrUsingbyContainers `  and `ErrInvalidType`

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Describe how you did it
none


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews
none


