### PR TITLE
bugfix: can't quota on disk quota

### DIFF
--- a/storage/quota/grpquota.go
+++ b/storage/quota/grpquota.go
@@ -175,6 +175,11 @@ func (quota *GrpQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 		return "", false, ""
 	}
 
+	var (
+		mountPoint string
+		fsType     string
+	)
+
 	// Two formats of group quota.
 	// /dev/sdb1 /home/pouch ext4 rw,relatime,prjquota,data=ordered 0 0
 	// /dev/sda1 /home/pouch ext4 rw,relatime,data=ordered,jqfmt=vfsv0,grpjquota=aquota.group 0 0
@@ -184,20 +189,22 @@ func (quota *GrpQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 			continue
 		}
 
-		mountPoint := parts[1]
-		fsType := parts[2]
-
-		devID2, _ := system.GetDevID(mountPoint)
+		devID2, _ := system.GetDevID(parts[1])
 		if devID != devID2 {
 			continue
 		}
 
+		// get device's mountpoint and fs type.
+		mountPoint = parts[1]
+		fsType = parts[2]
+
+		// check the device turn on the prpquota or not.
 		if strings.Contains(parts[3], "grpquota") || strings.Contains(parts[3], "grpjquota") {
 			return mountPoint, true, fsType
 		}
 	}
 
-	return "", false, ""
+	return mountPoint, false, fsType
 }
 
 // SetDiskQuota is used to set quota for directory.

--- a/storage/quota/prjquota.go
+++ b/storage/quota/prjquota.go
@@ -185,6 +185,11 @@ func (quota *PrjQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 		return "", false, ""
 	}
 
+	var (
+		mountPoint string
+		fsType     string
+	)
+
 	// /dev/sdb1 /home/pouch ext4 rw,relatime,prjquota,data=ordered 0 0
 	for _, line := range strings.Split(string(output), "\n") {
 		parts := strings.Split(line, " ")
@@ -192,14 +197,16 @@ func (quota *PrjQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 			continue
 		}
 
-		mountPoint := parts[1]
-		fsType := parts[2]
-
-		devID2, _ := system.GetDevID(mountPoint)
+		devID2, _ := system.GetDevID(parts[1])
 		if devID != devID2 {
 			continue
 		}
 
+		// get device's mountpoint and fs type.
+		mountPoint = parts[1]
+		fsType = parts[2]
+
+		// check the device turn on the prjquota or not.
 		for _, value := range strings.Split(parts[3], ",") {
 			if value == "prjquota" {
 				return mountPoint, true, fsType
@@ -207,7 +214,7 @@ func (quota *PrjQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 		}
 	}
 
-	return "", false, ""
+	return mountPoint, false, fsType
 }
 
 // setQuota uses system tool "setquota" to set project quota for binding of limit and mountpoint and quotaID.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Can't quota on diskquota when mount file system without diskquota.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Sorry, it's hard to add integration test, you can test it as below.

### Ⅳ. Describe how to verify it
1. we just test prjquota on ubuntu 17.10

2. set your graph directory mount without prjquota/grpquota.
```
mount /dev/sdb /data
```

3. start pouchd and config graph directory in /etc/pouch/config.json
```
{
    "home-dir": "/data/pouch"
}
```

4. run container with disk quota is 5g
```
pouch run --rm --disk-quota 5g --name test -ti registry.hub.docker.com/library/fedora:latest df -h
```

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
