### PR TITLE
minor fixes for shell variables and spelling

### DIFF
--- a/docs/features/pouch_with_runV.md
+++ b/docs/features/pouch_with_runV.md
@@ -47,10 +47,9 @@ sudo yum install -y qemu qemu-kvm
 First, clone version v1.0.0 of runv project from GitHub:
 
 ```
-mkdir -p $Home/go/src/github.com/hyperhq
-cd $Home/go/src/github.com/hyperhq
+mkdir -p $HOME/go/src/github.com/hyperhq
+cd $HOME/go/src/github.com/hyperhq
 git clone --branch v1.0.0 https://github.com/hyperhq/runv.git
-export GOPATH=$HOME/go
 ```
 
 Second, build runv from source code:
@@ -61,7 +60,7 @@ sudo apt-get install automake
 cd runv
 ./autogen.sh
 ./configure
-sudo make
+make
 sudo make install
 ```
 
@@ -72,7 +71,7 @@ Then binary runv will be located in your PATH.
 [hyperstart](https://github.com/hyperhq/hyperstart) provides init task for hypervisor-based containers. We need to build guest kernel and initrd.img from source code version v1.0.0 as well:
 
 ```
-cd $Home/go/src/github.com/hyperhq
+cd $HOME/go/src/github.com/hyperhq
 git clone --branch v1.0.0 https://github.com/hyperhq/hyperstart.git
 cd hyperstart
 ./autogen.sh
@@ -136,7 +135,7 @@ It turns out that in experiment above kernel in host physical machine is 4.4.0-1
 
 ## Run legacy kernels
 
-runV(now kataconatiners) provides a general way to provide an isolated Linux kernel still based on OCI-compatible images. To be honest, Linux kernel running in Guest OS provisioned by runV is quite advanced and new. However, how to make legacy Linux kernel run in Guest OS is still a really huge challenge for the industry when using runV.
+runV (now katacontainers) provides a general way to provide an isolated Linux kernel still based on OCI-compatible images. To be honest, Linux kernel running in Guest OS provisioned by runV is quite advanced and new. However, how to make legacy Linux kernel run in Guest OS is still a really huge challenge for the industry when using runV.
 
 ### Scenario
 


### PR DESCRIPTION
- environment variables consistency
- GOPATH defaults to $HOME/go starting with Go 1.8
- minor typo

Signed-off-by: Oliver Frommel <ofr@zetalab.de>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


