### PR TITLE
feature: complete the details of StartPodSandbox

### DIFF
--- a/docs/kubernetes/pouch_cri_api_changelog.md
+++ b/docs/kubernetes/pouch_cri_api_changelog.md
@@ -8,6 +8,7 @@
     * [ImageStatus](#imagestatus "ImageStatus()")
     * [CreateContainer](#createcontainer "CreateContainer()")
     * [RemoveVolume](#removevolume "RemoveVolume()")
+    * [StartPodSandbox](#startpodsandbox "StartPodSandbox()")
 * [Pull Request](#pull-request)
 
 ## Overview
@@ -30,7 +31,10 @@ Kubernetes Version: V1.10.0+
 4. Support to the ability to acquire the envs of the Container.
      - Scenario:
         - In the Upgrade process, the env of the new container needs to remain consistent with that of the old container, so the envs of the old container needs to be read.
-   
+5. Support to the ability to start the PodSandbox specified and setup the network.
+     - Scenario:
+        - It will fail to get IP after PodSandbox restarts  because of the external factors such as shutdown the host.
+  
 # The Changes Of CRI API
 
 ## UpdateContainerResources
@@ -278,7 +282,8 @@ message ContainerConfig {
 
 + Provides an interface for removing volume.
 + The containerstatus interface supports querying volume by name.
-+ The changes need to be made in the proto file are as follows:
+
+The changes need to be made in the proto file are as follows:
 
 ```
 service VolumeService {
@@ -306,9 +311,40 @@ message Mount {
 
 ```
 
+## StartPodSandbox
+
+### What To Solve?
+
++ StartPodSandbox restarts a sandbox pod which was stopped by accident and setup the network with network plugin.
+
+### Modification
+
++ Provides an interface for starting PodSandbox specified.
+
+The changes need to be made in the proto file are as follows:
+
+```
+service RuntimeService {
+...
+    // Start a sandbox pod which was forced to stop by external factors.
+    // Network plugin returns same IPs when input same pod names and namespaces
+    rpc StartPodSandbox(StartPodSandboxRequest) returns (StartPodSandboxResponse) {}
+...
+}
+
+message StartPodSandboxRequest {
+    // ID of the PodSandbox to start.
+    string pod_sandbox_id = 1;
+}
+
+message StartPodSandboxResponse {}
+```
+
 ## Pull Request
 
 + feature: extend cri apis for special needs [#1617](https://github.com/alibaba/pouch/pull/1617)
 + feature: extend cri apis for remove volume [#2124](https://github.com/alibaba/pouch/pull/2124)
 + feature: extend cri apis for support quotaID [#2138](https://github.com/alibaba/pouch/pull/2138)
 + feature: extend cri apis for get envs [#2163](https://github.com/alibaba/pouch/pull/2163)
++ feature: extend cri apis for support StartPodSandbox [#2242](https://github.com/alibaba/pouch/pull/2242)
+


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Provide an interface to start a sandbox pod which was stopped by accident and setup the network with network plugin.

**Note:** Only if the CNI-plugin supports returning the same IP with the same parameters of `containdID` ,`pod name`,`pod namespace`, we will make sure it reacquire the original network configuration  of sandbox, like IP address.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None.

### Ⅳ. Describe how to verify it
use [cri-tools](https://github.com/Starnop/cri-tools/tree/cri-tools-ali)
```
# cat pod-config.json 
{
    "metadata": {
        "name": "nginx-sandbox",
        "namespace": "default",
        "attempt": 1,
        "uid": "hdishd83djaidwnduwk28bcsb"
    },
    "linux": {
    }
}

# cat container-config.json 
{
  "metadata": {
      "name": "busybox"
  },
  "image":{
      "image": "busybox"
  },
  "command": [
      "top"
  ],
  "linux": {
  }
}

# crictl runp pod-config.json 
DEBU[0000] RunPodSandboxRequest: &RunPodSandboxRequest{Config:&PodSandboxConfig{Metadata:&PodSandboxMetadata{Name:nginx-sandbox,Uid:hdishd83djaidwnduwk28bcsb,Namespace:default,Attempt:1,},Hostname:,LogDirectory:,DnsConfig:nil,PortMappings:[],Labels:map[string]string{},Annotations:map[string]string{},Linux:&LinuxPodSandboxConfig{CgroupParent:,SecurityContext:nil,Sysctls:map[string]string{},},},} 
DEBU[0000] RunPodSandboxResponse: &RunPodSandboxResponse{PodSandboxId:7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6,} 
7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6

# crictl create 7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6 container-config.json pod-config.json 
DEBU[0000] CreateContainerRequest: &CreateContainerRequest{PodSandboxId:7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6,Config:&ContainerConfig{Metadata:&ContainerMetadata{Name:busybox,Attempt:0,},Image:&ImageSpec{Image:busybox,},Command:[top],Args:[],WorkingDir:,Envs:[],Mounts:[],Devices:[],Labels:map[string]string{},Annotations:map[string]string{},LogPath:,Stdin:false,StdinOnce:false,Tty:false,Linux:&LinuxContainerConfig{Resources:nil,SecurityContext:nil,},Windows:nil,NetPriority:0,QuotaId:,},SandboxConfig:&PodSandboxConfig{Metadata:&PodSandboxMetadata{Name:nginx-sandbox,Uid:hdishd83djaidwnduwk28bcsb,Namespace:default,Attempt:1,},Hostname:,LogDirectory:,DnsConfig:nil,PortMappings:[],Labels:map[string]string{},Annotations:map[string]string{},Linux:&LinuxPodSandboxConfig{CgroupParent:,SecurityContext:nil,Sysctls:map[string]string{},},},} 
DEBU[0000] CreateContainerResponse: &CreateContainerResponse{ContainerId:a0bf0780844bb939c14cf43c2f34e42c99eb021fd35645dd1a1aeb6bbbce535f,} 
a0bf0780844bb939c14cf43c2f34e42c99eb021fd35645dd1a1aeb6bbbce535f

# crictl inspectp 7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6
DEBU[0000] PodSandboxStatusRequest: &PodSandboxStatusRequest{PodSandboxId:7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6,Verbose:true,} 
DEBU[0000] PodSandboxStatusResponse: &PodSandboxStatusResponse{Status:&PodSandboxStatus{Id:7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6,Metadata:&PodSandboxMetadata{Name:nginx-sandbox,Uid:hdishd83djaidwnduwk28bcsb,Namespace:default,Attempt:1,},State:SANDBOX_READY,CreatedAt:1536916075102934587,Network:&PodSandboxNetworkStatus{Ip:10.244.1.108,},Linux:&LinuxPodSandboxStatus{Namespaces:&Namespace{Options:&NamespaceOption{Network:POD,Pid:POD,Ipc:POD,},},},Labels:map[string]string{},Annotations:map[string]string{},},Info:map[string]string{},} 
{
  "status": {
    "id": "7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6",
    "metadata": {
      "attempt": 1,
      "name": "nginx-sandbox",
      "namespace": "default",
      "uid": "hdishd83djaidwnduwk28bcsb"
    },
    "state": "SANDBOX_READY",
    "createdAt": "2018-09-14T09:07:55.102934587Z",
    "network": {
      "ip": "10.244.1.108"
    },
    "linux": {
      "namespaces": {
        "options": {
          "ipc": "POD",
          "network": "POD",
          "pid": "POD"
        }
      }
    },
    "labels": {},
    "annotations": {}
  }
}

# crictl stopp 7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6
DEBU[0000] StopPodSandboxRequest: &StopPodSandboxRequest{PodSandboxId:7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6,} 
DEBU[0000] StopPodSandboxResponse: &StopPodSandboxResponse{} 
Stopped sandbox 7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6

# crictl startp 7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6
DEBU[0000] StartPodSandboxRequest: &StartPodSandboxRequest{PodSandboxId:7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6,} 
DEBU[0000] StartPodSandboxResponse: &StartPodSandboxResponse{} 
7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6

# crictl inspectp 7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6
DEBU[0000] PodSandboxStatusRequest: &PodSandboxStatusRequest{PodSandboxId:7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6,Verbose:true,} 
DEBU[0000] PodSandboxStatusResponse: &PodSandboxStatusResponse{Status:&PodSandboxStatus{Id:7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6,Metadata:&PodSandboxMetadata{Name:nginx-sandbox,Uid:hdishd83djaidwnduwk28bcsb,Namespace:default,Attempt:1,},State:SANDBOX_READY,CreatedAt:1536916075102934587,Network:&PodSandboxNetworkStatus{Ip:10.244.1.109,},Linux:&LinuxPodSandboxStatus{Namespaces:&Namespace{Options:&NamespaceOption{Network:POD,Pid:POD,Ipc:POD,},},},Labels:map[string]string{},Annotations:map[string]string{},},Info:map[string]string{},} 
{
  "status": {
    "id": "7fa3bf8c5cb8e97f1b09369bf182afb6b6f1ebdf74d072a95960942a3f2b9fb6",
    "metadata": {
      "attempt": 1,
      "name": "nginx-sandbox",
      "namespace": "default",
      "uid": "hdishd83djaidwnduwk28bcsb"
    },
    "state": "SANDBOX_READY",
    "createdAt": "2018-09-14T09:07:55.102934587Z",
    "network": {
      "ip": "10.244.1.108"
    },
    "linux": {
      "namespaces": {
        "options": {
          "ipc": "POD",
          "network": "POD",
          "pid": "POD"
        }
      }
    },
    "labels": {},
    "annotations": {}
  }
}

```

### Ⅴ. Special notes for reviews
Related Pull Request: https://github.com/alibaba/pouch/pull/2237

