### PR TITLE
feature: support update hostname

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2487,6 +2487,9 @@ definitions:
             x-nullable: true
             additionalProperties:
               type: "string"
+          Hostname:
+            type: "string"
+            description: "update hostname for container"
 
   ContainerUpgradeConfig:
     description: |

--- a/apis/types/resources.go
+++ b/apis/types/resources.go
@@ -122,7 +122,7 @@ type Resources struct {
 	// Total memory limit (memory + swap). Set as `-1` to enable unlimited swap.
 	MemorySwap int64 `json:"MemorySwap"`
 
-	// Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
+	// Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100. -1 is also accepted, as a legacy alias of 0.
 	// Maximum: 100
 	// Minimum: -1
 	MemorySwappiness *int64 `json:"MemorySwappiness"`

--- a/apis/types/update_config.go
+++ b/apis/types/update_config.go
@@ -23,6 +23,9 @@ type UpdateConfig struct {
 	//
 	Env []string `json:"Env"`
 
+	// update hostname for container
+	Hostname string `json:"Hostname,omitempty"`
+
 	// List of labels set to container.
 	Label []string `json:"Label"`
 
@@ -45,6 +48,8 @@ func (m *UpdateConfig) UnmarshalJSON(raw []byte) error {
 
 		Env []string `json:"Env"`
 
+		Hostname string `json:"Hostname,omitempty"`
+
 		Label []string `json:"Label"`
 
 		RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
@@ -56,6 +61,8 @@ func (m *UpdateConfig) UnmarshalJSON(raw []byte) error {
 	m.DiskQuota = dataAO1.DiskQuota
 
 	m.Env = dataAO1.Env
+
+	m.Hostname = dataAO1.Hostname
 
 	m.Label = dataAO1.Label
 
@@ -79,6 +86,8 @@ func (m UpdateConfig) MarshalJSON() ([]byte, error) {
 
 		Env []string `json:"Env"`
 
+		Hostname string `json:"Hostname,omitempty"`
+
 		Label []string `json:"Label"`
 
 		RestartPolicy *RestartPolicy `json:"RestartPolicy,omitempty"`
@@ -87,6 +96,8 @@ func (m UpdateConfig) MarshalJSON() ([]byte, error) {
 	dataAO1.DiskQuota = m.DiskQuota
 
 	dataAO1.Env = m.Env
+
+	dataAO1.Hostname = m.Hostname
 
 	dataAO1.Label = m.Label
 

--- a/cli/update.go
+++ b/cli/update.go
@@ -51,6 +51,7 @@ func (uc *UpdateCommand) addFlags() {
 	flagSet.StringSliceVarP(&uc.labels, "label", "l", nil, "Set label for container")
 	flagSet.StringVar(&uc.restartPolicy, "restart", "", "Restart policy to apply when container exits")
 	flagSet.StringSliceVar(&uc.diskQuota, "disk-quota", nil, "Update disk quota for container(/=10g)")
+	flagSet.StringVar(&uc.hostname, "hostname", "", "Update hostname")
 }
 
 // updateRun is the entry of update command.
@@ -95,6 +96,7 @@ func (uc *UpdateCommand) updateRun(args []string) error {
 		RestartPolicy: restartPolicy,
 		Resources:     resource,
 		DiskQuota:     diskQuota,
+		Hostname:      uc.hostname,
 	}
 
 	apiClient := uc.cli.Client()

--- a/daemon/mgr/container_update_hostname.go
+++ b/daemon/mgr/container_update_hostname.go
@@ -1,0 +1,84 @@
+package mgr
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+	"syscall"
+
+	"github.com/alibaba/pouch/pkg/nsexec"
+)
+
+func init() {
+	nsexec.Register("sethostname", handleUpdateHostname)
+}
+
+func handleUpdateHostname(data []byte) (res []byte, err error) {
+	oldHostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+
+	err = syscall.Sethostname(data)
+	if err != nil {
+		return nil, err
+	}
+
+	//update /etc/hostname and /etc/hosts
+	err = ioutil.WriteFile("/etc/hostname", append(data, '\n'), 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update /etc/hostname: %v", err)
+	}
+
+	hosts, err := ioutil.ReadFile("/etc/hosts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to update /etc/hosts: %v", err)
+	}
+
+	exp1 := regexp.MustCompile(fmt.Sprintf(`\s%s\s`, oldHostname))
+	exp2 := regexp.MustCompile(fmt.Sprintf(`\s%s$`, oldHostname))
+
+	replaceStr1 := fmt.Sprintf(" %s ", string(data))
+	replaceStr2 := fmt.Sprintf(" %s", string(data))
+
+	d := string(hosts)
+	lines := strings.Split(d, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, oldHostname) {
+			continue
+		}
+
+		newLine := line
+
+		if exp1.FindString(newLine) != "" {
+			newLine = exp1.ReplaceAllString(newLine, replaceStr1)
+		}
+
+		if exp2.FindString(newLine) != "" {
+			newLine = exp2.ReplaceAllString(newLine, replaceStr2)
+		}
+
+		lines[i] = newLine
+	}
+
+	newHosts := strings.Join(lines, "\n")
+	err = ioutil.WriteFile("/etc/hosts", []byte(newHosts), 0644)
+
+	return nil, err
+}
+
+func updateHostnameForRunningContainer(hostname string, container *Container) error {
+	pid := container.State.Pid
+	if pid <= 0 {
+		return fmt.Errorf("container pid %d is not vaild", pid)
+	}
+
+	_, err := nsexec.NsExec(int(pid), nsexec.Op{OpCode: "sethostname", Data: []byte(hostname)})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/daemon/mgr/network_utils.go
+++ b/daemon/mgr/network_utils.go
@@ -9,6 +9,11 @@ import (
 	"github.com/docker/libnetwork"
 )
 
+const (
+	// NetworkModeHost means container network mode is host
+	NetworkModeHost = "host"
+)
+
 // IsContainer is used to check if network mode is container mode.
 func IsContainer(mode string) bool {
 	parts := strings.SplitN(mode, ":", 2)
@@ -17,7 +22,7 @@ func IsContainer(mode string) bool {
 
 // IsHost is used to check if network mode is host mode.
 func IsHost(mode string) bool {
-	return mode == "host"
+	return mode == NetworkModeHost
 }
 
 // IsNone is used to check if network mode is none mode.

--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -387,7 +387,7 @@ func setupNamespaces(ctx context.Context, c *Container, specWrapper *SpecWrapper
 
 // isHost indicates whether the container shares the host's corresponding namespace.
 func isHost(mode string) bool {
-	return mode == "host"
+	return mode == NetworkModeHost
 }
 
 // isContainer indicates whether the container uses another container's corresponding namespace.

--- a/main.go
+++ b/main.go
@@ -35,6 +35,10 @@ var (
 	logOpts      []string
 )
 
+func init() {
+	reexec.Register("nsexec", reexecRunNsExec)
+}
+
 var cfg = &config.Config{}
 
 func main() {

--- a/nsexec.go
+++ b/nsexec.go
@@ -1,0 +1,39 @@
+// +build linux
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+
+	"github.com/alibaba/pouch/pkg/nsexec"
+
+	_ "github.com/opencontainers/runc/libcontainer/nsenter"
+	"github.com/sirupsen/logrus"
+)
+
+// reexecRunNsExec will run nsenter in go init and join to container namespace
+func reexecRunNsExec() {
+	logrus.Infof("run reexecRunNsExec")
+	initPipe := os.Getenv("_LIBCONTAINER_INITPIPE")
+	pipeFd, err := strconv.Atoi(initPipe)
+	if err != nil {
+		panic("init pipe get failed")
+	}
+
+	f := os.NewFile(uintptr(pipeFd), "init")
+	defer f.Close()
+
+	nsexecOp := nsexec.Op{}
+	err = json.NewDecoder(f).Decode(&nsexecOp)
+	if err != nil {
+		panic("op failed")
+	}
+
+	res := nsexec.Dispatch(nsexecOp)
+	err = json.NewEncoder(f).Encode(res)
+	if err != nil {
+		panic("send data failed")
+	}
+}

--- a/pkg/nsexec/nsexec_child_linux.go
+++ b/pkg/nsexec/nsexec_child_linux.go
@@ -1,0 +1,26 @@
+package nsexec
+
+import "fmt"
+
+// Dispatch should be called by pouchd nsexec to do function in container namespace
+func Dispatch(op Op) *Result {
+	f, exist := registerFuncMap[op.OpCode]
+	if !exist {
+		return &Result{
+			Finish: true,
+			ErrMsg: fmt.Sprintf("not register nsexec op %s", op.OpCode),
+		}
+	}
+
+	res, err := f(op.Data)
+	errMsg := ""
+	if err != nil {
+		errMsg = err.Error()
+	}
+
+	return &Result{
+		Finish: true,
+		ErrMsg: errMsg,
+		Data:   res,
+	}
+}

--- a/pkg/nsexec/nsexec_linux.go
+++ b/pkg/nsexec/nsexec_linux.go
@@ -1,0 +1,265 @@
+package nsexec
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink/nl"
+)
+
+// Package nsexec is to join container namespace to do some update in container such as update hostname, etc.
+// Calls NsExec with param NsExecOp will do function in container namespace which has been registered
+// by NsExecOp.OpCode. As to realize it, we set a new command nsexec which imports package
+// github.com/opencontainers/runc/libcontainer/nsenter in which use C code to join namespace.
+
+var (
+	registerFuncMap = map[string]func(data []byte) (res []byte, err error){}
+)
+
+// Op is Nsexec input, opCode should be registered
+type Op struct {
+	OpCode string `json:"opCode"`
+	Data   []byte `json:"data"`
+}
+
+// Result is the Nsexec result output
+type Result struct {
+	Finish bool   `json:"finish"`
+	Data   []byte `json:"data"`
+	ErrMsg string `json:"errMsg"`
+}
+
+type pid struct {
+	Pid      int `json:"pid"`
+	PidFirst int `json:"pid_first"`
+}
+
+type process struct {
+	initArgs   []string
+	stdin      io.Reader
+	stdout     io.Writer
+	stderr     io.Writer
+	childPipe  *os.File
+	parentPipe *os.File
+	cmd        *exec.Cmd
+}
+
+const stdioFdCount = 3
+
+// Register function which can execute in container namesapce
+func Register(op string, handle func(data []byte) (res []byte, err error)) {
+	if _, exist := registerFuncMap[op]; exist {
+		panic(fmt.Sprintf("nsexec func already registered under name %s", op))
+	}
+
+	registerFuncMap[op] = handle
+}
+
+func newExecProcess(stdin io.Reader, stdout io.Writer, stderr io.Writer) *process {
+	return &process{
+		initArgs: []string{"/proc/self/exe", "nsexec"},
+		stdin:    stdin,
+		stdout:   stdout,
+		stderr:   stderr,
+	}
+}
+
+func newNsExecCmd(p *process) {
+	cmd := &exec.Cmd{
+		Path: p.initArgs[0],
+		Args: []string{p.initArgs[1]},
+	}
+
+	cmd.ExtraFiles = append(cmd.ExtraFiles, p.childPipe)
+	cmd.Env = append(cmd.Env,
+		fmt.Sprintf("_LIBCONTAINER_INITPIPE=%d", stdioFdCount+len(cmd.ExtraFiles)-1),
+	)
+	cmd.Stdin = p.stdin
+	cmd.Stdout = p.stdout
+	cmd.Stderr = p.stderr
+	p.cmd = cmd
+}
+
+//setns is to wait init process
+func setns(p *process) error {
+	status, err := p.cmd.Process.Wait()
+	if err != nil {
+		p.cmd.Wait()
+		return err
+	}
+
+	if !status.Success() {
+		p.cmd.Wait()
+		logrus.Errorf("in nsexec,set ns failed:%s", status.String())
+		return &exec.ExitError{ProcessState: status}
+	}
+
+	var pid pid
+	err = json.NewDecoder(p.parentPipe).Decode(&pid)
+	if err != nil {
+		p.cmd.Wait()
+		return err
+	}
+
+	logrus.Infof("nsexec new pid is %d, pid_first is %d", pid.Pid, pid.PidFirst)
+
+	pidFirstProcess, err := os.FindProcess(pid.PidFirst)
+	if err != nil {
+		return err
+	}
+	//wait for first child pid to prevent zombie process
+	pidFirstProcess.Wait()
+
+	childProcess, err := os.FindProcess(pid.Pid)
+	if err != nil {
+		return err
+	}
+	//set init process as cmd process
+	p.cmd.Process = childProcess
+	return nil
+}
+
+// can setns in order.
+func orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string, error) {
+	paths := []string{}
+
+	for _, ns := range configs.NamespaceTypes() {
+
+		if p, ok := namespaces[ns]; ok && p != "" {
+			// check if the requested namespace is supported
+			if !configs.IsNamespaceSupported(ns) {
+				return nil, fmt.Errorf("namespace %s is not supported", ns)
+			}
+			// only set to join this namespace if it exists
+			if _, err := os.Lstat(p); err != nil {
+				return nil, fmt.Errorf("running lstat on namespace path %q, error:%s", p, err.Error())
+			}
+			// do not allow namespace path with comma as we use it to separate
+			// the namespace paths
+			if strings.ContainsRune(p, ',') {
+				return nil, fmt.Errorf("invalid path %s", p)
+			}
+			paths = append(paths, fmt.Sprintf("%s:%s", configs.NsName(ns), p))
+		}
+
+	}
+
+	return paths, nil
+}
+
+// NsExec is the entry to do ns exec and then do something in container namespace
+func NsExec(pid int, op Op) (result *Result, err error) {
+	nsMap := map[configs.NamespaceType]string{}
+	for _, nsType := range configs.NamespaceTypes() {
+		if !configs.IsNamespaceSupported(nsType) {
+			continue
+		}
+
+		//not set user namespace
+		if nsType == configs.NEWUSER {
+			continue
+		}
+
+		if _, ok := nsMap[nsType]; !ok {
+			ns := configs.Namespace{Type: nsType}
+			nsMap[ns.Type] = ns.GetPath(pid)
+		}
+	}
+
+	// build bootstrap data
+	// create the netlink message
+	r := nl.NewNetlinkRequest(int(libcontainer.InitMsg), 0)
+
+	// write cloneFlags
+	r.AddData(&libcontainer.Int32msg{
+		Type:  libcontainer.CloneFlagsAttr,
+		Value: uint32(0),
+	})
+
+	// write custom namespace paths
+	if len(nsMap) > 0 {
+		nsPaths, err := orderNamespacePaths(nsMap)
+		if err != nil {
+			return nil, err
+		}
+		r.AddData(&libcontainer.Bytemsg{
+			Type:  libcontainer.NsPathsAttr,
+			Value: []byte(strings.Join(nsPaths, ",")),
+		})
+	}
+
+	bootstrapData := bytes.NewReader(r.Serialize())
+
+	//create peer pipe
+	parentPipe, childPipe, err := utils.NewSockPair("init")
+	if err != nil {
+		return nil, err
+	}
+
+	defer parentPipe.Close()
+
+	buffer := bytes.NewBuffer(nil)
+	p := newExecProcess(nil, nil, buffer)
+	p.childPipe = childPipe
+	p.parentPipe = parentPipe
+
+	newNsExecCmd(p)
+	err = p.cmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("start nsexec failed:%s", err.Error())
+	}
+
+	childPipe.Close()
+
+	logrus.Infof("child pid is %d", p.cmd.Process.Pid)
+
+	defer func() {
+		if err != nil {
+			logrus.Errorf("nsexec read stderr from child:%s", buffer.String())
+		}
+	}()
+
+	//send bootstrapData to nsenter to join namespace
+	_, err = io.Copy(parentPipe, bootstrapData)
+	if err != nil {
+		return nil, fmt.Errorf("send bootstrapData to nsexec failed:%s", err.Error())
+	}
+
+	if err = setns(p); err != nil {
+		return nil, fmt.Errorf("set exec ns error:%s", err.Error())
+	}
+
+	if err = json.NewEncoder(parentPipe).Encode(op); err != nil {
+		return nil, fmt.Errorf("send NsExecOp error:%s", err.Error())
+	}
+
+	res := &Result{}
+	if err = json.NewDecoder(parentPipe).Decode(res); err != nil {
+		if err != io.EOF {
+			return nil, fmt.Errorf("read res from pipe error:%s", err.Error())
+		}
+	}
+
+	logrus.Infof("NsExecResult: %v", res)
+
+	if !res.Finish {
+		return nil, fmt.Errorf("not finish nsexec")
+	}
+
+	if err := syscall.Shutdown(int(p.parentPipe.Fd()), syscall.SHUT_WR); err != nil {
+		return nil, fmt.Errorf("shutting down init pipe failed:%s", err.Error())
+	}
+	// Must be done after Shutdown so the child will exit and we can wait for it.
+	p.cmd.Wait()
+	return res, nil
+}

--- a/pkg/nsexec/nsexec_unsupported.go
+++ b/pkg/nsexec/nsexec_unsupported.go
@@ -1,0 +1,21 @@
+// +build !linux
+
+package nsexec
+
+import "errors"
+
+//nsexec op struct, opCode should be registered
+type NsExecOp struct {
+	OpCode string `json:"opCode"`
+	Data   []byte `json:"data"`
+}
+
+type NsExecResult struct {
+	Finish bool   `json:"finish"`
+	Data   []byte `json:"data"`
+	ErrMsg string `json:"errMsg"`
+}
+
+func NsExec(pid int, op NsExecOp) (result *NsExecResult, err error) {
+	return errors.New("not supported")
+}

--- a/test/api_container_update_test.go
+++ b/test/api_container_update_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"strings"
+
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/go-check/check"
+
+	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/test/request"
+)
+
+// APIContainerUpdateSuite is the test suite for container attach API.
+type APIContainerUpdateSuite struct{}
+
+func init() {
+	check.Suite(&APIContainerUpdateSuite{})
+}
+
+// SetUpTest does common setup in the beginning of each test.
+func (suite *APIContainerUpdateSuite) SetUpTest(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	PullImage(c, busyboxImage)
+}
+
+func checkEqual(c *check.C, tty bool, conn net.Conn, br *bufio.Reader, exp string) {
+	defer conn.Close()
+
+	// Allocate a large space incase there is error.
+	var (
+		buf bytes.Buffer
+		err error
+	)
+
+	if !tty {
+		_, err = stdcopy.StdCopy(&buf, &buf, br)
+	} else {
+		_, err = io.Copy(&buf, br)
+	}
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.TrimSpace(buf.String()), check.Equals, exp, check.Commentf("Expected %s, got %s", exp, buf.String()))
+}
+
+// TestStoppedContainerUpdateHostname test stopped container update hostname
+func (suite *APIContainerUpdateSuite) TestStoppedContainerUpdateHostname(c *check.C) {
+	cname := "TestUpdateOk"
+	newHostname := "abcdefgh"
+
+	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
+
+	StartContainerOk(c, cname)
+	StopContainerOk(c, cname)
+
+	UpdateContaineHostnamerOK(c, cname, newHostname)
+	resp, err := request.Get("/containers/" + cname + "/json")
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 200)
+
+	got := types.ContainerJSON{}
+	err = request.DecodeBody(&got, resp.Body)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(string(got.Config.Hostname), check.Equals, newHostname)
+}
+
+// TestStoppedContainerUpdateHostname test stopped container update hostname
+func (suite *APIContainerUpdateSuite) TestRunningContainerUpdateHostname(c *check.C) {
+	cname := "TestUpdateOk"
+	newHostname := "abcdefgh"
+
+	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
+
+	StartContainerOk(c, cname)
+
+	UpdateContaineHostnamerOK(c, cname, newHostname)
+	resp, err := request.Get("/containers/" + cname + "/json")
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 200)
+
+	got := types.ContainerJSON{}
+	err = request.DecodeBody(&got, resp.Body)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(string(got.Config.Hostname), check.Equals, newHostname)
+
+	execID := CreateExecHostnameOk(c, cname)
+	obj := map[string]interface{}{}
+	resp, conn, br, err := request.Hijack("/exec/"+execID+"/start", request.WithJSONBody(obj))
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 200)
+	checkEqual(c, false, conn, br, newHostname)
+}

--- a/test/util_api.go
+++ b/test/util_api.go
@@ -336,3 +336,39 @@ func GetMetric(c *check.C, key string, keySuccess string) (int, int) {
 
 	return iCount, iCountSuccess
 }
+
+// UpdateContaineHostnamerOK update container and check resp is ok
+func UpdateContaineHostnamerOK(c *check.C, cname string, hostname string) {
+	updateConfig := map[string]interface{}{
+		"hostname": hostname,
+	}
+
+	resp, err := request.Post("/containers/"+cname+"/update", request.WithJSONBody(updateConfig))
+	c.Assert(err, check.IsNil)
+
+	defer resp.Body.Close()
+	CheckRespStatus(c, resp, 200)
+}
+
+// CreateExecHostnameOk exec process's environment with "hostname" CMD.
+func CreateExecHostnameOk(c *check.C, cname string) string {
+	obj := map[string]interface{}{
+		"Cmd":          []string{"hostname"},
+		"Detach":       true,
+		"AttachStderr": true,
+		"AttachStdout": true,
+		"AttachStdin":  true,
+		"Privileged":   false,
+		"User":         "",
+	}
+
+	body := request.WithJSONBody(obj)
+	resp, err := request.Post("/containers/"+cname+"/exec", body)
+
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 201)
+
+	var got types.ExecCreateResp
+	c.Assert(request.DecodeBody(&got, resp.Body), check.IsNil)
+	return got.ID
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/message_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/message_linux.go
@@ -1,0 +1,89 @@
+// +build linux
+
+package libcontainer
+
+import (
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+// list of known message types we want to send to bootstrap program
+// The number is randomly chosen to not conflict with known netlink types
+const (
+	InitMsg         uint16 = 62000
+	CloneFlagsAttr  uint16 = 27281
+	NsPathsAttr     uint16 = 27282
+	UidmapAttr      uint16 = 27283
+	GidmapAttr      uint16 = 27284
+	SetgroupAttr    uint16 = 27285
+	OomScoreAdjAttr uint16 = 27286
+	RootlessAttr    uint16 = 27287
+	UidmapPathAttr  uint16 = 27288
+	GidmapPathAttr  uint16 = 27289
+)
+
+type Int32msg struct {
+	Type  uint16
+	Value uint32
+}
+
+// Serialize serializes the message.
+// Int32msg has the following representation
+// | nlattr len | nlattr type |
+// | uint32 value             |
+func (msg *Int32msg) Serialize() []byte {
+	buf := make([]byte, msg.Len())
+	native := nl.NativeEndian()
+	native.PutUint16(buf[0:2], uint16(msg.Len()))
+	native.PutUint16(buf[2:4], msg.Type)
+	native.PutUint32(buf[4:8], msg.Value)
+	return buf
+}
+
+func (msg *Int32msg) Len() int {
+	return unix.NLA_HDRLEN + 4
+}
+
+// Bytemsg has the following representation
+// | nlattr len | nlattr type |
+// | value              | pad |
+type Bytemsg struct {
+	Type  uint16
+	Value []byte
+}
+
+func (msg *Bytemsg) Serialize() []byte {
+	l := msg.Len()
+	buf := make([]byte, (l+unix.NLA_ALIGNTO-1) & ^(unix.NLA_ALIGNTO-1))
+	native := nl.NativeEndian()
+	native.PutUint16(buf[0:2], uint16(l))
+	native.PutUint16(buf[2:4], msg.Type)
+	copy(buf[4:], msg.Value)
+	return buf
+}
+
+func (msg *Bytemsg) Len() int {
+	return unix.NLA_HDRLEN + len(msg.Value) + 1 // null-terminated
+}
+
+type Boolmsg struct {
+	Type  uint16
+	Value bool
+}
+
+func (msg *Boolmsg) Serialize() []byte {
+	buf := make([]byte, msg.Len())
+	native := nl.NativeEndian()
+	native.PutUint16(buf[0:2], uint16(msg.Len()))
+	native.PutUint16(buf[2:4], msg.Type)
+	if msg.Value {
+		buf[4] = 1
+	} else {
+		buf[4] = 0
+	}
+	return buf
+}
+
+func (msg *Boolmsg) Len() int {
+	return unix.NLA_HDRLEN + 1
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/README.md
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/README.md
@@ -1,0 +1,44 @@
+## nsenter
+
+The `nsenter` package registers a special init constructor that is called before 
+the Go runtime has a chance to boot.  This provides us the ability to `setns` on 
+existing namespaces and avoid the issues that the Go runtime has with multiple 
+threads.  This constructor will be called if this package is registered, 
+imported, in your go application.
+
+The `nsenter` package will `import "C"` and it uses [cgo](https://golang.org/cmd/cgo/)
+package. In cgo, if the import of "C" is immediately preceded by a comment, that comment, 
+called the preamble, is used as a header when compiling the C parts of the package.
+So every time we  import package `nsenter`, the C code function `nsexec()` would be 
+called. And package `nsenter` is now only imported in `main_unix.go`, so every time
+before we call `cmd.Start` on linux, that C code would run.
+
+Because `nsexec()` must be run before the Go runtime in order to use the
+Linux kernel namespace, you must `import` this library into a package if
+you plan to use `libcontainer` directly. Otherwise Go will not execute
+the `nsexec()` constructor, which means that the re-exec will not cause
+the namespaces to be joined. You can import it like this:
+
+```go
+import _ "github.com/opencontainers/runc/libcontainer/nsenter"
+```
+
+`nsexec()` will first get the file descriptor number for the init pipe
+from the environment variable `_LIBCONTAINER_INITPIPE` (which was opened
+by the parent and kept open across the fork-exec of the `nsexec()` init
+process). The init pipe is used to read bootstrap data (namespace paths,
+clone flags, uid and gid mappings, and the console path) from the parent
+process. `nsexec()` will then call `setns(2)` to join the namespaces
+provided in the bootstrap data (if available), `clone(2)` a child process
+with the provided clone flags, update the user and group ID mappings, do
+some further miscellaneous setup steps, and then send the PID of the
+child process to the parent of the `nsexec()` "caller". Finally,
+the parent `nsexec()` will exit and the child `nsexec()` process will
+return to allow the Go runtime take over.
+
+NOTE: We do both `setns(2)` and `clone(2)` even if we don't have any
+CLONE_NEW* clone flags because we must fork a new process in order to
+enter the PID namespace.
+
+
+

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/namespace.h
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/namespace.h
@@ -1,0 +1,32 @@
+#ifndef NSENTER_NAMESPACE_H
+#define NSENTER_NAMESPACE_H
+
+#ifndef _GNU_SOURCE
+#	define _GNU_SOURCE
+#endif
+#include <sched.h>
+
+/* All of these are taken from include/uapi/linux/sched.h */
+#ifndef CLONE_NEWNS
+#	define CLONE_NEWNS 0x00020000 /* New mount namespace group */
+#endif
+#ifndef CLONE_NEWCGROUP
+#	define CLONE_NEWCGROUP 0x02000000 /* New cgroup namespace */
+#endif
+#ifndef CLONE_NEWUTS
+#	define CLONE_NEWUTS 0x04000000 /* New utsname namespace */
+#endif
+#ifndef CLONE_NEWIPC
+#	define CLONE_NEWIPC 0x08000000 /* New ipc namespace */
+#endif
+#ifndef CLONE_NEWUSER
+#	define CLONE_NEWUSER 0x10000000 /* New user namespace */
+#endif
+#ifndef CLONE_NEWPID
+#	define CLONE_NEWPID 0x20000000 /* New pid namespace */
+#endif
+#ifndef CLONE_NEWNET
+#	define CLONE_NEWNET 0x40000000 /* New network namespace */
+#endif
+
+#endif /* NSENTER_NAMESPACE_H */

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsenter.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsenter.go
@@ -1,0 +1,12 @@
+// +build linux,!gccgo
+
+package nsenter
+
+/*
+#cgo CFLAGS: -Wall
+extern void nsexec();
+void __attribute__((constructor)) init(void) {
+	nsexec();
+}
+*/
+import "C"

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsenter_gccgo.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsenter_gccgo.go
@@ -1,0 +1,25 @@
+// +build linux,gccgo
+
+package nsenter
+
+/*
+#cgo CFLAGS: -Wall
+extern void nsexec();
+void __attribute__((constructor)) init(void) {
+	nsexec();
+}
+*/
+import "C"
+
+// AlwaysFalse is here to stay false
+// (and be exported so the compiler doesn't optimize out its reference)
+var AlwaysFalse bool
+
+func init() {
+	if AlwaysFalse {
+		// by referencing this C init() in a noop test, it will ensure the compiler
+		// links in the C function.
+		// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65134
+		C.init()
+	}
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsenter_unsupported.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsenter_unsupported.go
@@ -1,0 +1,5 @@
+// +build !linux !cgo
+
+package nsenter
+
+import "C"

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
@@ -1,0 +1,964 @@
+
+#define _GNU_SOURCE
+#include <endian.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <grp.h>
+#include <sched.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/ioctl.h>
+#include <sys/prctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+
+#include <linux/limits.h>
+#include <linux/netlink.h>
+#include <linux/types.h>
+
+/* Get all of the CLONE_NEW* flags. */
+#include "namespace.h"
+
+/* Synchronisation values. */
+enum sync_t {
+	SYNC_USERMAP_PLS = 0x40, /* Request parent to map our users. */
+	SYNC_USERMAP_ACK = 0x41, /* Mapping finished by the parent. */
+	SYNC_RECVPID_PLS = 0x42, /* Tell parent we're sending the PID. */
+	SYNC_RECVPID_ACK = 0x43, /* PID was correctly received by parent. */
+	SYNC_GRANDCHILD  = 0x44, /* The grandchild is ready to run. */
+	SYNC_CHILD_READY = 0x45, /* The child or grandchild is ready to return. */
+
+	/* XXX: This doesn't help with segfaults and other such issues. */
+	SYNC_ERR = 0xFF, /* Fatal error, no turning back. The error code follows. */
+};
+
+/* longjmp() arguments. */
+#define JUMP_PARENT 0x00
+#define JUMP_CHILD  0xA0
+#define JUMP_INIT   0xA1
+
+/* JSON buffer. */
+#define JSON_MAX 4096
+
+/* Assume the stack grows down, so arguments should be above it. */
+struct clone_t {
+	/*
+	 * Reserve some space for clone() to locate arguments
+	 * and retcode in this place
+	 */
+	char stack[4096] __attribute__ ((aligned(16)));
+	char stack_ptr[0];
+
+	/* There's two children. This is used to execute the different code. */
+	jmp_buf *env;
+	int jmpval;
+};
+
+struct nlconfig_t {
+	char *data;
+
+	/* Process settings. */
+	uint32_t cloneflags;
+	char *oom_score_adj;
+	size_t oom_score_adj_len;
+
+	/* User namespace settings.*/
+	char *uidmap;
+	size_t uidmap_len;
+	char *gidmap;
+	size_t gidmap_len;
+	char *namespaces;
+	size_t namespaces_len;
+	uint8_t is_setgroup;
+
+	/* Rootless container settings.*/
+	uint8_t is_rootless;
+	char *uidmappath;
+	size_t uidmappath_len;
+	char *gidmappath;
+	size_t gidmappath_len;
+};
+
+/*
+ * List of netlink message types sent to us as part of bootstrapping the init.
+ * These constants are defined in libcontainer/message_linux.go.
+ */
+#define INIT_MSG			62000
+#define CLONE_FLAGS_ATTR	27281
+#define NS_PATHS_ATTR		27282
+#define UIDMAP_ATTR			27283
+#define GIDMAP_ATTR			27284
+#define SETGROUP_ATTR		27285
+#define OOM_SCORE_ADJ_ATTR	27286
+#define ROOTLESS_ATTR	    27287
+#define UIDMAPPATH_ATTR	    27288
+#define GIDMAPPATH_ATTR	    27289
+
+/*
+ * Use the raw syscall for versions of glibc which don't include a function for
+ * it, namely (glibc 2.12).
+ */
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 14
+#	define _GNU_SOURCE
+#	include "syscall.h"
+#	if !defined(SYS_setns) && defined(__NR_setns)
+#		define SYS_setns __NR_setns
+#	endif
+
+#ifndef SYS_setns
+#	error "setns(2) syscall not supported by glibc version"
+#endif
+
+int setns(int fd, int nstype)
+{
+	return syscall(SYS_setns, fd, nstype);
+}
+#endif
+
+/* XXX: This is ugly. */
+static int syncfd = -1;
+
+/* TODO(cyphar): Fix this so it correctly deals with syncT. */
+#define bail(fmt, ...)								\
+	do {									\
+		int ret = __COUNTER__ + 1;					\
+		fprintf(stderr, "nsenter: " fmt ": %m\n", ##__VA_ARGS__);	\
+		if (syncfd >= 0) {						\
+			enum sync_t s = SYNC_ERR;				\
+			if (write(syncfd, &s, sizeof(s)) != sizeof(s))		\
+				fprintf(stderr, "nsenter: failed: write(s)");	\
+			if (write(syncfd, &ret, sizeof(ret)) != sizeof(ret))	\
+				fprintf(stderr, "nsenter: failed: write(ret)");	\
+		}								\
+		exit(ret);							\
+	} while(0)
+
+static int write_file(char *data, size_t data_len, char *pathfmt, ...)
+{
+	int fd, len, ret = 0;
+	char path[PATH_MAX];
+
+	va_list ap;
+	va_start(ap, pathfmt);
+	len = vsnprintf(path, PATH_MAX, pathfmt, ap);
+	va_end(ap);
+	if (len < 0)
+		return -1;
+
+	fd = open(path, O_RDWR);
+	if (fd < 0) {
+		return -1;
+	}
+
+	len = write(fd, data, data_len);
+	if (len != data_len) {
+		ret = -1;
+		goto out;
+	}
+
+out:
+	close(fd);
+	return ret;
+}
+
+enum policy_t {
+	SETGROUPS_DEFAULT = 0,
+	SETGROUPS_ALLOW,
+	SETGROUPS_DENY,
+};
+
+/* This *must* be called before we touch gid_map. */
+static void update_setgroups(int pid, enum policy_t setgroup)
+{
+	char *policy;
+
+	switch (setgroup) {
+		case SETGROUPS_ALLOW:
+			policy = "allow";
+			break;
+		case SETGROUPS_DENY:
+			policy = "deny";
+			break;
+		case SETGROUPS_DEFAULT:
+		default:
+			/* Nothing to do. */
+			return;
+	}
+
+	if (write_file(policy, strlen(policy), "/proc/%d/setgroups", pid) < 0) {
+		/*
+		 * If the kernel is too old to support /proc/pid/setgroups,
+		 * open(2) or write(2) will return ENOENT. This is fine.
+		 */
+		if (errno != ENOENT)
+			bail("failed to write '%s' to /proc/%d/setgroups", policy, pid);
+	}
+}
+
+static int try_mapping_tool(const char *app, int pid, char *map, size_t map_len)
+{
+	int child;
+
+	/*
+	 * If @app is NULL, execve will segfault. Just check it here and bail (if
+	 * we're in this path, the caller is already getting desparate and there
+	 * isn't a backup to this failing). This usually would be a configuration
+	 * or programming issue.
+	 */
+	if (!app)
+		bail("mapping tool not present");
+
+	child = fork();
+	if (child < 0)
+		bail("failed to fork");
+
+	if (!child) {
+#define MAX_ARGV 20
+		char *argv[MAX_ARGV];
+		char *envp[] = {NULL};
+		char pid_fmt[16];
+		int argc = 0;
+		char *next;
+
+		snprintf(pid_fmt, 16, "%d", pid);
+
+		argv[argc++] = (char *) app;
+		argv[argc++] = pid_fmt;
+		/*
+		 * Convert the map string into a list of argument that
+		 * newuidmap/newgidmap can understand.
+		 */
+
+		while (argc < MAX_ARGV) {
+			if (*map == '\0') {
+				argv[argc++] = NULL;
+				break;
+			}
+			argv[argc++] = map;
+			next = strpbrk(map, "\n ");
+			if (next == NULL)
+				break;
+			*next++ = '\0';
+			map = next + strspn(next, "\n ");
+		}
+
+		execve(app, argv, envp);
+		bail("failed to execv");
+	} else {
+		int status;
+
+		while (true) {
+			if (waitpid(child, &status, 0) < 0) {
+				if (errno == EINTR)
+					continue;
+				bail("failed to waitpid");
+			}
+			if (WIFEXITED(status) || WIFSIGNALED(status))
+				return WEXITSTATUS(status);
+		}
+	}
+
+	return -1;
+}
+
+static void update_uidmap(const char *path, int pid, char *map, size_t map_len)
+{
+	if (map == NULL || map_len <= 0)
+		return;
+
+	if (write_file(map, map_len, "/proc/%d/uid_map", pid) < 0) {
+		if (errno != EPERM)
+			bail("failed to update /proc/%d/uid_map", pid);
+		if (try_mapping_tool(path, pid, map, map_len))
+			bail("failed to use newuid map on %d", pid);
+	}
+}
+
+static void update_gidmap(const char *path, int pid, char *map, size_t map_len)
+{
+	if (map == NULL || map_len <= 0)
+		return;
+
+	if (write_file(map, map_len, "/proc/%d/gid_map", pid) < 0) {
+		if (errno != EPERM)
+			bail("failed to update /proc/%d/gid_map", pid);
+		if (try_mapping_tool(path, pid, map, map_len))
+			bail("failed to use newgid map on %d", pid);
+	}
+}
+
+static void update_oom_score_adj(char *data, size_t len)
+{
+	if (data == NULL || len <= 0)
+		return;
+
+	if (write_file(data, len, "/proc/self/oom_score_adj") < 0)
+		bail("failed to update /proc/self/oom_score_adj");
+}
+
+/* A dummy function that just jumps to the given jumpval. */
+static int child_func(void *arg) __attribute__ ((noinline));
+static int child_func(void *arg)
+{
+	struct clone_t *ca = (struct clone_t *)arg;
+	longjmp(*ca->env, ca->jmpval);
+}
+
+static int clone_parent(jmp_buf *env, int jmpval) __attribute__ ((noinline));
+static int clone_parent(jmp_buf *env, int jmpval)
+{
+	struct clone_t ca = {
+		.env    = env,
+		.jmpval = jmpval,
+	};
+
+	return clone(child_func, ca.stack_ptr, CLONE_PARENT | SIGCHLD, &ca);
+}
+
+/*
+ * Gets the init pipe fd from the environment, which is used to read the
+ * bootstrap data and tell the parent what the new pid is after we finish
+ * setting up the environment.
+ */
+static int initpipe(void)
+{
+	int pipenum;
+	char *initpipe, *endptr;
+
+	initpipe = getenv("_LIBCONTAINER_INITPIPE");
+	if (initpipe == NULL || *initpipe == '\0')
+		return -1;
+
+	pipenum = strtol(initpipe, &endptr, 10);
+	if (*endptr != '\0')
+		bail("unable to parse _LIBCONTAINER_INITPIPE");
+
+	return pipenum;
+}
+
+/* Returns the clone(2) flag for a namespace, given the name of a namespace. */
+static int nsflag(char *name)
+{
+	if (!strcmp(name, "cgroup"))
+		return CLONE_NEWCGROUP;
+	else if (!strcmp(name, "ipc"))
+		return CLONE_NEWIPC;
+	else if (!strcmp(name, "mnt"))
+		return CLONE_NEWNS;
+	else if (!strcmp(name, "net"))
+		return CLONE_NEWNET;
+	else if (!strcmp(name, "pid"))
+		return CLONE_NEWPID;
+	else if (!strcmp(name, "user"))
+		return CLONE_NEWUSER;
+	else if (!strcmp(name, "uts"))
+		return CLONE_NEWUTS;
+
+	/* If we don't recognise a name, fallback to 0. */
+	return 0;
+}
+
+static uint32_t readint32(char *buf)
+{
+	return *(uint32_t *) buf;
+}
+
+static uint8_t readint8(char *buf)
+{
+	return *(uint8_t *) buf;
+}
+
+static void nl_parse(int fd, struct nlconfig_t *config)
+{
+	size_t len, size;
+	struct nlmsghdr hdr;
+	char *data, *current;
+
+	/* Retrieve the netlink header. */
+	len = read(fd, &hdr, NLMSG_HDRLEN);
+	if (len != NLMSG_HDRLEN)
+		bail("invalid netlink header length %zu", len);
+
+	if (hdr.nlmsg_type == NLMSG_ERROR)
+		bail("failed to read netlink message");
+
+	if (hdr.nlmsg_type != INIT_MSG)
+		bail("unexpected msg type %d", hdr.nlmsg_type);
+
+	/* Retrieve data. */
+	size = NLMSG_PAYLOAD(&hdr, 0);
+	current = data = malloc(size);
+	if (!data)
+		bail("failed to allocate %zu bytes of memory for nl_payload", size);
+
+	len = read(fd, data, size);
+	if (len != size)
+		bail("failed to read netlink payload, %zu != %zu", len, size);
+
+	/* Parse the netlink payload. */
+	config->data = data;
+	while (current < data + size) {
+		struct nlattr *nlattr = (struct nlattr *)current;
+		size_t payload_len = nlattr->nla_len - NLA_HDRLEN;
+
+		/* Advance to payload. */
+		current += NLA_HDRLEN;
+
+		/* Handle payload. */
+		switch (nlattr->nla_type) {
+		case CLONE_FLAGS_ATTR:
+			config->cloneflags = readint32(current);
+			break;
+		case ROOTLESS_ATTR:
+			config->is_rootless = readint8(current);
+			break;
+		case OOM_SCORE_ADJ_ATTR:
+			config->oom_score_adj = current;
+			config->oom_score_adj_len = payload_len;
+			break;
+		case NS_PATHS_ATTR:
+			config->namespaces = current;
+			config->namespaces_len = payload_len;
+			break;
+		case UIDMAP_ATTR:
+			config->uidmap = current;
+			config->uidmap_len = payload_len;
+			break;
+		case GIDMAP_ATTR:
+			config->gidmap = current;
+			config->gidmap_len = payload_len;
+			break;
+		case UIDMAPPATH_ATTR:
+			config->uidmappath = current;
+			config->uidmappath_len = payload_len;
+			break;
+		case GIDMAPPATH_ATTR:
+			config->gidmappath = current;
+			config->gidmappath_len = payload_len;
+			break;
+		case SETGROUP_ATTR:
+			config->is_setgroup = readint8(current);
+			break;
+		default:
+			bail("unknown netlink message type %d", nlattr->nla_type);
+		}
+
+		current += NLA_ALIGN(payload_len);
+	}
+}
+
+void nl_free(struct nlconfig_t *config)
+{
+	free(config->data);
+}
+
+void join_namespaces(char *nslist)
+{
+	int num = 0, i;
+	char *saveptr = NULL;
+	char *namespace = strtok_r(nslist, ",", &saveptr);
+	struct namespace_t {
+		int fd;
+		int ns;
+		char type[PATH_MAX];
+		char path[PATH_MAX];
+	} *namespaces = NULL;
+
+	if (!namespace || !strlen(namespace) || !strlen(nslist))
+		bail("ns paths are empty");
+
+	/*
+	 * We have to open the file descriptors first, since after
+	 * we join the mnt namespace we might no longer be able to
+	 * access the paths.
+	 */
+	do {
+		int fd;
+		char *path;
+		struct namespace_t *ns;
+
+		/* Resize the namespace array. */
+		namespaces = realloc(namespaces, ++num * sizeof(struct namespace_t));
+		if (!namespaces)
+			bail("failed to reallocate namespace array");
+		ns = &namespaces[num - 1];
+
+		/* Split 'ns:path'. */
+		path = strstr(namespace, ":");
+		if (!path)
+			bail("failed to parse %s", namespace);
+		*path++ = '\0';
+
+		fd = open(path, O_RDONLY);
+		if (fd < 0)
+			bail("failed to open %s", path);
+
+		ns->fd = fd;
+		ns->ns = nsflag(namespace);
+		strncpy(ns->path, path, PATH_MAX);
+	} while ((namespace = strtok_r(NULL, ",", &saveptr)) != NULL);
+
+	/*
+	 * The ordering in which we join namespaces is important. We should
+	 * always join the user namespace *first*. This is all guaranteed
+	 * from the container_linux.go side of this, so we're just going to
+	 * follow the order given to us.
+	 */
+
+	for (i = 0; i < num; i++) {
+		struct namespace_t ns = namespaces[i];
+
+		if (setns(ns.fd, ns.ns) < 0)
+			bail("failed to setns to %s", ns.path);
+
+		close(ns.fd);
+	}
+
+	free(namespaces);
+}
+
+void nsexec(void)
+{
+	int pipenum;
+	jmp_buf env;
+	int sync_child_pipe[2], sync_grandchild_pipe[2];
+	struct nlconfig_t config = {0};
+
+	/*
+	 * If we don't have an init pipe, just return to the go routine.
+	 * We'll only get an init pipe for start or exec.
+	 */
+	pipenum = initpipe();
+	if (pipenum == -1)
+		return;
+
+	/* Parse all of the netlink configuration. */
+	nl_parse(pipenum, &config);
+
+	/* Set oom_score_adj. This has to be done before !dumpable because
+	 * /proc/self/oom_score_adj is not writeable unless you're an privileged
+	 * user (if !dumpable is set). All children inherit their parent's
+	 * oom_score_adj value on fork(2) so this will always be propagated
+	 * properly.
+	 */
+	update_oom_score_adj(config.oom_score_adj, config.oom_score_adj_len);
+
+	/*
+	 * Make the process non-dumpable, to avoid various race conditions that
+	 * could cause processes in namespaces we're joining to access host
+	 * resources (or potentially execute code).
+	 *
+	 * However, if the number of namespaces we are joining is 0, we are not
+	 * going to be switching to a different security context. Thus setting
+	 * ourselves to be non-dumpable only breaks things (like rootless
+	 * containers), which is the recommendation from the kernel folks.
+	 */
+	if (config.namespaces) {
+		if (prctl(PR_SET_DUMPABLE, 0, 0, 0, 0) < 0)
+			bail("failed to set process as non-dumpable");
+	}
+
+	/* Pipe so we can tell the child when we've finished setting up. */
+	if (socketpair(AF_LOCAL, SOCK_STREAM, 0, sync_child_pipe) < 0)
+		bail("failed to setup sync pipe between parent and child");
+
+	/*
+	 * We need a new socketpair to sync with grandchild so we don't have
+	 * race condition with child.
+	 */
+	if (socketpair(AF_LOCAL, SOCK_STREAM, 0, sync_grandchild_pipe) < 0)
+		bail("failed to setup sync pipe between parent and grandchild");
+
+	/* TODO: Currently we aren't dealing with child deaths properly. */
+
+	/*
+	 * Okay, so this is quite annoying.
+	 *
+	 * In order for this unsharing code to be more extensible we need to split
+	 * up unshare(CLONE_NEWUSER) and clone() in various ways. The ideal case
+	 * would be if we did clone(CLONE_NEWUSER) and the other namespaces
+	 * separately, but because of SELinux issues we cannot really do that. But
+	 * we cannot just dump the namespace flags into clone(...) because several
+	 * usecases (such as rootless containers) require more granularity around
+	 * the namespace setup. In addition, some older kernels had issues where
+	 * CLONE_NEWUSER wasn't handled before other namespaces (but we cannot
+	 * handle this while also dealing with SELinux so we choose SELinux support
+	 * over broken kernel support).
+	 *
+	 * However, if we unshare(2) the user namespace *before* we clone(2), then
+	 * all hell breaks loose.
+	 *
+	 * The parent no longer has permissions to do many things (unshare(2) drops
+	 * all capabilities in your old namespace), and the container cannot be set
+	 * up to have more than one {uid,gid} mapping. This is obviously less than
+	 * ideal. In order to fix this, we have to first clone(2) and then unshare.
+	 *
+	 * Unfortunately, it's not as simple as that. We have to fork to enter the
+	 * PID namespace (the PID namespace only applies to children). Since we'll
+	 * have to double-fork, this clone_parent() call won't be able to get the
+	 * PID of the _actual_ init process (without doing more synchronisation than
+	 * I can deal with at the moment). So we'll just get the parent to send it
+	 * for us, the only job of this process is to update
+	 * /proc/pid/{setgroups,uid_map,gid_map}.
+	 *
+	 * And as a result of the above, we also need to setns(2) in the first child
+	 * because if we join a PID namespace in the topmost parent then our child
+	 * will be in that namespace (and it will not be able to give us a PID value
+	 * that makes sense without resorting to sending things with cmsg).
+	 *
+	 * This also deals with an older issue caused by dumping cloneflags into
+	 * clone(2): On old kernels, CLONE_PARENT didn't work with CLONE_NEWPID, so
+	 * we have to unshare(2) before clone(2) in order to do this. This was fixed
+	 * in upstream commit 1f7f4dde5c945f41a7abc2285be43d918029ecc5, and was
+	 * introduced by 40a0d32d1eaffe6aac7324ca92604b6b3977eb0e. As far as we're
+	 * aware, the last mainline kernel which had this bug was Linux 3.12.
+	 * However, we cannot comment on which kernels the broken patch was
+	 * backported to.
+	 *
+	 * -- Aleksa "what has my life come to?" Sarai
+	 */
+
+	switch (setjmp(env)) {
+	/*
+	 * Stage 0: We're in the parent. Our job is just to create a new child
+	 *          (stage 1: JUMP_CHILD) process and write its uid_map and
+	 *          gid_map. That process will go on to create a new process, then
+	 *          it will send us its PID which we will send to the bootstrap
+	 *          process.
+	 */
+	case JUMP_PARENT: {
+			int len;
+			pid_t child, first_child = -1;
+			char buf[JSON_MAX];
+			bool ready = false;
+
+			/* For debugging. */
+			prctl(PR_SET_NAME, (unsigned long) "runc:[0:PARENT]", 0, 0, 0);
+
+			/* Start the process of getting a container. */
+			child = clone_parent(&env, JUMP_CHILD);
+			if (child < 0)
+				bail("unable to fork: child_func");
+
+			/*
+			 * State machine for synchronisation with the children.
+			 *
+			 * Father only return when both child and grandchild are
+			 * ready, so we can receive all possible error codes
+			 * generated by children.
+			 */
+			while (!ready) {
+				enum sync_t s;
+				int ret;
+
+				syncfd = sync_child_pipe[1];
+				close(sync_child_pipe[0]);
+
+				if (read(syncfd, &s, sizeof(s)) != sizeof(s))
+					bail("failed to sync with child: next state");
+
+				switch (s) {
+				case SYNC_ERR:
+					/* We have to mirror the error code of the child. */
+					if (read(syncfd, &ret, sizeof(ret)) != sizeof(ret))
+						bail("failed to sync with child: read(error code)");
+
+					exit(ret);
+				case SYNC_USERMAP_PLS:
+					/*
+					 * Enable setgroups(2) if we've been asked to. But we also
+					 * have to explicitly disable setgroups(2) if we're
+					 * creating a rootless container (this is required since
+					 * Linux 3.19).
+					 */
+					if (config.is_rootless && config.is_setgroup) {
+						kill(child, SIGKILL);
+						bail("cannot allow setgroup in an unprivileged user namespace setup");
+					}
+
+					if (config.is_setgroup)
+						update_setgroups(child, SETGROUPS_ALLOW);
+					if (config.is_rootless)
+						update_setgroups(child, SETGROUPS_DENY);
+
+					/* Set up mappings. */
+					update_uidmap(config.uidmappath, child, config.uidmap, config.uidmap_len);
+					update_gidmap(config.gidmappath, child, config.gidmap, config.gidmap_len);
+
+					s = SYNC_USERMAP_ACK;
+					if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
+						kill(child, SIGKILL);
+						bail("failed to sync with child: write(SYNC_USERMAP_ACK)");
+					}
+					break;
+				case SYNC_RECVPID_PLS: {
+						first_child = child;
+
+						/* Get the init_func pid. */
+						if (read(syncfd, &child, sizeof(child)) != sizeof(child)) {
+							kill(first_child, SIGKILL);
+							bail("failed to sync with child: read(childpid)");
+						}
+
+						/* Send ACK. */
+						s = SYNC_RECVPID_ACK;
+						if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
+							kill(first_child, SIGKILL);
+							kill(child, SIGKILL);
+							bail("failed to sync with child: write(SYNC_RECVPID_ACK)");
+						}
+					}
+					break;
+				case SYNC_CHILD_READY:
+					ready = true;
+					break;
+				default:
+					bail("unexpected sync value: %u", s);
+				}
+			}
+
+			/* Now sync with grandchild. */
+
+			ready = false;
+			while (!ready) {
+				enum sync_t s;
+				int ret;
+
+				syncfd = sync_grandchild_pipe[1];
+				close(sync_grandchild_pipe[0]);
+
+				s = SYNC_GRANDCHILD;
+				if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
+					kill(child, SIGKILL);
+					bail("failed to sync with child: write(SYNC_GRANDCHILD)");
+				}
+
+				if (read(syncfd, &s, sizeof(s)) != sizeof(s))
+					bail("failed to sync with child: next state");
+
+				switch (s) {
+				case SYNC_ERR:
+					/* We have to mirror the error code of the child. */
+					if (read(syncfd, &ret, sizeof(ret)) != sizeof(ret))
+						bail("failed to sync with child: read(error code)");
+
+					exit(ret);
+				case SYNC_CHILD_READY:
+					ready = true;
+					break;
+				default:
+					bail("unexpected sync value: %u", s);
+				}
+			}
+
+			/*
+			 * Send the init_func pid and the pid of the first child back to our parent.
+			 *
+			 * We need to send both back because we can't reap the first child we created (CLONE_PARENT).
+			 * It becomes the responsibility of our parent to reap the first child.
+			 */
+			len = snprintf(buf, JSON_MAX, "{\"pid\": %d, \"pid_first\": %d}\n", child, first_child);
+			if (len < 0) {
+				kill(child, SIGKILL);
+				bail("unable to generate JSON for child pid");
+			}
+			if (write(pipenum, buf, len) != len) {
+				kill(child, SIGKILL);
+				bail("unable to send child pid to bootstrapper");
+			}
+
+			exit(0);
+		}
+
+	/*
+	 * Stage 1: We're in the first child process. Our job is to join any
+	 *          provided namespaces in the netlink payload and unshare all
+	 *          of the requested namespaces. If we've been asked to
+	 *          CLONE_NEWUSER, we will ask our parent (stage 0) to set up
+	 *          our user mappings for us. Then, we create a new child
+	 *          (stage 2: JUMP_INIT) for PID namespace. We then send the
+	 *          child's PID to our parent (stage 0).
+	 */
+	case JUMP_CHILD: {
+			pid_t child;
+			enum sync_t s;
+
+			/* We're in a child and thus need to tell the parent if we die. */
+			syncfd = sync_child_pipe[0];
+			close(sync_child_pipe[1]);
+
+			/* For debugging. */
+			prctl(PR_SET_NAME, (unsigned long) "runc:[1:CHILD]", 0, 0, 0);
+
+			/*
+			 * We need to setns first. We cannot do this earlier (in stage 0)
+			 * because of the fact that we forked to get here (the PID of
+			 * [stage 2: JUMP_INIT]) would be meaningless). We could send it
+			 * using cmsg(3) but that's just annoying.
+			 */
+			if (config.namespaces)
+				join_namespaces(config.namespaces);
+
+			/*
+			 * Unshare all of the namespaces. Now, it should be noted that this
+			 * ordering might break in the future (especially with rootless
+			 * containers). But for now, it's not possible to split this into
+			 * CLONE_NEWUSER + [the rest] because of some RHEL SELinux issues.
+			 *
+			 * Note that we don't merge this with clone() because there were
+			 * some old kernel versions where clone(CLONE_PARENT | CLONE_NEWPID)
+			 * was broken, so we'll just do it the long way anyway.
+			 */
+			if (unshare(config.cloneflags) < 0)
+				bail("failed to unshare namespaces");
+
+			/*
+			 * Deal with user namespaces first. They are quite special, as they
+			 * affect our ability to unshare other namespaces and are used as
+			 * context for privilege checks.
+			 */
+			if (config.cloneflags & CLONE_NEWUSER) {
+				/*
+				 * We don't have the privileges to do any mapping here (see the
+				 * clone_parent rant). So signal our parent to hook us up.
+				 */
+
+				/* Switching is only necessary if we joined namespaces. */
+				if (config.namespaces) {
+					if (prctl(PR_SET_DUMPABLE, 1, 0, 0, 0) < 0)
+						bail("failed to set process as dumpable");
+				}
+				s = SYNC_USERMAP_PLS;
+				if (write(syncfd, &s, sizeof(s)) != sizeof(s))
+					bail("failed to sync with parent: write(SYNC_USERMAP_PLS)");
+
+				/* ... wait for mapping ... */
+
+				if (read(syncfd, &s, sizeof(s)) != sizeof(s))
+					bail("failed to sync with parent: read(SYNC_USERMAP_ACK)");
+				if (s != SYNC_USERMAP_ACK)
+					bail("failed to sync with parent: SYNC_USERMAP_ACK: got %u", s);
+				/* Switching is only necessary if we joined namespaces. */
+				if (config.namespaces) {
+					if (prctl(PR_SET_DUMPABLE, 0, 0, 0, 0) < 0)
+						bail("failed to set process as dumpable");
+				}
+			}
+
+			/*
+			 * TODO: What about non-namespace clone flags that we're dropping here?
+			 *
+			 * We fork again because of PID namespace, setns(2) or unshare(2) don't
+			 * change the PID namespace of the calling process, because doing so
+			 * would change the caller's idea of its own PID (as reported by getpid()),
+			 * which would break many applications and libraries, so we must fork
+			 * to actually enter the new PID namespace.
+			 */
+			child = clone_parent(&env, JUMP_INIT);
+			if (child < 0)
+				bail("unable to fork: init_func");
+
+			/* Send the child to our parent, which knows what it's doing. */
+			s = SYNC_RECVPID_PLS;
+			if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
+				kill(child, SIGKILL);
+				bail("failed to sync with parent: write(SYNC_RECVPID_PLS)");
+			}
+			if (write(syncfd, &child, sizeof(child)) != sizeof(child)) {
+				kill(child, SIGKILL);
+				bail("failed to sync with parent: write(childpid)");
+			}
+
+			/* ... wait for parent to get the pid ... */
+
+			if (read(syncfd, &s, sizeof(s)) != sizeof(s)) {
+				kill(child, SIGKILL);
+				bail("failed to sync with parent: read(SYNC_RECVPID_ACK)");
+			}
+			if (s != SYNC_RECVPID_ACK) {
+				kill(child, SIGKILL);
+				bail("failed to sync with parent: SYNC_RECVPID_ACK: got %u", s);
+			}
+
+			s = SYNC_CHILD_READY;
+			if (write(syncfd, &s, sizeof(s)) != sizeof(s)) {
+				kill(child, SIGKILL);
+				bail("failed to sync with parent: write(SYNC_CHILD_READY)");
+			}
+
+			/* Our work is done. [Stage 2: JUMP_INIT] is doing the rest of the work. */
+			exit(0);
+		}
+
+	/*
+	 * Stage 2: We're the final child process, and the only process that will
+	 *          actually return to the Go runtime. Our job is to just do the
+	 *          final cleanup steps and then return to the Go runtime to allow
+	 *          init_linux.go to run.
+	 */
+	case JUMP_INIT: {
+			/*
+			 * We're inside the child now, having jumped from the
+			 * start_child() code after forking in the parent.
+			 */
+			enum sync_t s;
+
+			/* We're in a child and thus need to tell the parent if we die. */
+			syncfd = sync_grandchild_pipe[0];
+			close(sync_grandchild_pipe[1]);
+			close(sync_child_pipe[0]);
+			close(sync_child_pipe[1]);
+
+			/* For debugging. */
+			prctl(PR_SET_NAME, (unsigned long) "runc:[2:INIT]", 0, 0, 0);
+
+			if (read(syncfd, &s, sizeof(s)) != sizeof(s))
+				bail("failed to sync with parent: read(SYNC_GRANDCHILD)");
+			if (s != SYNC_GRANDCHILD)
+				bail("failed to sync with parent: SYNC_GRANDCHILD: got %u", s);
+
+			if (setsid() < 0)
+				bail("setsid failed");
+
+			if (setuid(0) < 0)
+				bail("setuid failed");
+
+			if (setgid(0) < 0)
+				bail("setgid failed");
+
+			if (!config.is_rootless && config.is_setgroup) {
+				if (setgroups(0, NULL) < 0)
+					bail("setgroups failed");
+			}
+
+			s = SYNC_CHILD_READY;
+			if (write(syncfd, &s, sizeof(s)) != sizeof(s))
+				bail("failed to sync with patent: write(SYNC_CHILD_READY)");
+
+			/* Close sync pipes. */
+			close(sync_grandchild_pipe[0]);
+
+			/* Free netlink data. */
+			nl_free(&config);
+
+			/* Finish executing, let the Go runtime take over. */
+			return;
+		}
+	default:
+		bail("unexpected jump value");
+	}
+
+	/* Should never be reached. */
+	bail("should never be reached");
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/utils/cmsg.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/utils/cmsg.go
@@ -1,0 +1,93 @@
+// +build linux
+
+package utils
+
+/*
+ * Copyright 2016, 2017 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// MaxSendfdLen is the maximum length of the name of a file descriptor being
+// sent using SendFd. The name of the file handle returned by RecvFd will never
+// be larger than this value.
+const MaxNameLen = 4096
+
+// oobSpace is the size of the oob slice required to store a single FD. Note
+// that unix.UnixRights appears to make the assumption that fd is always int32,
+// so sizeof(fd) = 4.
+var oobSpace = unix.CmsgSpace(4)
+
+// RecvFd waits for a file descriptor to be sent over the given AF_UNIX
+// socket. The file name of the remote file descriptor will be recreated
+// locally (it is sent as non-auxiliary data in the same payload).
+func RecvFd(socket *os.File) (*os.File, error) {
+	// For some reason, unix.Recvmsg uses the length rather than the capacity
+	// when passing the msg_controllen and other attributes to recvmsg.  So we
+	// have to actually set the length.
+	name := make([]byte, MaxNameLen)
+	oob := make([]byte, oobSpace)
+
+	sockfd := socket.Fd()
+	n, oobn, _, _, err := unix.Recvmsg(int(sockfd), name, oob, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if n >= MaxNameLen || oobn != oobSpace {
+		return nil, fmt.Errorf("recvfd: incorrect number of bytes read (n=%d oobn=%d)", n, oobn)
+	}
+
+	// Truncate.
+	name = name[:n]
+	oob = oob[:oobn]
+
+	scms, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return nil, err
+	}
+	if len(scms) != 1 {
+		return nil, fmt.Errorf("recvfd: number of SCMs is not 1: %d", len(scms))
+	}
+	scm := scms[0]
+
+	fds, err := unix.ParseUnixRights(&scm)
+	if err != nil {
+		return nil, err
+	}
+	if len(fds) != 1 {
+		return nil, fmt.Errorf("recvfd: number of fds is not 1: %d", len(fds))
+	}
+	fd := uintptr(fds[0])
+
+	return os.NewFile(fd, string(name)), nil
+}
+
+// SendFd sends a file descriptor over the given AF_UNIX socket. In
+// addition, the file.Name() of the given file will also be sent as
+// non-auxiliary data in the same payload (allowing to send contextual
+// information for a file descriptor).
+func SendFd(socket *os.File, name string, fd uintptr) error {
+	if len(name) >= MaxNameLen {
+		return fmt.Errorf("sendfd: filename too long: %s", name)
+	}
+	oob := unix.UnixRights(int(fd))
+	return unix.Sendmsg(int(socket.Fd()), []byte(name), oob, nil, 0)
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/utils/utils.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/utils/utils.go
@@ -1,0 +1,127 @@
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	exitSignalOffset = 128
+)
+
+// GenerateRandomName returns a new name joined with a prefix.  This size
+// specified is used to truncate the randomly generated value
+func GenerateRandomName(prefix string, size int) (string, error) {
+	id := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, id); err != nil {
+		return "", err
+	}
+	if size > 64 {
+		size = 64
+	}
+	return prefix + hex.EncodeToString(id)[:size], nil
+}
+
+// ResolveRootfs ensures that the current working directory is
+// not a symlink and returns the absolute path to the rootfs
+func ResolveRootfs(uncleanRootfs string) (string, error) {
+	rootfs, err := filepath.Abs(uncleanRootfs)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(rootfs)
+}
+
+// ExitStatus returns the correct exit status for a process based on if it
+// was signaled or exited cleanly
+func ExitStatus(status unix.WaitStatus) int {
+	if status.Signaled() {
+		return exitSignalOffset + int(status.Signal())
+	}
+	return status.ExitStatus()
+}
+
+// WriteJSON writes the provided struct v to w using standard json marshaling
+func WriteJSON(w io.Writer, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+// CleanPath makes a path safe for use with filepath.Join. This is done by not
+// only cleaning the path, but also (if the path is relative) adding a leading
+// '/' and cleaning it (then removing the leading '/'). This ensures that a
+// path resulting from prepending another path will always resolve to lexically
+// be a subdirectory of the prefixed path. This is all done lexically, so paths
+// that include symlinks won't be safe as a result of using CleanPath.
+func CleanPath(path string) string {
+	// Deal with empty strings nicely.
+	if path == "" {
+		return ""
+	}
+
+	// Ensure that all paths are cleaned (especially problematic ones like
+	// "/../../../../../" which can cause lots of issues).
+	path = filepath.Clean(path)
+
+	// If the path isn't absolute, we need to do more processing to fix paths
+	// such as "../../../../<etc>/some/path". We also shouldn't convert absolute
+	// paths to relative ones.
+	if !filepath.IsAbs(path) {
+		path = filepath.Clean(string(os.PathSeparator) + path)
+		// This can't fail, as (by definition) all paths are relative to root.
+		path, _ = filepath.Rel(string(os.PathSeparator), path)
+	}
+
+	// Clean the path again for good measure.
+	return filepath.Clean(path)
+}
+
+// SearchLabels searches a list of key-value pairs for the provided key and
+// returns the corresponding value. The pairs must be separated with '='.
+func SearchLabels(labels []string, query string) string {
+	for _, l := range labels {
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		if parts[0] == query {
+			return parts[1]
+		}
+	}
+	return ""
+}
+
+// Annotations returns the bundle path and user defined annotations from the
+// libcontainer state.  We need to remove the bundle because that is a label
+// added by libcontainer.
+func Annotations(labels []string) (bundle string, userAnnotations map[string]string) {
+	userAnnotations = make(map[string]string)
+	for _, l := range labels {
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		if parts[0] == "bundle" {
+			bundle = parts[1]
+		} else {
+			userAnnotations[parts[0]] = parts[1]
+		}
+	}
+	return
+}
+
+func GetIntSize() int {
+	return int(unsafe.Sizeof(1))
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go
@@ -1,0 +1,44 @@
+// +build !windows
+
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+func CloseExecFrom(minFd int) error {
+	fdList, err := ioutil.ReadDir("/proc/self/fd")
+	if err != nil {
+		return err
+	}
+	for _, fi := range fdList {
+		fd, err := strconv.Atoi(fi.Name())
+		if err != nil {
+			// ignore non-numeric file names
+			continue
+		}
+
+		if fd < minFd {
+			// ignore descriptors lower than our specified minimum
+			continue
+		}
+
+		// intentionally ignore errors from unix.CloseOnExec
+		unix.CloseOnExec(fd)
+		// the cases where this might fail are basically file descriptors that have already been closed (including and especially the one that was created when ioutil.ReadDir did the "opendir" syscall)
+	}
+	return nil
+}
+
+// NewSockPair returns a new unix socket pair
+func NewSockPair(name string) (parent *os.File, child *os.File, err error) {
+	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return os.NewFile(uintptr(fds[1]), name+"-p"), os.NewFile(uintptr(fds[0]), name+"-c"), nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1487,6 +1487,12 @@
 			"revisionTime": "2017-11-08T19:22:26Z"
 		},
 		{
+			"checksumSHA1": "5sA8fmTdySRJUW2EvJoq/Lz2ol0=",
+			"path": "github.com/opencontainers/runc/libcontainer",
+			"revision": "e6516b3d5dc780cb57a976013c242a9a93052543",
+			"revisionTime": "2017-12-15T16:47:07Z"
+		},
+		{
 			"checksumSHA1": "gVVY8k2G3ws+V1czsfxfuRs8log=",
 			"path": "github.com/opencontainers/runc/libcontainer/apparmor",
 			"revision": "e6516b3d5dc780cb57a976013c242a9a93052543",
@@ -1505,6 +1511,12 @@
 			"revisionTime": "2017-12-15T16:47:07Z"
 		},
 		{
+			"checksumSHA1": "klDr+R6CJJbkCxpScifrtMLtL6Q=",
+			"path": "github.com/opencontainers/runc/libcontainer/nsenter",
+			"revision": "e6516b3d5dc780cb57a976013c242a9a93052543",
+			"revisionTime": "2017-12-15T16:47:07Z"
+		},
+		{
 			"checksumSHA1": "tsnOAtUqj1ZRWilpG3Ovq/IyPDk=",
 			"path": "github.com/opencontainers/runc/libcontainer/system",
 			"revision": "e6516b3d5dc780cb57a976013c242a9a93052543",
@@ -1513,6 +1525,12 @@
 		{
 			"checksumSHA1": "2qNNJI8F5B8fG9RU4cxrJy43I8s=",
 			"path": "github.com/opencontainers/runc/libcontainer/user",
+			"revision": "e6516b3d5dc780cb57a976013c242a9a93052543",
+			"revisionTime": "2017-12-15T16:47:07Z"
+		},
+		{
+			"checksumSHA1": "Sb296YW4V+esieanrx4Nzt2L5lU=",
+			"path": "github.com/opencontainers/runc/libcontainer/utils",
 			"revision": "e6516b3d5dc780cb57a976013c242a9a93052543",
 			"revisionTime": "2017-12-15T16:47:07Z"
 		},


### PR DESCRIPTION
Signed-off-by: allen.wang <allen.wq@alipay.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Consider to update container's hostname in a running container, It should join container namespace. So it imports package github.com/opencontainers/runc/libcontainer/nsenter to meet the requirement(about more implementation details refferring to Ⅳ. Describe how to verify it). Otherwise, It provides more register functions which can do more in container namespace. 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2179 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add test TestRunningContainerUpdateHostname and TestStoppedContainerUpdateHostname.


### Ⅳ. Describe how to verify it
after doing update hostname, we can exec into container, and run command "hostname" to verify it.  

### Ⅴ. Special notes for reviews
It adds a package pkg/nsexec, which defines a function NsExec to join container namespace.  It provides register functions map to allow do something in container namespace such as update hostname.  It registers a reexec command called nsexec, which imports  github.com/opencontainers/runc/libcontainer/nsenter to join container namespace by calling C code. Package pkg/nsexec executes new command to call pouchd nsexec. 
