### PR TITLE
bugfix: exec stdin should support -i

### DIFF
--- a/daemon/mgr/container_exec.go
+++ b/daemon/mgr/container_exec.go
@@ -57,6 +57,11 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, attac
 		return err
 	}
 
+	// FIXME(fuweid): make attachConfig consistent with execConfig
+	if attach != nil {
+		attach.Stdin = execConfig.AttachStdin
+	}
+
 	eio, err := mgr.openExecIO(execid, attach)
 	if err != nil {
 		return err
@@ -79,10 +84,6 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, attac
 			mgr.IOs.Remove(execid)
 		}
 	}()
-
-	if attach != nil {
-		attach.Stdin = execConfig.AttachStdin
-	}
 
 	c, err := mgr.container(execConfig.ContainerID)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

ExecStartConfig.Terminal doesn't equal to AttachStdin. Need to use
AttachStdin when create ContainerIO.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Will do in the following PR.

### Ⅳ. Describe how to verify it

```
# vagrant @ ubuntu-xenial in ~/go/src/github.com/alibaba/pouch on git:bugfix_exec_stdin o [23:14:57]
$ sudo pouch exec -i a9aca3 sh
ls -al
total 44
drwxr-xr-x    1 root     root          4096 Sep 19 15:11 .
drwxr-xr-x    1 root     root          4096 Sep 19 15:11 ..
drwxr-xr-x    2 root     root         12288 Jul 31 20:20 bin
drwxr-xr-x    5 root     root           360 Sep 19 15:11 dev
drwxr-xr-x    1 root     root          4096 Sep 19 15:11 etc
drwxr-xr-x    2 nobody   nogroup       4096 Jul 31 20:20 home
dr-xr-xr-x  153 root     root             0 Sep 19 15:11 proc
drwx------    1 root     root          4096 Sep 19 15:11 root
drwxr-xr-x    2 root     root            40 Sep 19 15:11 run
dr-xr-xr-x   13 root     root             0 Sep 19 15:11 sys
drwxrwxrwt    2 root     root          4096 Jul 31 20:20 tmp
drwxr-xr-x    3 root     root          4096 Jul 31 20:20 usr
drwxr-xr-x    4 root     root          4096 Jul 31 20:20 var
date
Wed Sep 19 15:15:04 UTC 2018
exit
```

### Ⅴ. Special notes for reviews


