### PR TITLE
bugfix: Fix #1955 that cannot remove image reference by specified reference when other references are used

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alibaba/pouch/pkg/httputils"
 
 	"github.com/gorilla/mux"
+	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 )
 
@@ -99,18 +100,26 @@ func (s *Server) removeImage(ctx context.Context, rw http.ResponseWriter, req *h
 		return err
 	}
 
-	containers, err := s.ContainerMgr.List(ctx, &mgr.ContainerListOption{
-		All: true,
-		FilterFunc: func(c *mgr.Container) bool {
-			return c.Image == image.ID
-		}})
+	refs, err := s.ImageMgr.ListReferences(ctx, digest.Digest(image.ID))
 	if err != nil {
 		return err
 	}
 
 	isForce := httputils.BoolValue(req, "force")
-	if !isForce && len(containers) > 0 {
-		return fmt.Errorf("Unable to remove the image %q (must force) - container (%s, %s) is using this image", image.ID, containers[0].ID, containers[0].Name)
+	// We only should check the image whether used by container when there is only one primary reference.
+	if len(refs) == 1 {
+		containers, err := s.ContainerMgr.List(ctx, &mgr.ContainerListOption{
+			All: true,
+			FilterFunc: func(c *mgr.Container) bool {
+				return c.Image == image.ID
+			}})
+		if err != nil {
+			return err
+		}
+
+		if !isForce && len(containers) > 0 {
+			return fmt.Errorf("Unable to remove the image %q (must force) - container (%s, %s) is using this image", image.ID, containers[0].ID, containers[0].Name)
+		}
 	}
 
 	if err := s.ImageMgr.RemoveImage(ctx, name, isForce); err != nil {

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/containerd/containerd"
 	ctrdmetaimages "github.com/containerd/containerd/images"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -46,6 +46,9 @@ type ImageMgr interface {
 
 	// CheckReference returns imageID, actual reference and primary reference.
 	CheckReference(ctx context.Context, idOrRef string) (digest.Digest, reference.Named, reference.Named, error)
+
+	// ListReferences returns all references
+	ListReferences(ctx context.Context, imageID digest.Digest) ([]reference.Named, error)
 
 	// LoadImage creates a set of images by tarstream.
 	LoadImage(ctx context.Context, imageName string, tarstream io.ReadCloser) error
@@ -338,6 +341,12 @@ func (mgr *ImageManager) CheckReference(ctx context.Context, idOrRef string) (ac
 		}
 	}
 	return
+}
+
+// ListReferences returns all references
+func (mgr *ImageManager) ListReferences(ctx context.Context, imageID digest.Digest) ([]reference.Named, error) {
+	// NOTE: we just keep ctx and error for further expansion
+	return mgr.localStore.GetPrimaryReferences(imageID), nil
 }
 
 // updateLocalStore updates the local store.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Fix that cannot remove image by specified reference when other references are used.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1955

### Ⅲ. Describe how you did it
Add a new method `ListReferences` to `mgr.ImageMgr` for returning all references of image, so we only should check the image whether used by container when there is only one primary reference in method `Server.removeImage`.

### Ⅳ. Describe how to verify it
1. tag one image
```
# pouch tag registry.hub.docker.com/library/busybox:1.28 tag-busybox:1.28
```

2. start one container based on tagged image.
```
# pouch run -d --name c1 registry.hub.docker.com/library/tag-busybox:1.28 top
1d3c455dad6e8213f1d36b05924f61ac232492cb360929303a72265f1bea2314
```

3. remove original image successfully.
```
# pouch rmi registry.hub.docker.com/library/busybox:1.28
```

### Ⅴ. Special notes for reviews


