### PR TITLE
bugfix: use more accurate flag %T to print func

### DIFF
--- a/daemon/logger/syslog/syslog_test.go
+++ b/daemon/logger/syslog/syslog_test.go
@@ -42,7 +42,7 @@ func TestParseOptions(t *testing.T) {
 
 	// check formatter and framer
 	if !isSameFunc(opts.formatter, srslog.RFC3164Formatter) || !isSameFunc(opts.framer, srslog.DefaultFramer) {
-		t.Fatalf("expect formatter(%v) & framer(%v), but got formatter(%v) & framer(%v)",
+		t.Fatalf("expect formatter(%T) & framer(%T), but got formatter(%T) & framer(%T)",
 			srslog.RFC3164Formatter, srslog.DefaultFramer, opts.formatter, opts.framer,
 		)
 	}


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

### Ⅰ. Describe what this PR did
use %T instead of %v to print function.

### Ⅱ. Does this pull request fix one issue?
fixes Issue #2204 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Yes


### Ⅳ. Describe how to verify it
`make test
`
### Ⅴ. Special notes for reviews
As [go docs](https://github.com/golang/go/blob/dev.boringcrypto.go1.9/src/cmd/vet/testdata/print.go) line 217 told.

