### PR TITLE
[bugfix] we should parse env params when create container

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1036,42 +1036,11 @@ func (mgr *ContainerManager) Update(ctx context.Context, name string, config *ty
 	}
 
 	// Update Env
-	if len(config.Env) > 0 {
-		newEnvMap, err := opts.ParseEnv(config.Env)
-		if err != nil {
-			return errors.Wrapf(err, "failed to parse new env")
-		}
-
-		oldEnvMap, err := opts.ParseEnv(c.Config.Env)
-		if err != nil {
-			return errors.Wrapf(err, "failed to parse old env")
-		}
-
-		for k, v := range newEnvMap {
-			// key should not be empty
-			if k == "" {
-				continue
-			}
-
-			// add or change an env
-			if v != "" {
-				oldEnvMap[k] = v
-				continue
-			}
-
-			// value is empty, we need delete the env
-			if _, exists := oldEnvMap[k]; exists {
-				delete(oldEnvMap, k)
-			}
-		}
-
-		newEnvSlice := []string{}
-		for k, v := range oldEnvMap {
-			newEnvSlice = append(newEnvSlice, fmt.Sprintf("%s=%s", k, v))
-		}
-
-		c.Config.Env = newEnvSlice
+	newEnvSlice, err := mergeEnvSlice(config.Env, c.Config.Env)
+	if err != nil {
+		return err
 	}
+	c.Config.Env = newEnvSlice
 
 	// If container is not running, update container metadata struct is enough,
 	// resources will be updated when the container is started again,

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -287,11 +287,13 @@ func (c *Container) merge(getconfig func() (v1.ImageConfig, error)) error {
 		}
 		c.Config.Entrypoint = config.Entrypoint
 	}
-	if c.Config.Env == nil {
-		c.Config.Env = config.Env
-	} else {
-		c.Config.Env = append(c.Config.Env, config.Env...)
+
+	// ContainerConfig.Env is new, and the ImageConfig.Env is old
+	newEnvSlice, err := mergeEnvSlice(c.Config.Env, config.Env)
+	if err != nil {
+		return err
 	}
+	c.Config.Env = newEnvSlice
 	if c.Config.WorkingDir == "" {
 		c.Config.WorkingDir = config.WorkingDir
 	}

--- a/daemon/mgr/container_utils_test.go
+++ b/daemon/mgr/container_utils_test.go
@@ -187,3 +187,84 @@ func Test_parsePSOutput(t *testing.T) {
 		})
 	}
 }
+
+func Test_mergeEnvSlice(t *testing.T) {
+	type args struct {
+		newEnv []string
+		oldEnv []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "test1",
+			args: args{
+				newEnv: []string{"a=b"},
+				oldEnv: []string{"c=d"},
+			},
+			want:    []string{"c=d", "a=b"},
+			wantErr: false,
+		},
+		{
+			name: "test2",
+			args: args{
+				newEnv: []string{"test=false"},
+				oldEnv: []string{"test=true"},
+			},
+			want:    []string{"test=false"},
+			wantErr: false,
+		},
+		{
+			name: "test3",
+			args: args{
+				newEnv: []string{"wrong-format"},
+				oldEnv: []string{"c=d"},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "test4",
+			args: args{
+				newEnv: []string{},
+				oldEnv: []string{"c=d"},
+			},
+			want:    []string{"c=d"},
+			wantErr: false,
+		},
+		{
+			name: "test5",
+			args: args{
+				newEnv: []string{"a=b"},
+				oldEnv: []string{},
+			},
+			want:    []string{"a=b"},
+			wantErr: false,
+		},
+		{
+			name: "test6",
+			args: args{
+				newEnv: []string{"a="},
+				oldEnv: []string{"a=b"},
+			},
+			want:    []string{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mergeEnvSlice(tt.args.newEnv, tt.args.oldEnv)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mergeEnvSlice() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeEnvSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
We did not parse env params when create a container, just `append` image env to container env slice.  So we will occur errors blow:

we use a test image: `mysql:5.7`, it has env like blow:
```
root@osboxes:pouch (master) -> pouch image inspect registry.hub.docker.com/library/mysql:5.7 | grep -A 6 -B 3 Env
            "Entrypoint": [
                "docker-entrypoint.sh"
            ],
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "GOSU_VERSION=1.7",
                "MYSQL_MAJOR=5.7",
                "MYSQL_VERSION=5.7.23-1debian9"
            ],
```

If we use this image to create a container, and specify an env like `GOSU_VERSION=2.0`, we will get a container like : 
```
root@osboxes:pouch (master) -> pouch run -d -t --name=test -e "GOSU_VERSION=2.0" -e "test=foo" --net=bridge -v /data  registry.hub.docker.com/library/mysql:5.7 top
00b09689623709005d0910793663aabf454ac0c0fa4006a347545b8403fc6061
root@osboxes:pouch (master) -> pouch inspect test | grep -A 6 -B 3 Env
            "Entrypoint": [
                "docker-entrypoint.sh"
            ],
            "Env": [
                "GOSU_VERSION=2.0",
                "test=foo",
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "GOSU_VERSION=1.7",
                "MYSQL_MAJOR=5.7",
                "MYSQL_VERSION=5.7.23-1debian9"
```

we have two env `GOSU_VERSION`, one is `GOSU_VERSION=2.0`, another is `GOSU_VERSION=1.7`


### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Added testcase

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


