### PR TITLE
test: add test case for privileged container

### DIFF
--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -307,7 +307,7 @@ func setupDevices(ctx context.Context, c *Container, s *specs.Spec) error {
 	}
 
 	s.Linux.Devices = append(s.Linux.Devices, devs...)
-	s.Linux.Resources.Devices = append(s.Linux.Resources.Devices, devPermissions...)
+	s.Linux.Resources.Devices = devPermissions
 	return nil
 }
 

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -232,17 +232,6 @@ func (suite *PouchRunSuite) TestRunWithoutCapability(c *check.C) {
 	defer DelContainerForceMultyTime(c, name)
 }
 
-// TestRunWithPrivilege is to verify run container with privilege.
-func (suite *PouchRunSuite) TestRunWithPrivilege(c *check.C) {
-	name := "run-privilege"
-
-	res := command.PouchRun("run", "--name", name, "--privileged",
-		busyboxImage, "brctl", "addbr", "foobar")
-	defer DelContainerForceMultyTime(c, name)
-
-	res.Assert(c, icmd.Success)
-}
-
 // checkFileContains checks the content of fname contains expt
 func checkFileContains(c *check.C, fname string, expt string) {
 	cmdResult := icmd.RunCommand("cat", fname)

--- a/test/cli_run_with_privileged_test.go
+++ b/test/cli_run_with_privileged_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// PouchRunPrivilegedSuite is the test suite for run CLI.
+type PouchRunPrivilegedSuite struct{}
+
+func init() {
+	check.Suite(&PouchRunPrivilegedSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each test suite.
+func (suite *PouchRunPrivilegedSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	environment.PruneAllContainers(apiClient)
+
+	PullImage(c, busyboxImage)
+}
+
+// TearDownTest does cleanup work in the end of each test.
+func (suite *PouchRunPrivilegedSuite) TearDownTest(c *check.C) {
+}
+
+// TestRunWithAndWithoutPrivileged is to verify run container with privilege.
+func (suite *PouchRunPrivilegedSuite) TestRunWithAndWithoutPrivileged(c *check.C) {
+	name := "TestRunWithPrivileged"
+	command.PouchRun("run", "--name", name, "--privileged", busyboxImage, "brctl", "addbr", "foobar").Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+
+	name1 := "TestRunWithoutPrivileged"
+	res := command.PouchRun("run", "--name", name1, busyboxImage, "brctl", "addbr", "foobar")
+	defer DelContainerForceMultyTime(c, name1)
+	if res.ExitCode == 0 {
+		c.Errorf("non-privileged container executes brctl should failed, but succeeded: %v", res.Combined())
+	}
+
+	expected := "Operation not permitted"
+	if out := res.Combined(); !strings.Contains(out, expected) {
+		c.Errorf("expected %s, but got %s", expected, out)
+	}
+}
+
+func (suite *PouchRunPrivilegedSuite) TestRunCheckProcWritableWithAndWithoutPrivileged(c *check.C) {
+	name := "TestRunProcWritableInPrivileged"
+	command.PouchRun("run", "--name", name, "--privileged", busyboxImage, "sh", "-c", "touch /proc/sysrq-trigger").Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+
+	name1 := "TestRunProcNotWritableInNonPrivileged"
+	res := command.PouchRun("run", "--name", name1, busyboxImage, "sh", "-c", "touch /proc/sysrq-trigger")
+	defer DelContainerForceMultyTime(c, name1)
+
+	if res.ExitCode == 0 {
+		c.Errorf("non-privileged container executes touch /proc/sysrq-trigger should failed, but succeeded: %v", res.Combined())
+	}
+
+	expected := "Read-only file system"
+	if out := res.Combined(); !strings.Contains(out, expected) {
+		c.Errorf("expected %s, but got %s", expected, out)
+	}
+}
+
+func (suite *PouchRunPrivilegedSuite) TestRunCheckSysWritableWithAndWithoutPrivileged(c *check.C) {
+	name := "TestRunSysWritableInPrivileged"
+	command.PouchRun("run", "--name", name, "--privileged", busyboxImage, "sh", "-c", "touch /sys/kernel/profiling").Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+
+	name1 := "TestRunSysNotWritableInNonPrivileged"
+	res := command.PouchRun("run", "--name", name1, busyboxImage, "sh", "-c", "touch /sys/kernel/profiling")
+	defer DelContainerForceMultyTime(c, name1)
+
+	if res.ExitCode == 0 {
+		c.Errorf("non-privileged container executes touch /sys/kernel/profiling should failed, but succeeded: %v", res.Combined())
+	}
+
+	expected := "Read-only file system"
+	if out := res.Combined(); !strings.Contains(out, expected) {
+		c.Errorf("expected %s, but got %s", expected, out)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

Actually, `pouchd` already supports creating `privileged` containers. But, we have not checked the feature before.

So, in this `PR`, i add some test cases to check if the `privileged` containers work as expected.

### Ⅱ. Does this pull request fix one issue?
none


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
It is what this `PR` doing that add more test cases.


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

