### PR TITLE
test: remove the criu install from package dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ package-dependencies: ## install containerd, runc and lxcfs dependencies for pac
 	hack/install/install_containerd.sh
 	hack/install/install_lxcfs.sh
 	hack/install/install_runc.sh
-	hack/install/install_criu.sh
 
 .PHONY: download-dependencies
 download-dependencies: package-dependencies ## install dumb-init, local-persist, nsenter and CI tools dependencies
@@ -104,6 +103,7 @@ download-dependencies: package-dependencies ## install dumb-init, local-persist,
 	hack/install/install_dumb_init.sh
 	hack/install/install_local_persist.sh
 	hack/install/install_nsenter.sh
+	hack/install/install_criu.sh
 
 .PHONY: clean
 clean: ## clean to remove bin/* and files created by module

--- a/daemon/mgr/container_exec.go
+++ b/daemon/mgr/container_exec.go
@@ -69,13 +69,14 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, attac
 				stdout = stdcopy.NewStdWriter(stdout, stdcopy.Stdout)
 			}
 			stdout.Write([]byte(err.Error() + "\r\n"))
-			// close io to make hijack connection exit
-			eio.Close()
-			mgr.IOs.Remove(execid)
 			// set exec exit status
 			execConfig.Running = false
 			exitCode := 126
 			execConfig.ExitCode = int64(exitCode)
+
+			// close io to make hijack connection exit
+			eio.Close()
+			mgr.IOs.Remove(execid)
 		}
 	}()
 

--- a/hack/install/install_criu.sh
+++ b/hack/install/install_criu.sh
@@ -8,16 +8,16 @@ source "./check.sh"
 # criu::ubuntu::install_dependencies will install dependencies packages.
 criu::ubuntu::install_dependencies() {
   apt-get install -y -q \
-	  build-essential \
-	  libnet1-dev \
-	  libprotobuf-dev \
-	  libprotobuf-c0-dev \
-	  protobuf-c-compiler \
-	  protobuf-compiler \
-	  python-protobuf \
-	  libnl-3-dev \
-	  libcap-dev \
-	  asciidoc
+    build-essential \
+    libnet1-dev \
+    libprotobuf-dev \
+    libprotobuf-c0-dev \
+    protobuf-c-compiler \
+    protobuf-compiler \
+    python-protobuf \
+    libnl-3-dev \
+    libcap-dev \
+    asciidoc
 }
 
 # criu::ubuntu::install will install criu from source.
@@ -49,6 +49,9 @@ main() {
   if [[ "${os_dist}" = "Ubuntu" ]]; then
     criu::ubuntu::install_dependencies > /dev/null
     criu::ubuntu::install > /dev/null
+  else
+    echo "will support redhat soon"
+    exit 0
   fi
 
   # final check


### PR DESCRIPTION
package deb/rpm doesn't require criu.

Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

No need

### Ⅳ. Describe how to verify it

CI

### Ⅴ. Special notes for reviews


