### PR TITLE
bugfix: make container create request validation more strict with no …

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2108,11 +2108,13 @@ definitions:
         type: "array"
         items:
           type: "string"
+        uniqueItems: true
       Cmd:
         description: "Command to run specified an array of strings."
         type: "array"
         items:
           type: "string"
+        uniqueItems: false
       ArgsEscaped:
         description: "Command is already escaped (Windows only)"
         type: "boolean"
@@ -2139,6 +2141,7 @@ definitions:
         type: "array"
         items:
           type: "string"
+        uniqueItems: false
       NetworkDisabled:
         description: "Disable networking for the container."
         type: "boolean"
@@ -2169,6 +2172,7 @@ definitions:
         type: "array"
         items:
           type: "string"
+        uniqueItems: false
       Rich:
         type: "boolean"
         description: "Whether to start container in rich container mode. (default false)"
@@ -2280,37 +2284,44 @@ definitions:
             description: "A list of kernel capabilities to add to the container."
             items:
               type: "string"
+            uniqueItems: true
           CapDrop:
             type: "array"
             description: "A list of kernel capabilities to drop from the container."
             items:
               type: "string"
+            uniqueItems: true
           Dns:
             type: "array"
             description: "A list of DNS servers for the container to use."
             items:
               type: "string"
+            uniqueItems: true
           DnsOptions:
             type: "array"
             description: "A list of DNS options."
             items:
               type: "string"
+            uniqueItems: true
           DnsSearch:
             type: "array"
             description: "A list of DNS search domains."
             items:
               type: "string"
+            uniqueItems: true
           ExtraHosts:
             type: "array"
             description: |
               A list of hostnames/IP mappings to add to the container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
             items:
               type: "string"
+            uniqueItems: true
           GroupAdd:
             type: "array"
             description: "A list of additional groups that the container process will run as."
             items:
               type: "string"
+            uniqueItems: true
           IpcMode:
             type: "string"
             description: |
@@ -2360,12 +2371,14 @@ definitions:
             description: "A list of string values to customize labels for MLS systems, such as SELinux."
             items:
               type: "string"
+            uniqueItems: true
           StorageOpt:
             type: "object"
             description: |
               Storage driver options for this container, in the form `{"size": "120G"}`.
             additionalProperties:
               type: "string"
+            uniqueItems: true
           Tmpfs:
             type: "object"
             description: |

