### PR TITLE
fix: make iterateTLSConfig only work for TLS config

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -169,7 +169,7 @@ func (cfg *Config) MergeConfigurations(flagSet *pflag.FlagSet) error {
 	}
 
 	fileFlags := make(map[string]interface{}, 0)
-	iterateConfig(origin, fileFlags)
+	iterateTLSConfig(origin, fileFlags)
 
 	// check if invalid or unknown flag exist in config file
 	if err = getUnknownFlags(flagSet, fileFlags); err != nil {
@@ -229,11 +229,12 @@ func (cfg *Config) delValue(flagSet *pflag.FlagSet, fileFlags map[string]interfa
 	return cfg
 }
 
-// iterateConfig resolves key-value from config file iteratly.
-func iterateConfig(origin map[string]interface{}, config map[string]interface{}) {
+// iterateTLSConfig resolves key-value from config file iteratly.
+// only for TLS config, and recursive once.
+func iterateTLSConfig(origin map[string]interface{}, config map[string]interface{}) {
 	for k, v := range origin {
-		if c, ok := v.(map[string]interface{}); ok && k != "add-runtime" {
-			iterateConfig(c, config)
+		if c, ok := v.(map[string]interface{}); ok && k == "TLS" {
+			iterateTLSConfig(c, config)
 		} else {
 			config[k] = v
 		}

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -7,41 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIterateConfig(t *testing.T) {
+func TestIterateTLSConfig(t *testing.T) {
 	assert := assert.New(t)
-	origin := map[string]interface{}{
-		"a": "a",
-		"b": "b",
-		"c": "c",
-		"iter1": map[string]interface{}{
-			"i1": "i1",
-			"i2": "i2",
-		},
-		"iter11": map[string]interface{}{
-			"ii1": map[string]interface{}{
-				"iii1": "iii1",
-				"iii2": "iii2",
-			},
-		},
-	}
-
-	expect := map[string]interface{}{
-		"a":    "a",
-		"b":    "b",
-		"c":    "c",
-		"i1":   "i1",
-		"i2":   "i2",
-		"iii1": "iii1",
-		"iii2": "iii2",
-	}
-
-	config := make(map[string]interface{})
-	iterateConfig(origin, config)
-	assert.Equal(config, expect)
 
 	// test nil map will not cause panic
-	config = make(map[string]interface{})
-	iterateConfig(nil, config)
+	config := make(map[string]interface{})
+	iterateTLSConfig(nil, config)
 	assert.Equal(config, map[string]interface{}{})
 }
 


### PR DESCRIPTION
Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


