### PR TITLE
test: fix typo in TestAliKernelDiskQuotaWorks

### DIFF
--- a/test/cli_alikernel_test.go
+++ b/test/cli_alikernel_test.go
@@ -57,7 +57,7 @@ func (suite *PouchAliKernelSuite) TestAliKernelDiskQuotaWorks(c *check.C) {
 	// generate a file larger than 1G should fail.
 	expct = icmd.Expected{
 		ExitCode: 1,
-		Error:    "Disk quota exceeded",
+		Err:      "Disk quota exceeded",
 	}
 	cmd := "dd if=/dev/zero of=/mnt/test bs=1024k count=1500"
 	err = command.PouchRun("exec", funcname, "sh", "-c", cmd).Compare(expct)


### PR DESCRIPTION
In icmd/command.go, the Expected struct contains Error and Err,
the Err will be used when expected error is included.

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Fix test failure in PouchAliKernelSuite.TestAliKernelDiskQuotaWorks

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it
s/Error/Err/

### Ⅳ. Describe how to verify it
go test -check.f PouchAliKernelSuite.TestAliKernelDiskQuotaWorks

### Ⅴ. Special notes for reviews


