### PR TITLE
tools: add fixquota tool

### DIFF
--- a/storage/quota/quota.go
+++ b/storage/quota/quota.go
@@ -198,7 +198,7 @@ func SetRootfsDiskQuota(basefs, size string, quotaID uint32) (uint32, error) {
 			return 0, fmt.Errorf("failed to set disk quota: %v", err)
 		}
 
-		if err := setQuotaForDir(dir, quotaID); err != nil {
+		if err := SetQuotaForDir(dir, quotaID); err != nil {
 			return 0, fmt.Errorf("failed to set dir quota: %v", err)
 		}
 	}
@@ -206,8 +206,8 @@ func SetRootfsDiskQuota(basefs, size string, quotaID uint32) (uint32, error) {
 	return quotaID, nil
 }
 
-// setQuotaForDir sets file attribute
-func setQuotaForDir(src string, quotaID uint32) error {
+// SetQuotaForDir sets file attribute
+func SetQuotaForDir(src string, quotaID uint32) error {
 	filepath.Walk(src, func(path string, fd os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("setQuota walk dir %s get error %v", path, err)

--- a/tools/fixquota.go
+++ b/tools/fixquota.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+
+	"github.com/alibaba/pouch/storage/quota"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	dir       string
+	quotaID   uint32
+	recursive bool
+)
+
+func run(cmd *cobra.Command) error {
+	_, err := quota.StartQuotaDriver(dir)
+	if err != nil {
+		logrus.Errorf("failed to start quota driver for %s, err: %v", dir, err)
+		return err
+	}
+
+	_, err = quota.SetSubtree(dir, quotaID)
+	if err != nil {
+		logrus.Errorf("failed to set subtree for %s, quota id: %d, err: %v", dir, quotaID, err)
+		return err
+	}
+
+	if recursive {
+		if err := quota.SetQuotaForDir(dir, quotaID); err != nil {
+			logrus.Errorf("failed to set quota id for %s recursively, quota id: %d, err: %v", dir, quotaID, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func setupFlags(cmd *cobra.Command) {
+	flagSet := cmd.Flags()
+
+	flagSet.StringVarP(&dir, "dir", "d", "", "The directory is set quota id.")
+	flagSet.Uint32VarP(&quotaID, "quota-id", "i", 0, "The quota id to set.")
+	flagSet.BoolVarP(&recursive, "recursive", "r", true, "Set the directory recursively.")
+}
+
+func main() {
+	var cmdServe = &cobra.Command{
+		Use:          "fixquota <-d /path> <-i id>",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd)
+		},
+	}
+
+	setupFlags(cmdServe)
+	if err := cmdServe.Execute(); err != nil {
+		logrus.Error(err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add fixquota tool to fix multi quota id for one volume or mount path.

```
Usage:
  fixquota <-d /path> <-i id> [flags]

Flags:
  -d, --dir string        The directory is set quota id.
  -h, --help              help for fixquota
  -i, --quota-id uint32   The quota id to set.
  -r, --recursive         Set the directory recursively. (default true)
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
NONE


### Ⅳ. Describe how to verify it
With command:
```
./fixquota -d /data/path -i 16777218
```
### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
