### PR TITLE
docs: fix stop example

### DIFF
--- a/cli/stop.go
+++ b/cli/stop.go
@@ -70,7 +70,7 @@ func stopExample() string {
 Name     ID       Status    Image                              Runtime
 foo      71b9c1   Running   docker.io/library/busybox:latest   runc
 $ pouch stop foo
-$ pouch ps
+$ pouch ps -a
 Name     ID       Status    Image                              Runtime
 foo      71b9c1   Stopped   docker.io/library/busybox:latest   runc`
 }


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
pouch stop -h,  example looks not correct.
```
 Examples:
$ pouch ps
Name     ID       Status    Image                              Runtime
foo      71b9c1   Running   docker.io/library/busybox:latest   runc
$ pouch stop foo
$ pouch ps
Name     ID       Status    Image                              Runtime
foo      71b9c1   Stopped   docker.io/library/busybox:latest   runc
```
pouch ps doesn't list containers in STOP state. must use -a flag.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Yes


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


