### PR TITLE
bugfix: fix can't set macaddress for endpoint

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -330,3 +330,24 @@ func StringSliceEqual(s1, s2 []string) bool {
 
 	return true
 }
+
+// MergeMap merges the m2 into m1, if it has the same keys, m2 will overwrite m1.
+func MergeMap(m1 map[string]interface{}, m2 map[string]interface{}) (map[string]interface{}, error) {
+	if m1 == nil && m2 == nil {
+		return nil, fmt.Errorf("all of maps are nil")
+	}
+
+	if m1 == nil {
+		return m2, nil
+	}
+
+	if m2 == nil {
+		return m1, nil
+	}
+
+	for k, v := range m2 {
+		m1[k] = v
+	}
+
+	return m1, nil
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -544,3 +544,35 @@ func TestStringSliceEqual(t *testing.T) {
 		}
 	}
 }
+
+func TestMergeMap(t *testing.T) {
+	type Expect struct {
+		err   error
+		key   string
+		value interface{}
+	}
+	tests := []struct {
+		m1     map[string]interface{}
+		m2     map[string]interface{}
+		expect Expect
+	}{
+		{nil, nil, Expect{fmt.Errorf("all of maps are nil"), "", nil}},
+		{nil, map[string]interface{}{"a": "a"}, Expect{nil, "a", "a"}},
+		{map[string]interface{}{"a": "a"}, nil, Expect{nil, "a", "a"}},
+		{map[string]interface{}{"a": "a"}, map[string]interface{}{"a": "b"}, Expect{nil, "a", "b"}},
+		{map[string]interface{}{"a": "a"}, map[string]interface{}{"b": "b"}, Expect{nil, "b", "b"}},
+	}
+
+	for _, test := range tests {
+		m3, err := MergeMap(test.m1, test.m2)
+		if err != nil {
+			if test.expect.err.Error() != err.Error() {
+				t.Fatalf("MergeMap(%v, %v) expected: %v, but got %v", test.m1, test.m2, test.expect.err, err)
+			}
+		} else {
+			if m3[test.expect.key] != test.expect.value {
+				t.Fatalf("MergeMap(%v, %v) expected: %v, but got %v", test.m1, test.m2, test.expect.value, m3[test.expect.key])
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
When user set the mac address in container's config:
`container.Config.MacAddress`, now it will not take effect.

The method is setting the mac address into the endpoint's options, it
will set into network device by libnetwork or it's remote plugins.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Add testcase: `TestCreateWithMacAddress` to check the mac address is set
into container's device or not.

### Ⅳ. Describe how to verify it
Using testcase `TestCreateWithMacAddress` to verify it

### Ⅴ. Special notes for reviews
NONE

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
