### PR TITLE
bugfix: fix meta store return all item when empty prefix

### DIFF
--- a/pkg/meta/store.go
+++ b/pkg/meta/store.go
@@ -248,6 +248,10 @@ func (s *Store) GetWithPrefix(prefix string) ([]Object, error) {
 func (s *Store) KeysWithPrefix(prefix string) ([]string, error) {
 	var keys []string
 
+	if len(prefix) == 0 {
+		return keys, nil
+	}
+
 	fn := func(prefix patricia.Prefix, item patricia.Item) error {
 		keys = append(keys, string(prefix))
 		return nil

--- a/pkg/meta/store_test.go
+++ b/pkg/meta/store_test.go
@@ -200,3 +200,63 @@ func TestBoltdbRemove(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+type Demo4 struct {
+	A int
+	B string
+}
+
+func (d *Demo4) Key() string {
+	return d.B
+}
+
+var boltdb4 *Store
+
+var boltdbCfg4 = Config{
+	Driver:  "boltdb",
+	BaseDir: "/tmp/bolt4.db",
+	Buckets: []Bucket{
+		{"boltdb", reflect.TypeOf(Demo4{})},
+	},
+}
+
+func TestKeysWithPrefix(t *testing.T) {
+	var err error
+	boltdb4, err = NewStore(boltdbCfg4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// put 1
+	if err := boltdb4.Put(&Demo4{
+		A: 1,
+		B: "prefixkey",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// put 2
+	if err := boltdb4.Put(&Demo4{
+		A: 2,
+		B: "prefixkey2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// find item with prefix
+	obj, err := boltdb4.KeysWithPrefix("prefixkey")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(obj) != 2 {
+		t.Fatal("should get 2 item")
+	}
+
+	// find item with prefix empty should return null item
+	obj, err = boltdb4.KeysWithPrefix("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(obj) != 0 {
+		t.Fatal("should get empty item")
+	}
+}


### PR DESCRIPTION
meta store will return all items it keep if prefix is a empty
string.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

```
 func (mgr *ContainerManager) Get(ctx context.Context, name string) (*Container, error) {
+       name = ""
        c, err := mgr.container(name)
        if err != nil {
                return nil, err
```
make name to empty, test
```
root@www:/var/lib/pouch# curl  -X GET --unix-socket /var/run/pouchd.sock "http:/containers/92b62b/json"
{"message":"container: : too many"}
```
it will return all container infos.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

unit test add.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


