### PR TITLE
feature: add cgroupfs in Info API

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -20,6 +20,11 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const (
+	// CgroupfsDriverType refers to daemon's cgroup driver.
+	CgroupfsDriverType = "cgroupfs"
+)
+
 // Config refers to daemon's whole configurations.
 type Config struct {
 	sync.Mutex `json:"-"`
@@ -114,6 +119,14 @@ type Config struct {
 
 	// DefaultNamespace is passed to containerd.
 	DefaultNamespace string `json:"default-namespace,omitempty"`
+}
+
+// GetCgroupDriver gets cgroup driver used in runc.
+func (cfg *Config) GetCgroupDriver() string {
+	// current pouchd only supports directly managing cgroupfs.
+	// TODO: add 'systemd' to make systemd manage cgroupfs rather than directly using it.
+	// In the future we will support this config in the daemon configuration.
+	return CgroupfsDriverType
 }
 
 // Validate validates the user input config.

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -130,6 +130,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		HTTPProxy:         mgr.config.ImageProxy,
 		// HTTPSProxy: ,
 		// ID: ,
+		CgroupDriver:       mgr.config.GetCgroupDriver(),
 		Images:             int64(len(images)),
 		IndexServerAddress: "https://index.docker.io/v1/",
 		DefaultRegistry:    mgr.config.DefaultRegistry,

--- a/test/api_system_test.go
+++ b/test/api_system_test.go
@@ -55,6 +55,7 @@ func (suite *APISystemSuite) TestInfo(c *check.C) {
 	c.Assert(got.Driver, check.Equals, "overlayfs")
 	c.Assert(got.NCPU, check.Equals, int64(runtime.NumCPU()))
 	c.Assert(got.CriEnabled, check.Equals, false)
+	c.Assert(got.CgroupDriver, check.Equals, "cgroupfs")
 
 	// Check the volume drivers
 	c.Assert(len(got.VolumeDrivers), check.Equals, 3)


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add cgroupfs in Info API.

current pouchd only supports directly managing cgroupfs. In the future we will support this config in the daemon configuration.

TODO: add 'systemd' to make systemd manage cgroupfs rather than directly using it.
	

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix https://github.com/alibaba/pouch/issues/2143


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added in integraion test.


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

