### PR TITLE
cri: add default annotation sandboxid

### DIFF
--- a/cri/annotations/annotations.go
+++ b/cri/annotations/annotations.go
@@ -14,6 +14,9 @@ const (
 	// SandboxName is the sandbox name annotation
 	SandboxName = "io.kubernetes.cri-o.SandboxName"
 
+	// SandboxID is the sandbox id annotation
+	SandboxID = "io.kubernetes.cri-o.SandboxID"
+
 	// KubernetesRuntime is the runtime
 	KubernetesRuntime = "io.kubernetes.runtime"
 

--- a/cri/v1alpha1/cri.go
+++ b/cri/v1alpha1/cri.go
@@ -531,6 +531,7 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	specAnnotation := make(map[string]string)
 	specAnnotation[anno.ContainerType] = anno.ContainerTypeContainer
 	specAnnotation[anno.SandboxName] = podSandboxID
+	specAnnotation[anno.SandboxID] = podSandboxID
 
 	createConfig := &apitypes.ContainerCreateConfig{
 		ContainerConfig: apitypes.ContainerConfig{

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -560,6 +560,7 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	specAnnotation := make(map[string]string)
 	specAnnotation[anno.ContainerType] = anno.ContainerTypeContainer
 	specAnnotation[anno.SandboxName] = podSandboxID
+	specAnnotation[anno.SandboxID] = podSandboxID
 
 	resources := r.GetConfig().GetLinux().GetResources()
 	createConfig := &apitypes.ContainerCreateConfig{


### PR DESCRIPTION
for vm level runtime, add default annotation
io.kubernetes.cri-o.SandboxID when create container
in sanbox.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

As for kata, the default annotation is
```
// CRIContainerTypeKeyList lists all the CRI keys that could define
    // the container type from annotations in the config.json.
    CRIContainerTypeKeyList = []string{criContainerdAnnotations.ContainerType, crioAnnotations.ContainerType, dockershimAnnotations.ContainerTypeLabelKey}

    // CRISandboxNameKeyList lists all the CRI keys that could define
    // the sandbox ID (sandbox ID) from annotations in the config.json.
    CRISandboxNameKeyList = []string{criContainerdAnnotations.SandboxID, crioAnnotations.SandboxID, dockershimAnnotations.SandboxIDLabelKey}
```
I also wonder whether cri mistake `SandboxName` as `SandboxID` as default annotation, @YaoZengzeng @Starnop 
```
specAnnotation[anno.SandboxName] = podSandboxID
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


