### PR TITLE
bugfix: set pid of stopped container to 0

### DIFF
--- a/daemon/mgr/container_state.go
+++ b/daemon/mgr/container_state.go
@@ -105,7 +105,7 @@ func (c *Container) SetStatusStopped(exitCode int64, errMsg string) {
 	defer c.Unlock()
 	c.State.Status = types.StatusStopped
 	c.State.FinishedAt = time.Now().UTC().Format(utils.TimeLayout)
-	c.State.Pid = -1
+	c.State.Pid = 0
 	c.State.ExitCode = exitCode
 	c.State.Error = errMsg
 	c.setStatusFlags(types.StatusStopped)
@@ -117,7 +117,7 @@ func (c *Container) SetStatusExited(exitCode int64, errMsg string) {
 	defer c.Unlock()
 	c.State.Status = types.StatusExited
 	c.State.FinishedAt = time.Now().UTC().Format(utils.TimeLayout)
-	c.State.Pid = -1
+	c.State.Pid = 0
 	c.State.ExitCode = exitCode
 	c.State.Error = errMsg
 	c.setStatusFlags(types.StatusExited)

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -126,3 +126,36 @@ func (suite *PouchStopSuite) TestStopMultiContainers(c *check.C) {
 	c.Assert(string(result[0].State.Status), check.Equals, "stopped")
 
 }
+
+// TestStopPidValue ensure stopped container's pid is 0
+func (suite *PouchStopSuite) TestStopPidValue(c *check.C) {
+	name := "test-stop-pid-value"
+
+	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+
+	// test stop a created container
+	command.PouchRun("stop", name).Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", name).Stdout()
+	result := []types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result[0].State.Pid, check.Equals, int64(0))
+}
+
+// TestAutoStopPidValue ensure stopped container's pid is 0
+func (suite *PouchStopSuite) TestAutoStopPidValue(c *check.C) {
+	name := "test-auto-stop-pid-value"
+
+	command.PouchRun("run", "--name", name, busyboxImage, "echo", "hi").Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+
+	output := command.PouchRun("inspect", name).Stdout()
+	result := []types.ContainerJSON{}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		c.Errorf("failed to decode inspect output: %v", err)
+	}
+	c.Assert(result[0].State.Pid, check.Equals, int64(0))
+}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
We set pid of stopped container to `-1` before, it's ok that we do not check value of pid but the status of container when we want to check whether the container is stopped or not.

But now, `pouchd` supported `CRI`, the k8s will check the value of pid when the container stopped and the pid is `0` when container stopped.

So, in order to stay with moby and kubernetes, we also should change the pid to `0` when the container is stopped.

### Ⅱ. Does this pull request fix one issue?

none


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added `TestStopPidValue` test case


### Ⅳ. Describe how to verify it
```
root@osboxes:test (zr/pid-fix *) -> pouch run -d -t  centos top
d42b8e1c8c45dbdbf53f1fb2432ba6a0c2d730007601c8d47f2bdf94508f8c58
root@osboxes:test (zr/pid-fix) -> pouch ps
Name     ID       Status         Created         Image                                           Runtime
d42b8e   d42b8e   Up 3 seconds   4 seconds ago   registry.hub.docker.com/library/centos:latest   runc
root@osboxes:test (zr/pid-fix) -> pouch stop -t 3 d42b8e
d42b8e
root@osboxes:test (zr/pid-fix) -> pouch inspect -f '{{.State.Pid}}' d42b8e
0
```

### Ⅴ. Special notes for reviews
None

