### PR TITLE
test.cli_network_test: fix TestNetworkDefault failure on Ubuntu

### DIFF
--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -88,7 +88,13 @@ func (suite *PouchNetworkSuite) TestNetworkDefault(c *check.C) {
 	}
 	{
 		cmd := "ip r |grep default"
+		// The command output of "ip r | grep default" contains extra "proto static"
+		// on Ubuntu host, which is inconsistent with output in container
 		routeOnHost := icmd.RunCommand("bash", "-c", cmd).Stdout()
+		if strings.Contains(routeOnHost, "proto static") {
+			// keep command output consistent between Ubuntu host and container
+			routeOnHost = strings.Replace(routeOnHost, " proto static ", "", -1)
+		}
 		// Assign the host network to a container.
 		expct := icmd.Expected{
 			ExitCode: 0,


### PR DESCRIPTION
The command output of "ip r | grep default" contains extra "proto static" on Ubuntu host, which is inconsistent with output in container, the actual error as follows:

----------------------------------------------------------------------
FAIL: cli_network_test.go:59: PouchNetworkSuite.TestNetworkDefault

cli_network_test.go:101:
    c.Assert(err, check.IsNil)
... value *errors.errorString = &errors.errorString{s:"\nCommand:  /usr/local/bin/pouch run --name TestNetworkDefault --net host registry.hub.docker.com/library/busybox:1.28 ip r\nExitCode: 0\nError:    <nil>\nStdout:   default via 10.0.2.2 dev enp0s3  metric 100 \n10.0.2.0/24 dev enp0s3 scope link  src 10.0.2.15  metric 100 \n169.254.0.0/16 dev enp0s8 scope link  metric 1000 \n192.168.5.0/24 dev p0 scope link  src 192.168.5.1 \n192.168.56.0/24 dev enp0s8 scope link  src 192.168.56.101  metric 100 \n\nStderr:   \n\nFailures:\nExpected stdout to contain \"default via 10.0.2.2 dev enp0s3   metric 100 \\n\""} ("\nCommand:  /usr/local/bin/pouch run --name TestNetworkDefault --net host registry.hub.docker.com/library/busybox:1.28 ip r\nExitCode: 0\nError:    <nil>\nStdout:   default via 10.0.2.2 dev enp0s3  metric 100 \n10.0.2.0/24 dev enp0s3 scope link  src 10.0.2.15  metric 100 \n169.254.0.0/16 dev enp0s8 scope link  metric 1000 \n192.168.5.0/24 dev p0 scope link  src 192.168.5.1 \n192.168.56.0/24 dev enp0s8 scope link  src 192.168.56.101  metric 100 \n\nStderr:   \n\nFailures:\nExpected stdout to contain \"default via 10.0.2.2 dev enp0s3   metric 100 \\n\"")

OOPS: 0 passed, 1 FAILED
--- FAIL: Test (1.46s)


Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
to remove extra "proto static" string of "ip r" output on Ubuntu host

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None


### Ⅳ. Describe how to verify it
```shell
cd test && go test -v -check.f PouchNetworkSuite.TestNetworkDefault
```

### Ⅴ. Special notes for reviews


