### PR TITLE
bugfix: Fix that cannot update bridge when restart pouchd

### DIFF
--- a/network/mode/bridge/bridge.go
+++ b/network/mode/bridge/bridge.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alibaba/pouch/daemon/mgr"
 	"github.com/alibaba/pouch/network"
 	"github.com/alibaba/pouch/pkg/errtypes"
+	"github.com/alibaba/pouch/pkg/utils"
 
 	"github.com/docker/libnetwork/drivers/bridge"
 	"github.com/docker/libnetwork/netlabel"
@@ -30,55 +31,39 @@ func New(ctx context.Context, config network.BridgeConfig, manager mgr.NetworkMg
 		}
 	}
 
-	// set bridge name
+	// get bridge name
 	bridgeName := DefaultBridge
 	if config.Name != "" {
 		bridgeName = config.Name
 	}
 
+	// get bridge ip
+	bridgeIP := utils.StringDefault(config.IP, DefaultIPNet)
+	ipNet, err := netlink.ParseIPNet(bridgeIP)
+	if err != nil {
+		return fmt.Errorf("failed to parse ip %v", bridgeIP)
+	}
+	logrus.Debugf("initialize bridge network, bridge ip: %s.", ipNet)
+
 	// init host bridge network.
-	br, err := initBridgeDevice(bridgeName)
+	_, err = initBridgeDevice(bridgeName, ipNet)
 	if err != nil {
 		return err
 	}
 
-	var (
-		bridgeIPv4Address string
-	)
-	Addrs, err := netlink.AddrList(br, netlink.FAMILY_V4)
+	// get bridge subnet
+	_, subnet, err := net.ParseCIDR(bridgeIP)
 	if err != nil {
-		return errors.Wrap(err, "failed to get bridge addr")
+		return fmt.Errorf("failted to parse subnet %v", bridgeIP)
 	}
-	for _, addr := range Addrs {
-		cidr := addr.String()
-		if strings.Contains(cidr, ":") {
-			continue
-		}
-
-		parts := strings.Split(cidr, " ")
-		if len(parts) != 2 {
-			continue
-		}
-
-		bridgeIPv4Address = parts[0]
-		break
-	}
-
-	// get subnet
-	subnet := DefaultSubnet
-	if config.IP != "" {
-		subnet = config.IP
-	} else if bridgeIPv4Address != "" {
-		subnet = bridgeIPv4Address
-	}
-	logrus.Debugf("initialize bridge network, subnet: %s", subnet)
+	logrus.Debugf("initialize bridge network, bridge network: %s", subnet)
 
 	// get ip range
 	ipRange := DefaultIPRange
 	if config.FixedCIDR != "" {
 		ipRange = config.FixedCIDR
 	} else {
-		ipRange = subnet
+		ipRange = subnet.String()
 	}
 	logrus.Debugf("initialize bridge network, bridge ip range in subnet: %s", ipRange)
 
