### PR TITLE
bugfix: sort mounts according to the depth of destination path

### DIFF
--- a/daemon/mgr/spec_mount_test.go
+++ b/daemon/mgr/spec_mount_test.go
@@ -1,0 +1,41 @@
+package mgr
+
+import (
+	"reflect"
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func Test_sortMounts(t *testing.T) {
+	tests := []struct {
+		name string
+		args []specs.Mount
+		want []specs.Mount
+	}{
+		{
+			"Mounts is nil case",
+			nil,
+			nil,
+		},
+		{
+			"Normal Mounts",
+			[]specs.Mount{
+				{Destination: "/etc/resolv.conf"},
+				{Destination: "/etc"},
+			},
+			[]specs.Mount{
+				{Destination: "/etc"},
+				{Destination: "/etc/resolv.conf"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sortMounts(tt.args)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sortMounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

sortMounts sorts an array of mounts in lexicographic order.

This ensure that when mounting, the mounts don't shadow other mounts. 

For example, if mounting /etc and /etc/resolv.conf, /etc/resolv.conf must not be mounted first.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

ref: https://github.com/containerd/containerd/issues/2596

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Added

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


