### PR TITLE
bugfix: container inspect/list should return image field right

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -76,7 +76,7 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 	container := types.ContainerJSON{
 		ID:           c.ID,
 		Name:         c.Name,
-		Image:        c.Config.Image,
+		Image:        c.Image,
 		Created:      c.Created,
 		State:        c.State,
 		Config:       c.Config,
@@ -134,6 +134,7 @@ func (s *Server) getContainers(ctx context.Context, rw http.ResponseWriter, req 
 			ID:              c.ID,
 			Names:           []string{c.Name},
 			Image:           c.Config.Image,
+			ImageID:         c.Image,
 			Command:         strings.Join(c.Config.Cmd, " "),
 			Status:          status,
 			Created:         t.UnixNano(),

--- a/test/api_container_inspect_test.go
+++ b/test/api_container_inspect_test.go
@@ -22,6 +22,7 @@ func (suite *APIContainerInspectSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
 
 	PullImage(c, busyboxImage)
+	PullImage(c, busyboxImage125)
 }
 
 // TestInspectNoSuchContainer tests inspecting a container that doesn't exits return error.
@@ -35,10 +36,13 @@ func (suite *APIContainerInspectSuite) TestInspectNoSuchContainer(c *check.C) {
 func (suite *APIContainerInspectSuite) TestInpectOk(c *check.C) {
 	cname := "TestInpectOk"
 
-	CreateBusyboxContainerOk(c, cname)
+	resp, err := CreateBusybox125Container(cname, "top")
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 201)
+
 	defer DelContainerForceMultyTime(c, cname)
 
-	resp, err := request.Get("/containers/" + cname + "/json")
+	resp, err = request.Get("/containers/" + cname + "/json")
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 200)
 
@@ -49,8 +53,9 @@ func (suite *APIContainerInspectSuite) TestInpectOk(c *check.C) {
 	// TODO: missing case
 	//
 	// add more field checker
-	c.Assert(got.Image, check.Equals, busyboxImage)
 	c.Assert(got.Name, check.Equals, cname)
+	c.Assert(got.Image, check.Equals, busyboxImage125ID)
+	c.Assert(got.Config.Image, check.Equals, busyboxImage125)
 	c.Assert(got.Created, check.NotNil)
 	// StartedAt time should be 0001-01-01T00:00:00Z for a non-started container
 	c.Assert(got.State.StartedAt, check.Equals, time.Time{}.UTC().Format(time.RFC3339Nano))

--- a/test/api_container_list_test.go
+++ b/test/api_container_list_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"net/url"
+
+	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/test/request"
 
 	"github.com/go-check/check"
 )
@@ -16,10 +20,38 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIContainerListSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+
+	environment.PruneAllContainers(apiClient)
+	PullImage(c, busyboxImage125)
 }
 
 // TestListOk test api is ok with default parameters.
 func (suite *APIContainerListSuite) TestListOk(c *check.C) {
+	cname := "TestListOk"
+
+	resp, err := CreateBusybox125Container(cname, "top")
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 201)
+
+	defer DelContainerForceMultyTime(c, cname)
+
+	// NOTE: need to list all here because the container is not running
+	q := url.Values{}
+	q.Set("all", "true")
+	resp, err = request.Get("/containers/json", request.WithQuery(q))
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 200)
+
+	var got []types.Container
+	err = request.DecodeBody(&got, resp.Body)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(len(got), check.Equals, 1)
+
 	// TODO: missing case
-	helpwantedForMissingCase(c, "container api list 200 case")
+	//
+	// add more field checker
+	c.Assert(got[0].Names[0], check.Equals, cname)
+	c.Assert(got[0].Image, check.Equals, busyboxImage125)
+	c.Assert(got[0].ImageID, check.Equals, busyboxImage125ID)
 }

--- a/test/util_api.go
+++ b/test/util_api.go
@@ -62,6 +62,23 @@ func CreateBusyboxContainer(cname string, cmd ...string) (*http.Response, error)
 	return request.Post(path, query, body)
 }
 
+// CreateBusybox125Container creates busybox with cmd.
+func CreateBusybox125Container(cname string, cmd ...string) (*http.Response, error) {
+	q := url.Values{}
+	q.Add("name", cname)
+
+	obj := map[string]interface{}{
+		"Image":      busyboxImage125,
+		"Cmd":        cmd,
+		"HostConfig": map[string]interface{}{},
+	}
+
+	path := "/containers/create"
+	query := request.WithQuery(q)
+	body := request.WithJSONBody(obj)
+	return request.Post(path, query, body)
+}
+
 // StartContainerOk starts the container and asserts success.
 func StartContainerOk(c *check.C, cname string) {
 	resp, err := request.Post("/containers/" + cname + "/start")


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

In container inspect, we replace the root.Image field by
root.Config.Image. We should keep it unchanged. And container list API
also returns root.ImageID field.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

already add and update.


### Ⅳ. Describe how to verify it

CI

### Ⅴ. Special notes for reviews


