### PR TITLE
fix: make container state in inpsect API correct

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -3379,7 +3379,7 @@ definitions:
 
   ContainerState:
     type: "object"
-    required: [StartedAt, FinishedAt]
+    required: [StartedAt, FinishedAt, Pid, ExitCode, Error, OOMKilled, Dead, Paused, Restarting, Running, Status]
     properties:
       Status:
         $ref: "#/definitions/Status"
@@ -3396,27 +3396,35 @@ definitions:
 
           Use the `Status` field instead to determine if a container's state is "running".
         type: "boolean"
+        x-nullable: false
       Paused:
         description: "Whether this container is paused."
         type: "boolean"
+        x-nullable: false
       Restarting:
         description: "Whether this container is restarting."
         type: "boolean"
+        x-nullable: false
       OOMKilled:
         description: "Whether this container has been killed because it ran out of memory."
         type: "boolean"
+        x-nullable: false
       Dead:
         description: "Whether this container is dead."
         type: "boolean"
+        x-nullable: false
       Pid:
+        x-nullable: false
         description: "The process ID of this container"
         type: "integer"
       ExitCode:
+        x-nullable: false
         description: "The last exit code of this container"
         type: "integer"
       Error:
         description: "The error message of this container"
         type: "string"
+        x-nullable: false
       StartedAt:
         description: "The time when this container was last started."
         type: "string"

--- a/apis/types/container_state.go
+++ b/apis/types/container_state.go
@@ -19,29 +19,36 @@ import (
 type ContainerState struct {
 
 	// Whether this container is dead.
-	Dead bool `json:"Dead,omitempty"`
+	// Required: true
+	Dead bool `json:"Dead"`
 
 	// The error message of this container
-	Error string `json:"Error,omitempty"`
+	// Required: true
+	Error string `json:"Error"`
 
 	// The last exit code of this container
-	ExitCode int64 `json:"ExitCode,omitempty"`
+	// Required: true
+	ExitCode int64 `json:"ExitCode"`
 
 	// The time when this container last exited.
 	// Required: true
 	FinishedAt string `json:"FinishedAt"`
 
 	// Whether this container has been killed because it ran out of memory.
-	OOMKilled bool `json:"OOMKilled,omitempty"`
+	// Required: true
+	OOMKilled bool `json:"OOMKilled"`
 
 	// Whether this container is paused.
-	Paused bool `json:"Paused,omitempty"`
+	// Required: true
+	Paused bool `json:"Paused"`
 
 	// The process ID of this container
-	Pid int64 `json:"Pid,omitempty"`
+	// Required: true
+	Pid int64 `json:"Pid"`
 
 	// Whether this container is restarting.
-	Restarting bool `json:"Restarting,omitempty"`
+	// Required: true
+	Restarting bool `json:"Restarting"`
 
 	// Whether this container is running.
 	//
@@ -54,14 +61,16 @@ type ContainerState struct {
 	//
 	// Use the `Status` field instead to determine if a container's state is "running".
 	//
-	Running bool `json:"Running,omitempty"`
+	// Required: true
+	Running bool `json:"Running"`
 
 	// The time when this container was last started.
 	// Required: true
 	StartedAt string `json:"StartedAt"`
 
 	// status
-	Status Status `json:"Status,omitempty"`
+	// Required: true
+	Status Status `json:"Status"`
 }
 
 /* polymorph ContainerState Dead false */
@@ -90,7 +99,47 @@ type ContainerState struct {
 func (m *ContainerState) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateDead(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateError(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateExitCode(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateFinishedAt(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateOOMKilled(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validatePaused(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validatePid(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateRestarting(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateRunning(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -111,9 +160,81 @@ func (m *ContainerState) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *ContainerState) validateDead(formats strfmt.Registry) error {
+
+	if err := validate.Required("Dead", "body", bool(m.Dead)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerState) validateError(formats strfmt.Registry) error {
+
+	if err := validate.RequiredString("Error", "body", string(m.Error)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerState) validateExitCode(formats strfmt.Registry) error {
+
+	if err := validate.Required("ExitCode", "body", int64(m.ExitCode)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *ContainerState) validateFinishedAt(formats strfmt.Registry) error {
 
 	if err := validate.RequiredString("FinishedAt", "body", string(m.FinishedAt)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerState) validateOOMKilled(formats strfmt.Registry) error {
+
+	if err := validate.Required("OOMKilled", "body", bool(m.OOMKilled)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerState) validatePaused(formats strfmt.Registry) error {
+
+	if err := validate.Required("Paused", "body", bool(m.Paused)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerState) validatePid(formats strfmt.Registry) error {
+
+	if err := validate.Required("Pid", "body", int64(m.Pid)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerState) validateRestarting(formats strfmt.Registry) error {
+
+	if err := validate.Required("Restarting", "body", bool(m.Restarting)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerState) validateRunning(formats strfmt.Registry) error {
+
+	if err := validate.Required("Running", "body", bool(m.Running)); err != nil {
 		return err
 	}
 
@@ -130,10 +251,6 @@ func (m *ContainerState) validateStartedAt(formats strfmt.Registry) error {
 }
 
 func (m *ContainerState) validateStatus(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.Status) { // not required
-		return nil
-	}
 
 	if err := m.Status.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/apis/types/exec_create_config.go
+++ b/apis/types/exec_create_config.go
@@ -37,7 +37,7 @@ type ExecCreateConfig struct {
 	// Escape keys for detach
 	DetachKeys string `json:"DetachKeys,omitempty"`
 
-	// Env for commands
+	// envs for exec command in container
 	Env []string `json:"Env"`
 
 	// Is the container in privileged mode


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
like #2255 mentioned, inspect API should return pid of exit process. Also it will show lots of fields without ignoring them, like:
```
        "State": {
            "Dead": false,
            "Error": "",
            "ExitCode": 143,
            "FinishedAt": "2018-09-19T10:41:37.070677153Z",
            "OOMKilled": false,
            "Paused": false,
            "Pid": 0,
            "Restarting": false,
            "Running": false,
            "StartedAt": "2018-09-19T10:41:29.770644983Z",
            "Status": "stopped"
        },
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
link #2255 


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews


