### PR TITLE
bugfix: fix start container twice error

### DIFF
--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -226,6 +226,8 @@ func HandleErrorResponse(w http.ResponseWriter, err error) {
 		code = http.StatusBadRequest
 	} else if errtypes.IsAlreadyExisted(err) {
 		code = http.StatusConflict
+	} else if errtypes.IsNotModified(err) {
+		code = http.StatusNotModified
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -588,6 +588,8 @@ paths:
       responses:
         204:
           description: "no error"
+        304:
+          description: "container already started"
         404:
           $ref: "#/responses/404ErrorResponse"
         409:

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -479,6 +479,11 @@ func (mgr *ContainerManager) Start(ctx context.Context, id string, options *type
 		return err
 	}
 
+	// check if container's status is running
+	if c.IsRunning() {
+		return errors.Wrapf(errtypes.ErrNotModified, "container already started")
+	}
+
 	return mgr.start(ctx, c, options)
 }
 

--- a/pkg/errtypes/errors.go
+++ b/pkg/errtypes/errors.go
@@ -34,6 +34,9 @@ var (
 
 	// ErrVolumeNotFound represents that no such volume.
 	ErrVolumeNotFound = errorType{codeNotFound, "no such volume"}
+
+	// ErrNotModified represents that the resource is not modified
+	ErrNotModified = errorType{codeNotModified, "not modified"}
 )
 
 const (
@@ -46,6 +49,7 @@ const (
 	codeLockfailed
 	codeNotImplemented
 	codeInUse
+	codeNotModified
 )
 
 type errorType struct {
@@ -80,6 +84,11 @@ func IsTimeout(err error) bool {
 // IsInUse checks the error is using by others or not.
 func IsInUse(err error) bool {
 	return checkError(err, codeInUse)
+}
+
+// IsNotModified checks the error is not modified erro or not.
+func IsNotModified(err error) bool {
+	return checkError(err, codeNotModified)
 }
 
 func checkError(err error, code int) bool {

--- a/test/api_container_start_test.go
+++ b/test/api_container_start_test.go
@@ -92,3 +92,18 @@ func (suite *APIContainerStartSuite) TestInvalidParam(c *check.C) {
 	// TODO: missing case
 	helpwantedForMissingCase(c, "container api start bad request")
 }
+
+// TestStartAlreadyRunningContainer tests starting a running container
+func (suite *APIContainerStartSuite) TestStartAlreadyRunningContainer(c *check.C) {
+	cname := "TestStartAlreadyRunningContainer"
+
+	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
+
+	StartContainerOk(c, cname)
+
+	resp, err := request.Post("/containers/" + cname + "/start")
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 304)
+
+}

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -159,3 +159,12 @@ func (suite *PouchStopSuite) TestAutoStopPidValue(c *check.C) {
 	}
 	c.Assert(result[0].State.Pid, check.Equals, int64(0))
 }
+
+// TestStartContainerTwice tries to start a container twice
+func (suite *PouchStartSuite) TestStartContainerTwice(c *check.C) {
+	name := "TestStartContainerTwice"
+
+	command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	command.PouchRun("start", name).Assert(c, icmd.Success)
+	command.PouchRun("start", name).Assert(c, icmd.Success)
+}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

When starting a container,  we should check the container's status first. If the container is already started, we should just return `http.StatusNotModified` error.

### Ⅱ. Does this pull request fix one issue?

None

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add test case


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