--- a/apis/types/container_config.go
+++ b/apis/types/container_config.go
@@ -56,6 +56,7 @@ type ContainerConfig struct {
 
 	// A list of environment variables to set inside the container in the form `["VAR=value", ...]`. A variable without `=` is removed from the environment, rather than to have an empty value.
 	//
+	// Unique: true
 	Env []string `json:"Env"`
 
 	// An object mapping ports to an empty object in the form:`{<port>/<tcp|udp>: {}}`
@@ -276,6 +277,10 @@ func (m *ContainerConfig) validateEnv(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Env) { // not required
 		return nil
+	}
+
+	if err := validate.UniqueItems("Env", "body", m.Env); err != nil {
+		return err
 	}
 
 	return nil

--- a/apis/types/host_config.go
+++ b/apis/types/host_config.go
@@ -34,9 +34,11 @@ type HostConfig struct {
 	Binds []string `json:"Binds"`
 
 	// A list of kernel capabilities to add to the container.
+	// Unique: true
 	CapAdd []string `json:"CapAdd"`
 
 	// A list of kernel capabilities to drop from the container.
+	// Unique: true
 	CapDrop []string `json:"CapDrop"`
 
 	// Cgroup to use for the container.
@@ -51,12 +53,15 @@ type HostConfig struct {
 	ContainerIDFile string `json:"ContainerIDFile,omitempty"`
 
 	// A list of DNS servers for the container to use.
+	// Unique: true
 	DNS []string `json:"Dns"`
 
 	// A list of DNS options.
+	// Unique: true
 	DNSOptions []string `json:"DnsOptions"`
 
 	// A list of DNS search domains.
+	// Unique: true
 	DNSSearch []string `json:"DnsSearch"`
 
 	// Whether to enable lxcfs.
@@ -64,9 +69,11 @@ type HostConfig struct {
 
 	// A list of hostnames/IP mappings to add to the container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
 	//
+	// Unique: true
 	ExtraHosts []string `json:"ExtraHosts"`
 
 	// A list of additional groups that the container process will run as.
+	// Unique: true
 	GroupAdd []string `json:"GroupAdd"`
 
 	// Initial script executed in container. The script will be executed before entrypoint or command
@@ -133,6 +140,7 @@ type HostConfig struct {
 	Runtime string `json:"Runtime,omitempty"`
 
 	// A list of string values to customize labels for MLS systems, such as SELinux.
+	// Unique: true
 	SecurityOpt []string `json:"SecurityOpt"`
 
 	// Size of `/dev/shm` in bytes. If omitted, the system uses 64MB.
@@ -141,6 +149,7 @@ type HostConfig struct {
 
 	// Storage driver options for this container, in the form `{"size": "120G"}`.
 	//
+	// Unique: true
 	StorageOpt map[string]string `json:"StorageOpt,omitempty"`
 
 	// A list of kernel parameters (sysctls) to set in the container. For example: `{"net.ipv4.ip_forward": "1"}`
@@ -580,6 +589,10 @@ func (m *HostConfig) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateStorageOpt(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateVolumesFrom(formats); err != nil {
 		res = append(res, err)
 	}
@@ -609,6 +622,10 @@ func (m *HostConfig) validateCapAdd(formats strfmt.Registry) error {
 		return nil
 	}
 
+	if err := validate.UniqueItems("CapAdd", "body", m.CapAdd); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -616,6 +633,10 @@ func (m *HostConfig) validateCapDrop(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.CapDrop) { // not required
 		return nil
+	}
+
+	if err := validate.UniqueItems("CapDrop", "body", m.CapDrop); err != nil {
+		return err
 	}
 
 	return nil
@@ -658,6 +679,10 @@ func (m *HostConfig) validateDNS(formats strfmt.Registry) error {
 		return nil
 	}
 
+	if err := validate.UniqueItems("Dns", "body", m.DNS); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -665,6 +690,10 @@ func (m *HostConfig) validateDNSOptions(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.DNSOptions) { // not required
 		return nil
+	}
+
+	if err := validate.UniqueItems("DnsOptions", "body", m.DNSOptions); err != nil {
+		return err
 	}
 
 	return nil
@@ -676,6 +705,10 @@ func (m *HostConfig) validateDNSSearch(formats strfmt.Registry) error {
 		return nil
 	}
 
+	if err := validate.UniqueItems("DnsSearch", "body", m.DNSSearch); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -685,6 +718,10 @@ func (m *HostConfig) validateExtraHosts(formats strfmt.Registry) error {
 		return nil
 	}
 
+	if err := validate.UniqueItems("ExtraHosts", "body", m.ExtraHosts); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -692,6 +729,10 @@ func (m *HostConfig) validateGroupAdd(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.GroupAdd) { // not required
 		return nil
+	}
+
+	if err := validate.UniqueItems("GroupAdd", "body", m.GroupAdd); err != nil {
+		return err
 	}
 
 	return nil
@@ -835,6 +876,10 @@ func (m *HostConfig) validateSecurityOpt(formats strfmt.Registry) error {
 		return nil
 	}
 
+	if err := validate.UniqueItems("SecurityOpt", "body", m.SecurityOpt); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -846,6 +891,19 @@ func (m *HostConfig) validateShmSize(formats strfmt.Registry) error {
 
 	if err := validate.MinimumInt("ShmSize", "body", int64(*m.ShmSize), 0, false); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *HostConfig) validateStorageOpt(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.StorageOpt) { // not required
+		return nil
+	}
+
+	if swag.IsZero(m.StorageOpt) { // not required
+		return nil
 	}
 
 	return nil

--- a/test/api_container_create_test.go
+++ b/test/api_container_create_test.go
@@ -231,3 +231,28 @@ func (suite *APIContainerCreateSuite) TestCreateNvidiaConfig(c *check.C) {
 
 	DelContainerForceMultyTime(c, cname)
 }
+
+// TestCreateWithNonUniqueOptions creates a container with duplicate
+// items which is invalid in container request body.
+func (suite *APIContainerCreateSuite) TestCreateWithNonUniqueOptions(c *check.C) {
+	cname := "TestCreateWithNonUniqueOptions"
+	q := url.Values{}
+	q.Add("name", cname)
+	query := request.WithQuery(q)
+
+	obj := map[string]interface{}{
+		"Image": busyboxImage,
+		"HostConfig": map[string]interface{}{
+			"CapAdd": []string{
+				"SYS_PTRACE",
+				"SYS_PTRACE",
+				"SYS_ADMIN",
+			},
+		},
+	}
+	body := request.WithJSONBody(obj)
+
+	resp, err := request.Post("/containers/create", query, body)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 400)
+}


### PR DESCRIPTION
…duplicate items

Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In this pull request, we try to make some container create request validation more strict.

For example, in a container create request:

```
"CapAdd": [
      "SYS_RESOURCE",
      "SYS_MODULE",
      "SYS_PTRACE",
      "SYS_PACCT",
      "NET_ADMIN",
      "SYS_ADMIN",
      "SYS_RESOURCE",
      "SYS_MODULE",
      "SYS_PTRACE",
      "SYS_PACCT",
      "NET_ADMIN",
      "SYS_ADMIN ",
      "SYS_RESOURCE",
      "SYS_MODULE",
      "SYS_PTRACE",
      "SYS_PACCT",
      "NET_ADMIN",
      "SYS_ADMIN",
      "SYS_RESOURCE",
      "SYS_MODULE",
      "SYS_PTRACE",
      "SYS_PACCT",
      "NET_ADMIN",
      "SYS_ADMIN",
      "SYS_RESOURCE",
      "SYS_MODULE",
      "SYS_PTRACE",
      "SYS_PACCT",
      "NET_ADMIN",
      "SYS_ADMIN"
    ],
```

In this case with duplicate items in CapAdd, the API bridge layer could directly return 400 error.

I add some validation to make `CapAdd` items unique.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

