### PR TITLE
bugfix: use image reference during ContainerStatus

### DIFF
--- a/cri/v1alpha1/cri.go
+++ b/cri/v1alpha1/cri.go
@@ -710,11 +710,16 @@ func (c *CriManager) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 
 	labels, annotations := extractLabels(container.Config.Labels)
 
-	imageRef := container.Image
-	imageInfo, err := c.ImageMgr.GetImage(ctx, imageRef)
+	// FIXME(fuwei): if user repush image with the same reference, the image
+	// ID will be changed. For now, pouch daemon will remove the old image ID
+	// so that CRI fails to fetch the running container. Before upgrade
+	// pouch daemon image manager, we use reference to get image instead of
+	// id.
+	imageInfo, err := c.ImageMgr.GetImage(ctx, container.Config.Image)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get image %s: %v", imageRef, err)
+		return nil, fmt.Errorf("failed to get image %s: %v", container.Config.Image, err)
 	}
+	imageRef := imageInfo.ID
 	if len(imageInfo.RepoDigests) > 0 {
 		imageRef = imageInfo.RepoDigests[0]
 	}

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -709,11 +709,16 @@ func (c *CriManager) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 
 	labels, annotations := extractLabels(container.Config.Labels)
 
-	imageRef := container.Image
-	imageInfo, err := c.ImageMgr.GetImage(ctx, imageRef)
+	// FIXME(fuwei): if user repush image with the same reference, the image
+	// ID will be changed. For now, pouch daemon will remove the old image ID
+	// so that CRI fails to fetch the running container. Before upgrade
+	// pouch daemon image manager, we use reference to get image instead of
+	// id.
+	imageInfo, err := c.ImageMgr.GetImage(ctx, container.Config.Image)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get image %s: %v", imageRef, err)
+		return nil, fmt.Errorf("failed to get image %s: %v", container.Config.Image, err)
 	}
+	imageRef := imageInfo.ID
 	if len(imageInfo.RepoDigests) > 0 {
 		imageRef = imageInfo.RepoDigests[0]
 	}


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

If user repush image with the same reference, the image ID will be changed. For now, pouch daemon will remove the old image ID so that CRI fails to fetch the running container. Before upgrade pouch daemon image manager, we use reference to get image instead of id.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

NO


### Ⅳ. Describe how to verify it



### Ⅴ. Special notes for reviews


