### PR TITLE
bugfix: fix failed to run a container with specifying a non-exist workdir

### DIFF
--- a/daemon/mgr/container_exec.go
+++ b/daemon/mgr/container_exec.go
@@ -100,10 +100,15 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, attac
 		return err
 	}
 
+	cwd := c.Config.WorkingDir
+	if cwd == "" {
+		cwd = "/"
+	}
+
 	process := &specs.Process{
 		Args:     execConfig.Cmd,
 		Terminal: execConfig.Tty,
-		Cwd:      "/",
+		Cwd:      cwd,
 		Env:      c.Config.Env,
 		User: specs.User{
 			UID:            uid,

--- a/test/cli_exec_test.go
+++ b/test/cli_exec_test.go
@@ -178,3 +178,20 @@ func (suite *PouchExecSuite) TestExecUser(c *check.C) {
 		c.Fatalf("failed to run a container with expected user: %s, but got %s", "1001", res.Stdout())
 	}
 }
+
+// TestExecWithWorkingDir test working directory of exec process
+func (suite *PouchExecSuite) TestExecWithWorkingDir(c *check.C) {
+	cname := "TestExecWithWorkingDir"
+
+	dir := "/tmp/testworkingdir"
+
+	res := command.PouchRun("run", "-d", "--name", cname, "-w", dir, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
+
+	res = command.PouchRun("exec", cname, "pwd")
+	res.Assert(c, icmd.Success)
+	if !strings.Contains(res.Stdout(), dir) {
+		c.Fatalf("failed to run exec with specified working directory: %s, but got %s", dir, res.Stdout())
+	}
+}

--- a/test/cli_run_working_dir_test.go
+++ b/test/cli_run_working_dir_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// PouchRunWorkingDirSuite is the test suite for run CLI.
+type PouchRunWorkingDirSuite struct{}
+
+func init() {
+	check.Suite(&PouchRunWorkingDirSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each test suite.
+func (suite *PouchRunWorkingDirSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	environment.PruneAllContainers(apiClient)
+
+	PullImage(c, busyboxImage)
+}
+
+// TearDownTest does cleanup work in the end of each test.
+func (suite *PouchRunWorkingDirSuite) TearDownTest(c *check.C) {
+}
+
+// TestRunWithExistWorkingDir is to verify the valid running container
+// with specifying working dir
+func (suite *PouchRunWorkingDirSuite) TestRunWithExistWorkingDir(c *check.C) {
+	SkipIfFalse(c, environment.IsMemorySupport)
+
+	cname := "TestRunWithExistWorkingDir"
+	res := command.PouchRun("run", "-d", "-m", "100m", "-w", "/root", "--name", cname, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
+
+	// test if the value is in inspect result
+	res = command.PouchRun("inspect", cname)
+	res.Assert(c, icmd.Success)
+
+	result := []types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(res.Stdout()), &result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result[0].Config.WorkingDir, check.Equals, "/root")
+}
+
+// TestRunWithNotExistWorkingDir is to verify the valid running container
+// with specifying a not exist working dir
+func (suite *PouchRunWorkingDirSuite) TestRunWithNotExistWorkingDir(c *check.C) {
+	SkipIfFalse(c, environment.IsMemorySupport)
+
+	cname := "TestRunWithNotExistWorkingDir"
+	res := command.PouchRun("run", "-d", "-m", "100m", "-w", "/tmp/notexist/dir", "--name", cname, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
+
+	// test if the value is in inspect result
+	res = command.PouchRun("inspect", cname)
+	res.Assert(c, icmd.Success)
+
+	result := []types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(res.Stdout()), &result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result[0].Config.WorkingDir, check.Equals, "/tmp/notexist/dir")
+}
+
+// TestRunWithWorkingDir is to verify the valid running container
+// with specifying working dir
+func (suite *PouchRunWorkingDirSuite) TestRunWithWorkingDir(c *check.C) {
+	SkipIfFalse(c, environment.IsMemorySupport)
+	dir := "/tmp/testworkingdir"
+
+	cname := "TestRunWithNotExistWorkingDir"
+	res := command.PouchRun("run", "-m", "100m", "-w", dir, "--name", cname, busyboxImage, "pwd")
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
+
+	out := res.Combined()
+	out = strings.TrimSpace(out)
+	if out != dir {
+		c.Errorf("failed to set working directory, expect %s, got %s", dir, out)
+	}
+}
+
+// TestRunWithWorkingDirExistAndIsFile is to verify the valid running container
+// with specifying a exist file as working directory
+func (suite *PouchRunWorkingDirSuite) TestRunWithWorkingDirExistAndIsFile(c *check.C) {
+	SkipIfFalse(c, environment.IsMemorySupport)
+	dir := "/bin/cat"
+
+	cname := "TestRunWithWorkingDirExistAndIsFile"
+	res := command.PouchRun("run", "-m", "100m", "-w", dir, "--name", cname, busyboxImage, "pwd")
+	defer DelContainerForceMultyTime(c, cname)
+	c.Assert(res.Stderr(), check.NotNil)
+
+	expected := "not a directory"
+	if out := res.Combined(); !strings.Contains(out, expected) {
+		c.Errorf("error information unmatched, expect %s, got %s", expected, out)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

Fix a problem that failed to run a container when specifying a not-exist working directory
```
root@osboxes:pouch (zr/fix-workdir-notfound *) -> pouch run -d -t --name=test -e "GOSU_VERSION=2.0" -e "test=foo" --net=bridge -v /data  -w /tmp/ziren registry.hub.docker.com/library/mysql:5.7 top
Error: failed to run container test: {"message":"failed to create container(5e1065ae1b4a3b22914203dd64b1a2fbd305c90b8c6b567366b23b312f0a86dd) on containerd: failed to create task for container(5e1065ae1b4a3b22914203dd64b1a2fbd305c90b8c6b567366b23b312f0a86dd): OCI runtime create failed: container_linux.go:265: starting container process caused \"chdir to cwd (\\\"/tmp/ziren\\\") set in config.json failed: no such file or directory\": unknown"}
```


### Ⅱ. Does this pull request fix one issue?



### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

add `TestRunWithExistWorkingDir` `TestRunWithNotExistWorkingDir`


### Ⅳ. Describe how to verify it

Creating a container specifying a workdir not exist should success
```
 pouch run -d -t --name=test  -v /data  -w /tmp/test/notexist centos top
```

### Ⅴ. Special notes for reviews


