### PR TITLE
add timeout for curl to prevent from hanging

### DIFF
--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -341,7 +341,7 @@ func (suite *PouchNetworkSuite) TestNetworkPortMapping(c *check.C) {
 		image).Assert(c, icmd.Success)
 
 	time.Sleep(10 * time.Second)
-	err := icmd.RunCommand("curl", "localhost:9999").Compare(expct)
+	err := icmd.RunCommand("timeout", "5", "curl", "localhost:9999").Compare(expct)
 	c.Assert(err, check.IsNil)
 
 	command.PouchRun("rm", "-f", funcname)


### PR DESCRIPTION
Signed-off-by: Yuan Sun <yile.sy@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
In centos7.2, "curl localhost:9999" hangs. This PR is to prevent from hanging.

### Ⅱ. Does this pull request fix one issue?
Yes


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
This PR fixed the test case issue.


### Ⅳ. Describe how to verify it
add timeout command

### Ⅴ. Special notes for reviews
NA

