### PR TITLE
bugfix: make the output of some list operations optional

### DIFF
--- a/cri/v1alpha1/cri.go
+++ b/cri/v1alpha1/cri.go
@@ -621,7 +621,7 @@ func (c *CriManager) ListContainers(ctx context.Context, r *runtime.ListContaine
 	for _, c := range containerList {
 		container, err := toCriContainer(c)
 		if err != nil {
-			// TODO: log an error message?
+			logrus.Warnf("failed to translate container %v to cri container in ListContainers: %v", c.ID, err)
 			continue
 		}
 		containers = append(containers, container)

--- a/cri/v1alpha1/cri_wrapper.go
+++ b/cri/v1alpha1/cri_wrapper.go
@@ -31,12 +31,12 @@ func (c *CriWrapper) StreamServerStart() (err error) {
 
 // Version returns the runtime name, runtime version and runtime API version.
 func (c *CriWrapper) Version(ctx context.Context, r *runtime.VersionRequest) (res *runtime.VersionResponse, err error) {
-	logrus.Infof("Version shows the basic information of cri Manager")
+	logrus.Debugf("Version shows the basic information of cri Manager")
 	defer func() {
 		if err != nil {
 			logrus.Errorf("failed to get version: %v", err)
 		} else {
-			logrus.Infof("success to get version")
+			logrus.Debugf("success to get version")
 		}
 	}()
 	return c.CriManager.Version(ctx, r)
@@ -100,13 +100,13 @@ func (c *CriWrapper) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 
 // ListPodSandbox returns a list of Sandbox.
 func (c *CriWrapper) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (res *runtime.ListPodSandboxResponse, err error) {
-	logrus.Infof("ListPodSandbox with filter %+v", r.GetFilter())
+	logrus.Debugf("ListPodSandbox with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
 			logrus.Errorf("failed to ListPodSandbox: %v", err)
 		} else {
 			// NOTE: maybe log detailed sandbox items with higher log level.
-			logrus.Infof("success to ListPodSandbox: %+v", res.Items)
+			logrus.Debugf("success to ListPodSandbox: %+v", res.Items)
 		}
 	}()
 	return c.CriManager.ListPodSandbox(ctx, r)
@@ -170,13 +170,13 @@ func (c *CriWrapper) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 
 // ListContainers lists all containers matching the filter.
 func (c *CriWrapper) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (res *runtime.ListContainersResponse, err error) {
-	logrus.Infof("ListContainers with filter %+v", r.GetFilter())
+	logrus.Debugf("ListContainers with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
 			logrus.Errorf("failed to list containers with filter %+v: %v", r.GetFilter(), err)
 		} else {
 			// NOTE: maybe log detailed container items with higher log level.
-			logrus.Infof("success to list containers with filter: %+v", r.GetFilter())
+			logrus.Debugf("success to list containers with filter: %+v", r.GetFilter())
 		}
 	}()
 	return c.CriManager.ListContainers(ctx, r)
@@ -211,12 +211,12 @@ func (c *CriWrapper) ContainerStats(ctx context.Context, r *runtime.ContainerSta
 
 // ListContainerStats returns stats of all running containers.
 func (c *CriWrapper) ListContainerStats(ctx context.Context, r *runtime.ListContainerStatsRequest) (res *runtime.ListContainerStatsResponse, err error) {
-	logrus.Infof("ListContainerStats with filter %+v", r.GetFilter())
+	logrus.Debugf("ListContainerStats with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
 			logrus.Errorf("failed to get ListContainerStats: %v", err)
 		} else {
-			logrus.Infof("success to get ListContainerStats: %+v", res.GetStats())
+			logrus.Debugf("success to get ListContainerStats: %+v", res.GetStats())
 		}
 	}()
 	return c.CriManager.ListContainerStats(ctx, r)
@@ -317,13 +317,13 @@ func (c *CriWrapper) Status(ctx context.Context, r *runtime.StatusRequest) (res 
 
 // ListImages lists existing images.
 func (c *CriWrapper) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (res *runtime.ListImagesResponse, err error) {
-	logrus.Infof("ListImages with filter %+v", r.GetFilter())
+	logrus.Debugf("ListImages with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
 			logrus.Errorf("failed to list images with filter %+v: %v", r.GetFilter(), err)
 		} else {
 			// NOTE: maybe log detailed image items with higher log level.
-			logrus.Infof("success to list images with filter: %+v", r.GetFilter())
+			logrus.Debugf("success to list images with filter: %+v", r.GetFilter())
 		}
 	}()
 	return c.CriManager.ListImages(ctx, r)

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -636,7 +636,7 @@ func (c *CriManager) ListContainers(ctx context.Context, r *runtime.ListContaine
 	for _, c := range containerList {
 		container, err := toCriContainer(c)
 		if err != nil {
-			// TODO: log an error message?
+			logrus.Warnf("failed to translate container %v to cri container in ListContainers: %v", c.ID, err)
 			continue
 		}
 		containers = append(containers, container)
@@ -814,7 +814,7 @@ func (c *CriManager) ListContainerStats(ctx context.Context, r *runtime.ListCont
 	for _, container := range containers {
 		cs, err := c.getContainerMetrics(ctx, container)
 		if err != nil {
-			logrus.Errorf("failed to decode metrics of container %q: %v", container.ID, err)
+			logrus.Warnf("failed to decode metrics of container %q: %v", container.ID, err)
 			continue
 		}
 

--- a/cri/v1alpha2/cri_wrapper.go
+++ b/cri/v1alpha2/cri_wrapper.go
@@ -20,24 +20,22 @@ func NewCriWrapper(c *CriManager) *CriWrapper {
 // StreamServerStart starts the stream server of CRI.
 func (c *CriWrapper) StreamServerStart() (err error) {
 	logrus.Infof("StreamServerStart starts stream server of cri manager")
-	defer func() {
-		if err != nil {
-			logrus.Errorf("failed to start StreamServer: %v", err)
-		} else {
-			logrus.Infof("success to start StreamServer of cri manager")
-		}
-	}()
+	if err != nil {
+		logrus.Errorf("failed to start StreamServer: %v", err)
+	} else {
+		logrus.Infof("success to start StreamServer of cri manager")
+	}
 	return c.CriManager.StreamServerStart()
 }
 
 // Version returns the runtime name, runtime version and runtime API version.
 func (c *CriWrapper) Version(ctx context.Context, r *runtime.VersionRequest) (res *runtime.VersionResponse, err error) {
-	logrus.Infof("Version shows the basic information of cri Manager")
+	logrus.Debugf("Version shows the basic information of cri Manager")
 	defer func() {
 		if err != nil {
 			logrus.Errorf("failed to get version: %v", err)
 		} else {
-			logrus.Infof("success to get version")
+			logrus.Debugf("success to get version")
 		}
 	}()
 	return c.CriManager.Version(ctx, r)
@@ -101,13 +99,13 @@ func (c *CriWrapper) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 
 // ListPodSandbox returns a list of Sandbox.
 func (c *CriWrapper) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (res *runtime.ListPodSandboxResponse, err error) {
-	logrus.Infof("ListPodSandbox with filter %+v", r.GetFilter())
+	logrus.Debugf("ListPodSandbox with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
 			logrus.Errorf("failed to ListPodSandbox: %v", err)
 		} else {
 			// NOTE: maybe log detailed sandbox items with higher log level.
-			logrus.Infof("success to ListPodSandbox: %+v", res.Items)
+			logrus.Debugf("success to ListPodSandbox: %+v", res.Items)
 		}
 	}()
 	return c.CriManager.ListPodSandbox(ctx, r)
@@ -171,13 +169,13 @@ func (c *CriWrapper) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 
 // ListContainers lists all containers matching the filter.
 func (c *CriWrapper) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (res *runtime.ListContainersResponse, err error) {
-	logrus.Infof("ListContainers with filter %+v", r.GetFilter())
+	logrus.Debugf("ListContainers with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
 			logrus.Errorf("failed to list containers with filter %+v: %v", r.GetFilter(), err)
 		} else {
 			// NOTE: maybe log detailed container items with higher log level.
-			logrus.Infof("success to list containers with filter: %+v", r.GetFilter())
+			logrus.Debugf("success to list containers with filter: %+v", r.GetFilter())
 		}
 	}()
 	return c.CriManager.ListContainers(ctx, r)
@@ -188,7 +186,7 @@ func (c *CriWrapper) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 	logrus.Infof("ContainerStatus for %q", r.GetContainerId())
 	defer func() {
 		if err != nil {
-			logrus.Errorf("failed to get ContainerStatus: %q, %v", r.GetContainerId(), err)
+			logrus.Warnf("failed to get ContainerStatus: %q, %v", r.GetContainerId(), err)
 		} else {
 			logrus.Infof("success to get ContainerStatus: %q, %+v", r.GetContainerId(), res.GetStatus())
 		}
@@ -212,12 +210,12 @@ func (c *CriWrapper) ContainerStats(ctx context.Context, r *runtime.ContainerSta
 
 // ListContainerStats returns stats of all running containers.
 func (c *CriWrapper) ListContainerStats(ctx context.Context, r *runtime.ListContainerStatsRequest) (res *runtime.ListContainerStatsResponse, err error) {
-	logrus.Infof("ListContainerStats with filter %+v", r.GetFilter())
+	logrus.Debugf("ListContainerStats with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
 			logrus.Errorf("failed to get ListContainerStats: %v", err)
 		} else {
-			logrus.Infof("success to get ListContainerStats: %+v", res.GetStats())
+			logrus.Debugf("success to get ListContainerStats: %+v", res.GetStats())
 		}
 	}()
 	return c.CriManager.ListContainerStats(ctx, r)
@@ -335,13 +333,13 @@ func (c *CriWrapper) Status(ctx context.Context, r *runtime.StatusRequest) (res 
 
 // ListImages lists existing images.
 func (c *CriWrapper) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (res *runtime.ListImagesResponse, err error) {
-	logrus.Infof("ListImages with filter %+v", r.GetFilter())
+	logrus.Debugf("ListImages with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
 			logrus.Errorf("failed to list images with filter %+v: %v", r.GetFilter(), err)
 		} else {
 			// NOTE: maybe log detailed image items with higher log level.
-			logrus.Infof("success to list images with filter: %+v", r.GetFilter())
+			logrus.Debugf("success to list images with filter: %+v", r.GetFilter())
 		}
 	}()
 	return c.CriManager.ListImages(ctx, r)


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

1
Kubelet will try to do list (sandbox, container, etc) operations every seconds,

So pouch will output so many logs corresponding to the list operations

which is usually verbose and useless

So this PR make pouch only output the log of list operations when in debug mode.

2
Also change some error log to warning log which make pouch work well in Alibaba

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

No

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


