### PR TITLE
bugfix: avoid data race in set exec exit status

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -122,14 +122,13 @@ func (c *Client) execContainer(ctx context.Context, process *Process) error {
 			exitTime: status.ExitTime(),
 		}
 
-		if err := <-fail; err != nil {
-			msg.err = err
-		}
-
-		for _, hook := range c.hooks {
-			if err := hook(process.ExecID, msg); err != nil {
-				logrus.Errorf("failed to execute the exec exit hooks: %v", err)
-				break
+		// run hook if not got fail here
+		if err := <-fail; err == nil {
+			for _, hook := range c.hooks {
+				if err := hook(process.ExecID, msg); err != nil {
+					logrus.Errorf("failed to execute the exec exit hooks: %v", err)
+					break
+				}
 			}
 		}
 

--- a/daemon/mgr/container_exec.go
+++ b/daemon/mgr/container_exec.go
@@ -77,7 +77,6 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, attac
 			exitCode := 126
 			execConfig.ExitCode = int64(exitCode)
 		}
-		mgr.ExecProcesses.Put(execid, execConfig)
 	}()
 
 	if attach != nil {


### PR DESCRIPTION
there are two goroutines response for changed exec config information,
if exec process got error, data race appears, exec exit hook runs in a
goroutine, it modify exec exit status, StartExec also modify exec exit
status in another goroutine since error happend. Fix it by only one
place can modify exec exit status.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


