### PR TITLE
feature: make lxcfs configurable supportd in CRI

### DIFF
--- a/cri/annotations/annotations.go
+++ b/cri/annotations/annotations.go
@@ -16,4 +16,7 @@ const (
 
 	// KubernetesRuntime is the runtime
 	KubernetesRuntime = "io.kubernetes.runtime"
+
+	// LxcfsEnabled whether to enable lxcfs for a container
+	LxcfsEnabled = "io.kubernetes.lxcfs.enabled"
 )

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	goruntime "runtime"
+	"strconv"
 	"time"
 
 	apitypes "github.com/alibaba/pouch/apis/types"
@@ -279,6 +280,15 @@ func (c *CriManager) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		NetNSPath: netnsPath,
 		Runtime:   config.Annotations[anno.KubernetesRuntime],
 	}
+
+	if _, ok := config.Annotations[anno.LxcfsEnabled]; ok {
+		enableLxcfs, err := strconv.ParseBool(config.Annotations[anno.LxcfsEnabled])
+		if err != nil {
+			return nil, err
+		}
+		sandboxMeta.LxcfsEnabled = enableLxcfs
+	}
+
 	if err := c.SandboxStore.Put(sandboxMeta); err != nil {
 		return nil, err
 	}

--- a/cri/v1alpha2/cri_types.go
+++ b/cri/v1alpha2/cri_types.go
@@ -17,6 +17,9 @@ type SandboxMeta struct {
 
 	// Runtime is the runtime of sandbox
 	Runtime string
+
+	// Runtime whether to enable lxcfs for a container
+	LxcfsEnabled bool
 }
 
 // Key returns sandbox's id.

--- a/cri/v1alpha2/cri_utils.go
+++ b/cri/v1alpha2/cri_utils.go
@@ -685,6 +685,8 @@ func (c *CriManager) updateCreateConfig(createConfig *apitypes.ContainerCreateCo
 		createConfig.HostConfig.Runtime = sandboxMeta.Runtime
 	}
 
+	createConfig.HostConfig.EnableLxcfs = sandboxMeta.LxcfsEnabled
+
 	if lc := config.GetLinux(); lc != nil {
 		resources := lc.GetResources()
 		if resources != nil {


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Support resource review isolation via lxcfs in CRI Manager.

And define the specific naming in annotations:
`LxcfsEnabled = "io.kubernetes.lxcfs.enabled"`

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2172

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it

```
# cat pouch.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: pouch
  labels:
    pouch: pouch
spec:
  selector:
    matchLabels:
      pouch: pouch
  template:
    metadata:
      labels:
        pouch: pouch
      annotations:
        io.kubernetes.lxcfs.enabled: "true"
    spec:
      containers:
      - name: pouch
        image: docker.io/library/busybox:latest
        command:
          - top
        resources:
          requests:
            memory: "256Mi"
          limits:
            memory: "256Mi"
```
```
# kubectl create -f pouch.yaml
# pouch ps
Name                                                                                                           ID       Status       Created       Image                                                                 Runtime
k8s_pouch_pouch-5ddd8fc467-rmtcw_default_bc4b7972-b181-11e8-adae-42010a8c0003_0                                5391a9   Up 8 hours   8 hours ago   docker.io/library/busybox:latest                                      runc
k8s_POD_pouch-5ddd8fc467-rmtcw_default_bc4b7972-b181-11e8-adae-42010a8c0003_0                                  60a833   Up 8 hours   8 hours ago   registry.cn-hangzhou.aliyuncs.com/google-containers/pause-amd64:3.0   runc
```

```
# pouch exec k8s_pouch_pouch-5ddd8fc467-rmtcw_default_bc4b7972-b181-11e8-adae-42010a8c0003_0 cat /proc/meminfo 
MemTotal:         262144 kB
MemFree:          261368 kB
MemAvailable:     261368 kB
Buffers:               0 kB
Cached:                0 kB
SwapCached:            0 kB
Active:              156 kB
Inactive:              0 kB
Active(anon):        156 kB
Inactive(anon):        0 kB
Active(file):          0 kB
Inactive(file):        0 kB
Unevictable:           0 kB
Mlocked:            3652 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Dirty:               292 kB
Writeback:             0 kB
AnonPages:        561860 kB
Mapped:           395920 kB
Shmem:              5640 kB
Slab:               0 kB
SReclaimable:          0 kB
SUnreclaim:            0 kB
KernelStack:        6112 kB
PageTables:         6760 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:     1890884 kB
Committed_AS:    1550596 kB
VmallocTotal:   34359738367 kB
VmallocUsed:           0 kB
VmallocChunk:          0 kB
HardwareCorrupted:     0 kB
AnonHugePages:         0 kB
ShmemHugePages:        0 kB
ShmemPmdMapped:        0 kB
CmaTotal:              0 kB
CmaFree:               0 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
DirectMap4k:       88012 kB
DirectMap2M:     3844096 kB
DirectMap1G:           0 kB
```
### Ⅴ. Special notes for reviews