@@ -86,30 +71,12 @@ func New(ctx context.Context, config network.BridgeConfig, manager mgr.NetworkMg
 	gateway := DefaultGateway
 	if config.GatewayIPv4 != "" {
 		gateway = config.GatewayIPv4
-	} else {
-		// get the default route set as gateway.
-		routes, err := netlink.RouteList(br, netlink.FAMILY_V4)
-		if err != nil {
-			return errors.Wrap(err, "failed to get route list")
-		}
-		for _, route := range routes {
-			gw := route.Gw.String()
-			if gw != "" && gw != "<nil>" {
-				gateway = gw
-				break
-			}
-		}
-
-		// nat mode bridge have no default route, so let the bridge ip as gateway.
-		if bridgeIPv4Address != "" {
-			gateway = strings.Split(bridgeIPv4Address, "/")[0]
-		}
 	}
 	logrus.Debugf("initialize bridge network, gateway: %s", gateway)
 
 	ipamV4Conf := types.IPAMConfig{
 		AuxAddress: make(map[string]string),
-		Subnet:     subnet,
+		Subnet:     subnet.String(),
 		IPRange:    ipRange,
 		Gateway:    gateway,
 	}
@@ -148,15 +115,49 @@ func New(ctx context.Context, config network.BridgeConfig, manager mgr.NetworkMg
 	return err
 }
 
-func initBridgeDevice(name string) (netlink.Link, error) {
+func containIP(ip net.IPNet, br netlink.Link) bool {
+	addrs, err := netlink.AddrList(br, netlink.FAMILY_V4)
+	if err == nil {
+		for _, addr := range addrs {
+			if ip.IP.Equal(addr.IP) {
+				sizea, _ := ip.Mask.Size()
+				sizeb, _ := addr.Mask.Size()
+				if sizea == sizeb {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func existVethPair(br netlink.Link) bool {
+	allLinks, err := netlink.LinkList()
+	if err == nil {
+		for _, l := range allLinks {
+			if l.Type() == "veth" && l.Attrs().MasterIndex == br.Attrs().Index {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func initBridgeDevice(name string, ipNet *net.IPNet) (netlink.Link, error) {
 	br, err := netlink.LinkByName(name)
 	if err == nil && br != nil {
-		return br, nil
+		if containIP(*ipNet, br) { // do nothing if ip exists
+			return br, nil
+		}
+		if existVethPair(br) {
+			return nil, fmt.Errorf("failed to remove old bridge device due to existing veth pair")
+		}
+		netlink.LinkDel(br)
 	}
 
 	// generate mac address for bridge.
 	var ip []int
-	for _, v := range strings.Split(DefaultBridgeIP, ".") {
+	for _, v := range strings.Split(ipNet.IP.String(), ".") {
 		tmp, _ := strconv.Atoi(v)
 		ip = append(ip, tmp)
 	}
@@ -184,7 +185,7 @@ func initBridgeDevice(name string) (netlink.Link, error) {
 		}
 	}()
 
-	addr, err := netlink.ParseAddr(DefaultSubnet)
+	addr, err := netlink.ParseAddr(ipNet.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse ip address")
 	}

--- a/network/mode/bridge/vars.go
+++ b/network/mode/bridge/vars.go
@@ -4,11 +4,8 @@ const (
 	// DefaultBridge defines the default bridge name.
 	DefaultBridge = "p0"
 
-	// DefaultBridgeIP defines the default bridge ip.
-	DefaultBridgeIP = "192.168.5.1"
-
-	// DefaultSubnet defines the default bridge subnet.
-	DefaultSubnet = "192.168.5.1/24"
+	// DefaultIPNet defines the default bridge ip.
+	DefaultIPNet = "192.168.5.1/24"
 
 	// DefaultIPRange defines the default bridge ip range in ipam.
 	DefaultIPRange = "192.168.5.1/24"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -351,3 +351,11 @@ func MergeMap(m1 map[string]interface{}, m2 map[string]interface{}) (map[string]
 
 	return m1, nil
 }
+
+// StringDefault return default value if s is empty, otherwise return s.
+func StringDefault(s string, val string) string {
+	if s != "" {
+		return s
+	}
+	return val
+}


### PR DESCRIPTION
Signed-off-by: xiaoxubeii xiaoxubeii@gmail.com

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Fix that cannot update host bridge when restart pouchd daemon

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2128.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
YES.

### Ⅳ. Describe how to verify it

```
$ systemctl start pouch
$ ip a show p0
119: p0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN
    link/ether 02:42:c0:a8:05:01 brd ff:ff:ff:ff:ff:ff
    inet 192.168.5.1/24 brd 192.168.5.255 scope global p0
       valid_lft forever preferred_lft forever
    inet6 fe80::42:c0ff:fea8:501/64 scope link
       valid_lft forever preferred_lft forever

$ cat  <<EOF > /etc/pouch/config.json
{
  "network-config": {
    "bridge-config": {
      "bridge-name": "p0",
      "bip": "172.20.0.1/24",
      "mtu": 1500,
      "default-gateway": "172.20.0.1"
    }
  }
}
EOF

$ system restart pouch && ip a show p0
120: p0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN
    link/ether 02:42:ac:14:00:01 brd ff:ff:ff:ff:ff:ff
    inet 172.20.0.1/24 brd 172.20.0.255 scope global p0
       valid_lft forever preferred_lft forever
    inet6 fe80::42:acff:fe14:1/64 scope link
       valid_lft forever preferred_lft forever
```
### Ⅴ. Special notes for reviews
NONE.

