### PR TITLE
bugfix: fix stdin hang when `kubectl exec`

### DIFF
--- a/cri/stream/runtime.go
+++ b/cri/stream/runtime.go
@@ -53,6 +53,7 @@ func (s *streamRuntime) Exec(ctx context.Context, containerID string, cmd []stri
 	}
 
 	attachConfig := &mgr.AttachConfig{
+		Stdin:       streamOpts.Stdin,
 		Streams:     streams,
 		MuxDisabled: true,
 	}


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


