### PR TITLE
bugfix: make rpm package script works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script: |
     TEST_FLAGS= make build-integration-test
     sudo env "PATH=$PATH" make install
 
-    sudo env "PATH=$PATH" make download_dependencies
+    sudo env "PATH=$PATH" make download-dependencies
     sudo env "PATH=$PATH" make integration-test
     make coverage
   elif [[ "${TEST_SUITE}" = "criv1alpha1test" ]]; then
@@ -41,7 +41,7 @@ script: |
     TEST_FLAGS= make build-daemon-integration
     sudo env "PATH=$PATH" make install
 
-    sudo env "PATH=$PATH" make download_dependencies
+    sudo env "PATH=$PATH" make download-dependencies
     sudo env "PATH=$PATH" make cri-v1alpha1-test
     make coverage
   else
@@ -49,7 +49,7 @@ script: |
     TEST_FLAGS= make build-daemon-integration
     sudo env "PATH=$PATH" make install
 
-    sudo env "PATH=$PATH" make download_dependencies
+    sudo env "PATH=$PATH" make download-dependencies
     sudo env "PATH=$PATH" make cri-v1alpha2-test
     make coverage
   fi

--- a/Makefile
+++ b/Makefile
@@ -89,16 +89,20 @@ uninstall: ## uninstall pouchd and pouch binary
 	@rm -f $(addprefix $(DEST_DIR)/bin/,$(notdir $(DAEMON_BINARY_NAME)))
 	@rm -f $(addprefix $(DEST_DIR)/bin/,$(notdir $(CLI_BINARY_NAME)))
 
-.PHONY: download_dependencies
-download_dependencies: ## download related dependencies, such as dumb_init
+.PHONY: package-dependencies
+package-dependencies: ## install containerd, runc and lxcfs dependencies for packaging
+	@echo $@
+	hack/install/install_containerd.sh
+	hack/install/install_lxcfs.sh
+	hack/install/install_runc.sh
+
+.PHONY: download-dependencies
+download-dependencies: package-dependencies ## install dumb-init, local-persist, nsenter and CI tools dependencies
 	@echo $@
 	hack/install/install_ci_related.sh
-	hack/install/install_containerd.sh
 	hack/install/install_dumb_init.sh
 	hack/install/install_local_persist.sh
-	hack/install/install_lxcfs.sh
 	hack/install/install_nsenter.sh
-	hack/install/install_runc.sh
 
 .PHONY: clean
 clean: ## clean to remove bin/* and files created by module


### PR DESCRIPTION
Makefile: split download-dependencies into package-dependencies and
          download-dependencies for reusing codes in packaging.
hack/package/rpm/build.sh: synchronize Makefile changes

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
as summary

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None


### Ⅳ. Describe how to verify it
https://github.com/alibaba/pouch/tree/master/hack/package

### Ⅴ. Special notes for reviews


