### PR TITLE
feature: add disk quota for container metadata directory

### DIFF
--- a/daemon/mgr/container_storage.go
+++ b/daemon/mgr/container_storage.go
@@ -461,10 +461,19 @@ func (mgr *ContainerManager) setRootfsQuota(ctx context.Context, c *Container) e
 		return errors.Wrapf(err, "failed to change quota id: (%s) from string to int", qid)
 	}
 
-	err = quota.SetRootfsDiskQuota(c.MountFS, rootfsQuota, uint32(id))
+	// set rootfs quota
+	newID, err := quota.SetRootfsDiskQuota(c.MountFS, rootfsQuota, uint32(id))
 	if err != nil {
 		return errors.Wrapf(err, "failed to set rootfs quota, mountfs: (%s), quota: (%s), quota id: (%d)",
 			c.MountFS, rootfsQuota, id)
+	}
+
+	// set container's metadata directory diskquota, for limit the size of container's logs
+	metaDir := mgr.Store.Path(c.ID)
+	err = quota.SetDiskQuota(metaDir, rootfsQuota, newID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set container's log quota, dir: (%s), quota: (%s), quota id: (%d)",
+			metaDir, rootfsQuota, newID)
 	}
 
 	return nil
@@ -638,6 +647,39 @@ func (mgr *ContainerManager) Unmount(ctx context.Context, c *Container) error {
 	}
 
 	return os.RemoveAll(c.MountFS)
+}
+
+func (mgr *ContainerManager) initContainerStorage(ctx context.Context, c *Container) (err error) {
+	if err = mgr.Mount(ctx, c); err != nil {
+		return errors.Wrapf(err, "failed to mount rootfs: (%s)", c.MountFS)
+	}
+
+	defer func() {
+		if umountErr := mgr.Unmount(ctx, c); umountErr != nil {
+			if err != nil {
+				err = errors.Wrapf(err, "failed to umount rootfs: (%s), err: (%v)", c.MountFS, umountErr)
+			} else {
+				err = errors.Wrapf(umountErr, "failed to umount rootfs: (%s)", c.MountFS)
+			}
+		}
+	}()
+
+	// parse volume config
+	if err = mgr.generateMountPoints(ctx, c); err != nil {
+		return errors.Wrap(err, "failed to parse volume argument")
+	}
+
+	// set mount point disk quota
+	if err = mgr.setMountPointDiskQuota(ctx, c); err != nil {
+		return errors.Wrap(err, "failed to set mount point disk quota")
+	}
+
+	// set rootfs disk quota
+	if err = mgr.setRootfsQuota(ctx, c); err != nil {
+		logrus.Warnf("failed to set rootfs disk quota, err: %v", err)
+	}
+
+	return nil
 }
 
 func copyImageContent(source, destination string) error {

--- a/storage/quota/quota.go
+++ b/storage/quota/quota.go
@@ -167,33 +167,33 @@ func GetDefaultQuota(quotas map[string]string) string {
 }
 
 // SetRootfsDiskQuota is to set container rootfs dir disk quota.
-func SetRootfsDiskQuota(basefs, size string, quotaID uint32) error {
+func SetRootfsDiskQuota(basefs, size string, quotaID uint32) (uint32, error) {
 	overlayMountInfo, err := getOverlayMountInfo(basefs)
 	if err != nil {
-		return fmt.Errorf("failed to get overlay mount info: %v", err)
+		return 0, fmt.Errorf("failed to get overlay mount info: %v", err)
 	}
 
 	for _, dir := range []string{overlayMountInfo.Upper, overlayMountInfo.Work} {
 		_, err = StartQuotaDriver(dir)
 		if err != nil {
-			return fmt.Errorf("failed to start quota driver: %v", err)
+			return 0, fmt.Errorf("failed to start quota driver: %v", err)
 		}
 
 		quotaID, err = SetSubtree(dir, quotaID)
 		if err != nil {
-			return fmt.Errorf("failed to set subtree: %v", err)
+			return 0, fmt.Errorf("failed to set subtree: %v", err)
 		}
 
 		if err := SetDiskQuota(dir, size, quotaID); err != nil {
-			return fmt.Errorf("failed to set disk quota: %v", err)
+			return 0, fmt.Errorf("failed to set disk quota: %v", err)
 		}
 
 		if err := setQuotaForDir(dir, quotaID); err != nil {
-			return fmt.Errorf("failed to set dir quota: %v", err)
+			return 0, fmt.Errorf("failed to set dir quota: %v", err)
 		}
 	}
 
-	return nil
+	return quotaID, nil
 }
 
 // setQuotaForDir sets file attribute

--- a/test/cli_run_volume_test.go
+++ b/test/cli_run_volume_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
+	"github.com/pkg/errors"
 )
 
 // PouchRunVolumeSuite is the test suite for run CLI.
@@ -330,4 +332,66 @@ func (suite *PouchRunVolumeSuite) TestRunWithDiskQuota(c *check.C) {
 	}
 
 	c.Assert(found, check.Equals, true)
+}
+
+// TestRunWithDiskQuotaForLog tests limit the size of container's log.
+func (suite *PouchRunVolumeSuite) TestRunWithDiskQuotaForLog(c *check.C) {
+	if !environment.IsDiskQuota() {
+		c.Skip("Host does not support disk quota")
+	}
+
+	cname := "TestRunWithDiskQuotaForLog"
+	command.PouchRun("run", "-d", "--disk-quota", "10m",
+		"--name", cname, busyboxImage, "top").Assert(c, icmd.Success)
+
+	defer DelContainerForceMultyTime(c, cname)
+
+	containerMetaDir, err := getContainerMetaDir(cname)
+	c.Assert(err, check.Equals, nil)
+
+	testFile := filepath.Join(containerMetaDir, "diskquota_testfile")
+
+	icmd.RunCommand("groupadd", "quota").Assert(c, icmd.Success)
+	defer icmd.RunCommand("groupdel", "quota").Assert(c, icmd.Success)
+
+	icmd.RunCommand("useradd", "-g", "quota", "quota").Assert(c, icmd.Success)
+	defer icmd.RunCommand("userdel", "quota").Assert(c, icmd.Success)
+
+	expct := icmd.Expected{
+		ExitCode: 1,
+		Err:      "Disk quota exceeded",
+	}
+	err = icmd.RunCommand("dd", "if=/dev/zero", "of="+testFile, "bs=1M", "count=20", "oflag=direct").Compare(expct)
+	c.Assert(err, check.IsNil)
+}
+
+func getContainerMetaDir(name string) (string, error) {
+	ret := command.PouchRun("inspect", name)
+
+	mergedDir := ""
+	for _, line := range strings.Split(ret.Stdout(), "\n") {
+		if strings.Contains(line, "MergedDir") {
+			mergedDir = strings.Split(line, "\"")[3]
+			break
+		}
+	}
+
+	var (
+		graph string
+		cid   string
+	)
+	if mergedDir == "" {
+		return "", errors.Errorf("failed to get container metadata directory")
+	}
+
+	parts := strings.Split(mergedDir, "/")
+	for i, part := range parts {
+		if part == "containerd" {
+			graph = "/" + filepath.Join(parts[:i]...)
+			cid = parts[i+4]
+			break
+		}
+	}
+
+	return filepath.Join(graph, "containers", cid), nil
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add disk quota for container metadata directory, use to limit the size
of container's log files.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Added test case `TestRunWithDiskQuotaForLog`


### Ⅳ. Describe how to verify it
run test case `TestRunWithDiskQuotaForLog`

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
