### PR TITLE
bugfix: skip empty container dirs

### DIFF
--- a/daemon/mgr/container_storage.go
+++ b/daemon/mgr/container_storage.go
@@ -18,8 +18,8 @@ import (
 	"github.com/alibaba/pouch/pkg/system"
 	"github.com/alibaba/pouch/storage/quota"
 	volumetypes "github.com/alibaba/pouch/storage/volume/types"
-	"github.com/containerd/containerd/mount"
 
+	"github.com/containerd/containerd/mount"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/meta/local.go
+++ b/pkg/meta/local.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -98,6 +100,7 @@ func (s *localStore) Get(fileName, key string) ([]byte, error) {
 
 	if _, err := os.Stat(name); err != nil {
 		if os.IsNotExist(err) {
+			logrus.Warnf("container %s meta.json file not exist", key)
 			return nil, ErrObjectNotFound
 		}
 	}
@@ -186,7 +189,10 @@ func walkDir(dir string, handle func(os.FileInfo) error) error {
 		if !f.IsDir() {
 			continue
 		}
-		if err := handle(f); err != nil {
+
+		err := handle(f)
+		// Skip empty container dirs
+		if err != nil && err != ErrObjectNotFound {
 			return fmt.Errorf("failed to handle file %s: %v", f.Name(), err)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
If a container metadata dir is empty, just skip recover it

### Ⅱ. Does this pull request fix one issue?



### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Yes I Do 

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


