### PR TITLE
docs: fix some command which not have desc and example

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -16,8 +16,7 @@ import (
 )
 
 // execDescription is used to describe exec command in detail and auto generate command doc.
-// TODO: add description
-var execDescription = ""
+var execDescription = "Run a command in a running container"
 
 // ExecCommand is used to implement 'exec' command.
 type ExecCommand struct {
@@ -33,7 +32,7 @@ func (e *ExecCommand) Init(c *Cli) {
 	e.cli = c
 	e.cmd = &cobra.Command{
 		Use:   "exec [OPTIONS] CONTAINER COMMAND [ARG...]",
-		Short: "Exec a process in a running container",
+		Short: "Run a command in a running container",
 		Long:  execDescription,
 		Args:  cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/generate_doc.go
+++ b/cli/generate_doc.go
@@ -9,15 +9,14 @@ import (
 )
 
 // genDocDescription is used to describe gen-doc command in detail and auto generate command doc.
-// TODO: add description
-var genDocDescription = ""
+var genDocDescription = "Generate docs for cli command"
 
-// GenDocCommand is used to implement 'exec' command.
+// GenDocCommand is used to implement 'gen-doc' command.
 type GenDocCommand struct {
 	baseCommand
 }
 
-// Init initializes ExecCommand command.
+// Init initializes GenDocCommand command.
 func (g *GenDocCommand) Init(c *Cli) {
 	g.cli = c
 	g.cmd = &cobra.Command{
@@ -48,7 +47,6 @@ func (g *GenDocCommand) runGenDoc(args []string) error {
 }
 
 // genDocExample shows examples in genDoc command, and is used in auto-generated cli docs.
-// TODO: add example
 func genDocExample() string {
-	return ""
+	return "$ pouch gen-doc"
 }

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -17,7 +17,7 @@ var validDrivers = map[string]bool{
 }
 
 // logsDescription is used to describe logs command in detail and auto generate command doc.
-var logsDescription = ""
+var logsDescription = "Get container's logs"
 
 // LogsCommand use to implement 'logs' command, it is used to print a container's logs
 type LogsCommand struct {
@@ -97,5 +97,18 @@ func (lc *LogsCommand) runLogs(args []string) error {
 
 // logsExample shows examples in logs command, and is used in auto-generated cli docs.
 func logsExample() string {
-	return ``
+	return `$ pouch ps 
+Name     ID       Status      Created      Image                                          Runtime
+073f29   073f29   Up 1 day    2 days ago   registry.hub.docker.com/library/redis:latest   runc
+$ pouch logs 073f29
+1:C 04 Sep 05:42:01.600 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
+1:C 04 Sep 05:42:01.601 # Redis version=4.0.11, bits=64, commit=00000000, modified=0, pid=1, just started
+1:C 04 Sep 05:42:01.601 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
+1:M 04 Sep 05:42:01.601 * Increased maximum number of open files to 10032 (it was originally set to 1024).
+1:M 04 Sep 05:42:01.602 * Running mode=standalone, port=6379.
+1:M 04 Sep 05:42:01.602 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
+1:M 04 Sep 05:42:01.602 # Server initialized
+1:M 04 Sep 05:42:01.602 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
+1:M 04 Sep 05:42:01.602 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
+1:M 04 Sep 05:42:01.602 * Ready to accept connections`
 }

--- a/cli/restart.go
+++ b/cli/restart.go
@@ -65,5 +65,11 @@ func (rc *RestartCommand) runRestart(args []string) error {
 
 // restartExample shows examples in restart command, and is used in auto-generated cli docs.
 func restartExample() string {
-	return `//TODO`
+	return `$ pouch ps -a
+Name     ID       Status    Image                              Runtime
+foo      71b9c1   Stopped   docker.io/library/busybox:latest   runc
+$ pouch restart foo
+$ pouch ps
+Name     ID       Status    Image                              Runtime
+foo      71b9c1   Running   docker.io/library/busybox:latest   runc`
 }

--- a/cli/run.go
+++ b/cli/run.go
@@ -171,12 +171,12 @@ func (rc *RunCommand) runRun(args []string) error {
 func runExample() string {
 	return `$ pouch run --name test registry.hub.docker.com/library/busybox:latest echo "hi"
 hi
-$ pouch ps
+$ pouch ps -a
 Name   ID       Status    Image                                            Runtime   Created
 test   23f852   stopped   registry.hub.docker.com/library/busybox:latest   runc      4 seconds ago
 $ pouch run -d --name test registry.hub.docker.com/library/busybox:latest
 90719b5f9a455b3314a49e72e3ecb9962f215e0f90153aa8911882acf2ba2c84
-$ pouch ps
+$ pouch ps -a
 Name   ID       Status    Image                                            Runtime   Created
 test   90719b   stopped   registry.hub.docker.com/library/busybox:latest   runc      5 seconds ago
 $ pouch run --device /dev/zero:/dev/testDev:rwm --name test registry.hub.docker.com/library/busybox:latest ls -l /dev/testDev

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -8,7 +8,7 @@ import (
 )
 
 // upgradeDescription is used to describe upgrade command in detail and auto generate command doc.
-var upgradeDescription = ""
+var upgradeDescription = "Upgrade a container with new image and args"
 
 // UpgradeCommand use to implement 'upgrade' command, it is used to upgrade a container.
 type UpgradeCommand struct {


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
As title mentioned, related to gen-doc/exec/logs/upgrade/restart command.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
Maybe need a way to check the desc and example are not null when a pr implements a command. 

