### PR TITLE
bugfix: remove duplicate TypeUrl initialize

### DIFF
--- a/ctrd/client.go
+++ b/ctrd/client.go
@@ -109,7 +109,6 @@ func NewClient(homeDir string, opts ...ClientOpt) (APIClient, error) {
 	client.scheduler = scheduler
 
 	// start collect containerd events
-	initTypeURL()
 	go client.collectContainerdEvents()
 
 	return client, nil

--- a/ctrd/events.go
+++ b/ctrd/events.go
@@ -3,10 +3,8 @@ package ctrd
 import (
 	"context"
 
-	eventstypes "github.com/containerd/containerd/api/events"
 	eventsapi "github.com/containerd/containerd/api/services/events/v1"
 	"github.com/containerd/containerd/runtime"
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -37,11 +35,4 @@ func (c *Client) Events(ctx context.Context, ef ...string) (eventsapi.Events_Sub
 	return eventsClient.Subscribe(ctx, &eventsapi.SubscribeRequest{
 		Filters: ef,
 	})
-}
-
-// initTypeURL initializes URL type for containerd events url type,
-// it works for typeurl.UnmarshalAny
-func initTypeURL() {
-	proto.RegisterType((*eventstypes.ContainerDelete)(nil), "containerd.events.ContainerDelete")
-	proto.RegisterType((*eventstypes.TaskOOM)(nil), "containerd.events.TaskOOM")
 }


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
Remove duplicate initialisation of type url `containerd.events.ContainerDelete` and `containerd.events.TaskOOM`. Because those type already initialized in vendor

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Describe how you did it


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


