### PR TITLE
bugfix: remove blobs and snapshot when remove image

### DIFF
--- a/ctrd/image.go
+++ b/ctrd/image.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	ctrdmetaimages "github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/remotes"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -196,8 +195,6 @@ func (c *Client) PullImage(ctx context.Context, ref string, authConfig *types.Au
 }
 
 func (c *Client) pullImage(ctx context.Context, wrapperCli *WrapperClient, ref string, options []containerd.RemoteOpt) (containerd.Image, error) {
-	ctx = leases.WithLease(ctx, wrapperCli.lease.ID())
-
 	img, err := wrapperCli.client.Pull(ctx, ref, options...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to pull image")


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Don't add lease to the image since the containerdclient.Pull will add
the lease.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE


### Ⅲ. Describe how you did it

the lease should be released after pull. The containerd client has this functionality so that we should add the one.

### Ⅳ. Describe how to verify it

1. pull the image
```
$ sudo pouch pull busybox:1.28
registry.hub.docker.com/library/busybox:1.28:                                     resolved       |++++++++++++++++++++++++++++++++++++++|
index-sha256:141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47:    done           |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:74f634b1bc1bd74535d5209589734efbd44a25f4e2dc96d78784576a3eb5b335: done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:07a152489297fc2bca20be96fab3527ceac5668328a30fd543a160cd689ee548:    done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:8c811b4aec35f259572d0f79207bc0678df4c736eeec50bc9fec37ed936a472a:   done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 9.6 s
```

2. check the blobs
```
root@ubuntu-xenial:/var/lib/pouch/containerd/root/io.containerd.content.v1.content/blobs/sha256# ls -al
total 728
drwxr-xr-x 2 root root   4096 Aug 11 11:12 .
drwxr-xr-x 3 root root   4096 Aug 11 11:06 ..
-r--r--r-- 1 root root 723146 Aug 11 11:12 07a152489297fc2bca20be96fab3527ceac5668328a30fd543a160cd689ee548
-r--r--r-- 1 root root   2699 Aug 11 11:12 141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47
-r--r--r-- 1 root root    527 Aug 11 11:12 74f634b1bc1bd74535d5209589734efbd44a25f4e2dc96d78784576a3eb5b335
-r--r--r-- 1 root root   1497 Aug 11 11:12 8c811b4aec35f259572d0f79207bc0678df4c736eeec50bc9fec37ed936a472a
```

3. remove image
```
$ sudo pouch rmi busybox:1.28
busybox:1.28

root@ubuntu-xenial:/var/lib/pouch/containerd/root/io.containerd.content.v1.content/blobs/sha256# ls -al
total 8
drwxr-xr-x 2 root root 4096 Aug 11 11:12 .
drwxr-xr-x 3 root root 4096 Aug 11 11:06 ..
```


### Ⅴ. Special notes for reviews


