### PR TITLE
cgroup: enable memory swappiness equal to -1

### DIFF
--- a/apis/opts/memory_swappiness.go
+++ b/apis/opts/memory_swappiness.go
@@ -6,7 +6,7 @@ import "fmt"
 
 // ValidateMemorySwappiness verifies the correctness of memory-swappiness.
 func ValidateMemorySwappiness(memorySwappiness int64) error {
-	if memorySwappiness < 0 || memorySwappiness > 100 {
+	if memorySwappiness != -1 && (memorySwappiness < 0 || memorySwappiness > 100) {
 		return fmt.Errorf("invalid memory swappiness: %d (its range is 0-100)", memorySwappiness)
 	}
 	return nil

--- a/apis/opts/memory_swappiness_test.go
+++ b/apis/opts/memory_swappiness_test.go
@@ -16,7 +16,7 @@ func TestValidateMemorySwappiness(t *testing.T) {
 	testCases := []TestCase{
 		{
 			input:    -1,
-			expected: fmt.Errorf("invalid memory swappiness: %d (its range is 0-100)", -1),
+			expected: nil,
 		},
 		{
 			input:    0,

--- a/daemon/mgr/container_validation.go
+++ b/daemon/mgr/container_validation.go
@@ -100,7 +100,7 @@ func validateResource(r *types.Resources, update bool) ([]string, error) {
 			warnings = append(warnings, MemorySwappinessWarn)
 			r.MemorySwappiness = nil
 		}
-		if r.MemorySwappiness != nil && (*r.MemorySwappiness < 0 || *r.MemorySwappiness > 100) {
+		if r.MemorySwappiness != nil && *r.MemorySwappiness != -1 && (*r.MemorySwappiness < 0 || *r.MemorySwappiness > 100) {
 			return warnings, fmt.Errorf("MemorySwappiness should in range [0, 100]")
 		}
 		if r.OomKillDisable != nil && !cgroupInfo.Memory.OOMKillDisable {

--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -261,7 +261,7 @@ func setupMemory(ctx context.Context, r types.Resources, s *specs.Spec) {
 		memory.Swap = &v
 	}
 
-	if r.MemorySwappiness != nil {
+	if r.MemorySwappiness != nil && *r.MemorySwappiness != -1 {
 		v := uint64(*r.MemorySwappiness)
 		memory.Swappiness = &v
 	}

--- a/test/cli_run_memory_test.go
+++ b/test/cli_run_memory_test.go
@@ -36,6 +36,7 @@ func (suite *PouchRunMemorySuite) TearDownTest(c *check.C) {
 // TestRunWithMemoryswap is to verify the valid running container
 // with --memory-swap
 func (suite *PouchRunMemorySuite) TestRunWithMemoryswap(c *check.C) {
+	SkipIfFalse(c, environment.IsMemorySupport)
 	SkipIfFalse(c, environment.IsMemorySwapSupport)
 
 	cname := "TestRunWithMemoryswap"
@@ -90,8 +91,18 @@ func (suite *PouchRunMemorySuite) TestRunWithMemoryswap(c *check.C) {
 // TestRunWithMemoryswappiness is to verify the valid running container
 // with memory-swappiness
 func (suite *PouchRunMemorySuite) TestRunWithMemoryswappiness(c *check.C) {
-	cname := "TestRunWithMemoryswappiness"
-	res := command.PouchRun("run", "-d", "-m", "100m",
+	SkipIfFalse(c, environment.IsMemorySupport)
+	SkipIfFalse(c, environment.IsMemorySwappinessSupport)
+
+	cname := "TestRunWithMemoryswappiness-1"
+	res := command.PouchRun("run", "-d",
+		"--memory-swappiness", "-1",
+		"--name", cname, busyboxImage, "top")
+	DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
+
+	cname = "TestRunWithMemoryswappiness"
+	res = command.PouchRun("run", "-d", "-m", "100m",
 		"--memory-swappiness", "70",
 		"--name", cname, busyboxImage, "sleep", "10000")
 	defer DelContainerForceMultyTime(c, cname)
@@ -117,6 +128,8 @@ func (suite *PouchRunMemorySuite) TestRunWithMemoryswappiness(c *check.C) {
 
 // TestRunWithLimitedMemory is to verify the valid running container with -m
 func (suite *PouchRunMemorySuite) TestRunWithLimitedMemory(c *check.C) {
+	SkipIfFalse(c, environment.IsMemorySupport)
+
 	cname := "TestRunWithLimitedMemory"
 	res := command.PouchRun("run", "-d", "-m", "100m",
 		"--name", cname, busyboxImage, "top")
@@ -143,6 +156,8 @@ func (suite *PouchRunMemorySuite) TestRunWithLimitedMemory(c *check.C) {
 
 // TestRunMemoryOOM is to verify return value when a container is OOM.
 func (suite *PouchRunMemorySuite) TestRunMemoryOOM(c *check.C) {
+	SkipIfFalse(c, environment.IsMemorySupport)
+
 	cname := "TestRunMemoryOOM"
 	ret := command.PouchRun("run", "-m", "20m", "--name", cname, busyboxImage, "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
 	defer DelContainerForceMultyTime(c, cname)
@@ -151,6 +166,7 @@ func (suite *PouchRunMemorySuite) TestRunMemoryOOM(c *check.C) {
 
 // TestRunWithMemoryFlag test pouch run with memory flags
 func (suite *PouchRunSuite) TestRunWithMemoryFlag(c *check.C) {
+	SkipIfFalse(c, environment.IsMemorySupport)
 	SkipIfFalse(c, environment.IsMemorySwapSupport)
 
 	cname := "RunWithOnlyMemorySwap"

--- a/test/environment/env.go
+++ b/test/environment/env.go
@@ -48,9 +48,19 @@ var (
 var (
 	cgroupInfo *system.CgroupInfo
 
+	// IsMemorySupport checks if memory cgroup is avaible
+	IsMemorySupport = func() bool {
+		return cgroupInfo.Memory.MemoryLimit
+	}
+
 	// IsMemorySwapSupport checks if memory swap cgroup is avaible
 	IsMemorySwapSupport = func() bool {
 		return cgroupInfo.Memory.MemorySwap
+	}
+
+	// IsMemorySwappinessSupport checks if memory swappiness cgroup is avaible
+	IsMemorySwappinessSupport = func() bool {
+		return cgroupInfo.Memory.MemorySwappiness
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

enable memory-swappiness can be set to -1, -1 means do nothing.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

add！

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


