### PR TITLE
config: remove check unknow flag in config file

### DIFF
--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIterateConfig(t *testing.T) {
+func TestFlattenConfig(t *testing.T) {
 	assert := assert.New(t)
 	origin := map[string]interface{}{
 		"a": "a",
@@ -26,22 +26,24 @@ func TestIterateConfig(t *testing.T) {
 	}
 
 	expect := map[string]interface{}{
-		"a":    "a",
-		"b":    "b",
-		"c":    "c",
-		"i1":   "i1",
-		"i2":   "i2",
-		"iii1": "iii1",
-		"iii2": "iii2",
+		"a":  "a",
+		"b":  "b",
+		"c":  "c",
+		"i1": "i1",
+		"i2": "i2",
+		"ii1": map[string]interface{}{
+			"iii1": "iii1",
+			"iii2": "iii2",
+		},
 	}
 
 	config := make(map[string]interface{})
-	iterateConfig(origin, config)
+	flattenConfig(origin, config)
 	assert.Equal(config, expect)
 
 	// test nil map will not cause panic
 	config = make(map[string]interface{})
-	iterateConfig(nil, config)
+	flattenConfig(nil, config)
 	assert.Equal(config, map[string]interface{}{})
 }
 
@@ -77,47 +79,4 @@ func TestGetConflictConfigurations(t *testing.T) {
 	flags.Parse([]string{"--a=a1"})
 	assert.Equal("found conflict flags in command line and config file: from flag: a1 and from config file: a1",
 		getConflictConfigurations(flags, fileflags).Error())
-}
-
-func TestGetUnknownFlags(t *testing.T) {
-
-	flagSet := new(pflag.FlagSet)
-	flagSet.String("a", "a", "a")
-	flagSet.Bool("b", false, "b")
-	flagSet.Int("c", -500, "c")
-
-	flagSetNil := new(pflag.FlagSet)
-
-	assert := assert.New(t)
-
-	fileFlagsKnown := map[string]interface{}{
-		"a": "a",
-		"b": true,
-	}
-
-	fileFlagsUnknown := map[string]interface{}{
-		"c": 100,
-		"d": "d",
-	}
-
-	fileFlagsNil := map[string]interface{}{}
-
-	error := getUnknownFlags(flagSet, fileFlagsKnown)
-	assert.Equal(error, nil)
-
-	error = getUnknownFlags(flagSet, fileFlagsUnknown)
-	assert.NotNil(error)
-
-	error = getUnknownFlags(flagSet, fileFlagsNil)
-	assert.Equal(error, nil)
-
-	error = getUnknownFlags(flagSetNil, fileFlagsUnknown)
-	assert.NotNil(error)
-
-	error = getUnknownFlags(flagSetNil, fileFlagsKnown)
-	assert.NotNil(error)
-
-	error = getUnknownFlags(flagSetNil, fileFlagsNil)
-	assert.Equal(error, nil)
-
 }

--- a/test/z_cli_daemon_test.go
+++ b/test/z_cli_daemon_test.go
@@ -182,23 +182,6 @@ func (suite *PouchDaemonSuite) TestDaemonSliceFlagNotConflict(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-// TestDaemonConfigFileUnknownFlag tests start daemon with unknown flags in configure file.
-func (suite *PouchDaemonSuite) TestDaemonConfigFileUnknownFlag(c *check.C) {
-	path := "/tmp/pouch.json"
-	cfg := struct {
-		Adsj string `json:"adsj"`
-	}{
-		Adsj: "xxx",
-	}
-	err := CreateConfigFile(path, cfg)
-	c.Assert(err, check.IsNil)
-	defer os.Remove(path)
-
-	dcfg, err := StartDefaultDaemon("--debug", "--config-file="+path)
-	c.Assert(err, check.NotNil)
-	dcfg.KillDaemon()
-}
-
 // TestDaemonConfigFileAndCli tests start daemon with configure file and CLI .
 func (suite *PouchDaemonSuite) TestDaemonConfigFileAndCli(c *check.C) {
 	// Check default configure file could work


### PR DESCRIPTION
1. daemon config come from two part, one is command flag, the other
is from config file, but the flags from two part can not keep
consistent，so remove unknow flags check.
2. flatten 'key-value' in config file, check flags conflict between
command line and file.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


