### PR TITLE
bugfix: cannot get restartCount and let restartCount++ after restart container

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -74,14 +74,15 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 	}
 
 	container := types.ContainerJSON{
-		ID:          c.ID,
-		Name:        c.Name,
-		Image:       c.Config.Image,
-		Created:     c.Created,
-		State:       c.State,
-		Config:      c.Config,
-		HostConfig:  c.HostConfig,
-		Snapshotter: c.Snapshotter,
+		ID:           c.ID,
+		Name:         c.Name,
+		Image:        c.Config.Image,
+		Created:      c.Created,
+		State:        c.State,
+		Config:       c.Config,
+		HostConfig:   c.HostConfig,
+		Snapshotter:  c.Snapshotter,
+		RestartCount: c.RestartCount,
 		GraphDriver: &types.GraphDriverData{
 			Name: c.Snapshotter.Name,
 			Data: c.Snapshotter.Data,

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -796,8 +796,20 @@ func (mgr *ContainerManager) Restart(ctx context.Context, name string, timeout i
 	}
 
 	logrus.Debugf("start container %s when restarting", c.ID)
+
+	//let restartCount++
+	restartCount := c.RestartCount + 1
+
 	// start container
-	return mgr.start(ctx, c, &types.ContainerStartOptions{})
+	err = mgr.start(ctx, c, &types.ContainerStartOptions{})
+	if err != nil {
+		return err
+	}
+
+	c.RestartCount = restartCount
+
+	logrus.Debugf("container %s restartCount is %d", c.ID, c.RestartCount)
+	return c.Write(mgr.Store)
 }
 
 // Pause pauses a running container.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
pouch inspect -f {{.RestartCount}} can't get corrent restartCount.Add one line code to fix it.
the restartCount will not change after manually restart a container, this pr fix it

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
1. when pouch inspect a container, we will get the restartCount of this container.
2. after restart a container, the restartCount++.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


