### PR TITLE
bugfix: attach hanging of cri container

### DIFF
--- a/cri/v1alpha1/cri_utils.go
+++ b/cri/v1alpha1/cri_utils.go
@@ -866,6 +866,25 @@ func parseUserFromImageUser(id string) string {
 	return id
 }
 
+func (c *CriManager) attachLog(logPath string, containerID string, openStdin bool) error {
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
+	if err != nil {
+		return fmt.Errorf("failed to create container for opening log file failed: %v", err)
+	}
+	// Attach to the container to get log.
+	attachConfig := &mgr.AttachConfig{
+		Stdin:      openStdin,
+		Stdout:     true,
+		Stderr:     true,
+		CriLogFile: f,
+	}
+	err = c.ContainerMgr.Attach(context.Background(), containerID, attachConfig)
+	if err != nil {
+		return fmt.Errorf("failed to attach to container %q to get its log: %v", containerID, err)
+	}
+	return nil
+}
+
 func (c *CriManager) getContainerMetrics(ctx context.Context, meta *mgr.Container) (*runtime.ContainerStats, error) {
 	var usedBytes, inodesUsed uint64
 

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -563,7 +563,10 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	// Get container log.
 	if config.GetLogPath() != "" {
 		logPath := filepath.Join(sandboxConfig.GetLogDirectory(), config.GetLogPath())
-		err := c.attachLog(logPath, containerID)
+		// NOTE: If we attach log here, the IO of container will be created
+		// by this function first, so we should decide whether open the stdin
+		// here. It's weird actually, make it more elegant in the future.
+		err := c.attachLog(logPath, containerID, config.Stdin)
 		if err != nil {
 			return nil, err
 		}

--- a/cri/v1alpha2/cri_utils.go
+++ b/cri/v1alpha2/cri_utils.go
@@ -866,13 +866,14 @@ func parseUserFromImageUser(id string) string {
 	return id
 }
 
-func (c *CriManager) attachLog(logPath string, containerID string) error {
+func (c *CriManager) attachLog(logPath string, containerID string, openStdin bool) error {
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
 	if err != nil {
 		return fmt.Errorf("failed to create container for opening log file failed: %v", err)
 	}
 	// Attach to the container to get log.
 	attachConfig := &mgr.AttachConfig{
+		Stdin:      openStdin,
 		Stdout:     true,
 		Stderr:     true,
 		CriLogFile: f,


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

If we want to get the log of cri container, the step as follows:

1. create container

2. attach to the io of the container

3. start the container

Then the IO of the container will be created in step 2

So we should decide whether open the Stdin of Container IO, otherwise it will never be opened

which will result the hanging of attach


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


