### PR TITLE
bugfix: extend reference separator

### DIFF
--- a/pkg/reference/parse_test.go
+++ b/pkg/reference/parse_test.go
@@ -131,6 +131,22 @@ func TestParse(t *testing.T) {
 			input:    "  ",
 			expected: nil,
 			err:      ErrInvalid,
+		}, {
+			name:     "With __ as separator in name",
+			input:    "new__separator",
+			expected: namedReference{"new__separator"},
+		}, {
+			name:  "With __ as separator in name and tag",
+			input: "new__separator:build__testing",
+			expected: taggedReference{
+				Named: namedReference{"new__separator"},
+				tag:   "build__testing",
+			},
+		}, {
+			name:     "Invalid separator ___",
+			input:    "new__separator___invalid",
+			expected: nil,
+			err:      ErrInvalid,
 		},
 	} {
 		ref, err := Parse(tc.input)

--- a/pkg/reference/regexp.go
+++ b/pkg/reference/regexp.go
@@ -5,10 +5,12 @@ import "regexp"
 //
 // v1 org.opencontainers.image.ref.name:
 //
+// NOTE: extend separator with "__" here to compatibility with moby
+//
 // 	ref       ::= component ("/" component)*
 // 	component ::= alphanum (separator alphanum)*
 // 	alphanum  ::= [A-Za-z0-9]+
-// 	separator ::= [-._:@+] | "--"
+// 	separator ::= [-._:@+] | "--" | "__"
 //
 // In the image-spec, there is no definition about Tag.
 //
@@ -19,7 +21,7 @@ import "regexp"
 var (
 	regAlphanum = expression(`[A-Za-z0-9]`)
 
-	regSeparator = expression(`([-._:@+]|--)`)
+	regSeparator = expression(`([-._:@+]|--|__)`)
 
 	regComponent = group(
 		oneOrMore(regAlphanum),


### PR DESCRIPTION
Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In order to compatible with moby, need to extend oci separator with ___.

for example, `localhost:5000/testing:build__20180819` should be valid. However, the `___` is invalid.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #2113 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Added test 

### Ⅳ. Describe how to verify it

Check the test case

### Ⅴ. Special notes for reviews


