### PR TITLE
bugfix: avoid the deadlock when failed to remove invalid sandbox

### DIFF
--- a/cri/v1alpha1/cri_utils.go
+++ b/cri/v1alpha1/cri_utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/typeurl"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
@@ -311,6 +312,44 @@ func toCriSandbox(c *mgr.Container) (*runtime.PodSandbox, error) {
 		Labels:      labels,
 		Annotations: annotations,
 	}, nil
+}
+
+// It has the possibility that we failed to run the sandbox and it is not being cleaned up.
+// Kubelet will use list to get the sandboxes, but will not get the status of the failed pod
+// whose meta data has not been put into the Sandbox Store. And Kubelet will keep trying to
+// get the status of the failed pod and won't create a new one to replace it. It's a DEAD LOCK.
+// Actually Kubelet should not know the existence of invalid pod whose meta data won't be in the
+// Sandbox Store. So we could avoid the DEAD LOCK mentioned above.
+func (c *CriManager) filterInvalidSandboxes(ctx context.Context, sandboxes []*mgr.Container) ([]*mgr.Container, error) {
+	validSandboxes, err := c.SandboxStore.Keys()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*mgr.Container
+	for _, sandbox := range sandboxes {
+		exist := false
+		for _, id := range validSandboxes {
+			if sandbox.ID == id {
+				exist = true
+				break
+			}
+		}
+		if exist {
+			result = append(result, sandbox)
+			continue
+		}
+
+		status := sandbox.State.Status
+		// NOTE: what if the worst case that we failed to remove the sandbox and
+		// it is still running?
+		if status != apitypes.StatusRunning && status != apitypes.StatusCreated {
+			// Remove invalid sandbox.
+			logrus.Warnf("filterInvalidSandboxes: remove invalid sandbox %v", sandbox.ID)
+			c.ContainerMgr.Remove(ctx, sandbox.ID, &apitypes.ContainerRemoveOptions{Volumes: true, Force: true})
+		}
+	}
+	return result, nil
 }
 
 func filterCRISandboxes(sandboxes []*runtime.PodSandbox, filter *runtime.PodSandboxFilter) []*runtime.PodSandbox {

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -205,7 +205,10 @@ func (c *CriManager) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	defer func() {
 		// If running sandbox failed, clean up the container.
 		if retErr != nil {
-			c.ContainerMgr.Remove(ctx, id, &apitypes.ContainerRemoveOptions{Volumes: true, Force: true})
+			err := c.ContainerMgr.Remove(ctx, id, &apitypes.ContainerRemoveOptions{Volumes: true, Force: true})
+			if err != nil {
+				logrus.Errorf("failed to remove the container when running sandbox failed: %v", err)
+			}
 		}
 	}()
 
@@ -466,6 +469,11 @@ func (c *CriManager) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandb
 	sandboxList, err := c.ContainerMgr.List(ctx, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sandbox: %v", err)
+	}
+
+	sandboxList, err = c.filterInvalidSandboxes(ctx, sandboxList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to filter invalid sandboxes: %v", err)
 	}
 
 	sandboxes := make([]*runtime.PodSandbox, 0, len(sandboxList))


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

It has the possibility that we failed to run the sandbox and it is not being cleaned up.

Kubelet will use list to get the sandboxes, but will not get the status of the failed pod whose meta data has not been put into the Sandbox Store.

And Kubelet will keep trying to get the status of the failed pod and won't create a new one to replace it. 

It's a DEAD LOCK.

Actually Kubelet should not know the existent of invalid pod whose meta data won't be in the Sandbox Store.

So we could avoid the DEAD LOCK mentioned above.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


