### PR TITLE
[RFC] bugfix: call task.CloseIO after client close stdin

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/pkg/ioutils"
 
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/sirupsen/logrus"
@@ -143,7 +144,11 @@ func holdHijackConnection(ctx context.Context, conn net.Conn, reader *bufio.Read
 			io.Copy(conn, os.Stdin)
 		}
 
-		// TODO: close write side of conn
+		// NOTE: close write side and still wait for read side
+		if cw, ok := conn.(ioutils.CloseWriter); ok {
+			cw.CloseWrite()
+		}
+
 		close(stdinDone)
 	}()
 

--- a/pkg/ioutils/utils.go
+++ b/pkg/ioutils/utils.go
@@ -1,0 +1,26 @@
+package ioutils
+
+import "io"
+
+type writeCloserWrapper struct {
+	io.Writer
+	closeFunc func() error
+}
+
+func (w *writeCloserWrapper) Close() error {
+	return w.closeFunc()
+}
+
+// NewWriteCloserWrapper provides the ability to handle the cleanup during closer.
+func NewWriteCloserWrapper(w io.Writer, closeFunc func() error) io.WriteCloser {
+	return &writeCloserWrapper{
+		Writer:    w,
+		closeFunc: closeFunc,
+	}
+}
+
+// CloseWriter is an interface which represents the implementation closes the
+// writing side of writer.
+type CloseWriter interface {
+	CloseWrite() error
+}

--- a/test/cli_run_interactive_test.go
+++ b/test/cli_run_interactive_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// PouchRunInteractiveSuite is the test suite for run CLI.
+type PouchRunInteractiveSuite struct{}
+
+func init() {
+	check.Suite(&PouchRunInteractiveSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each test suite.
+func (suite *PouchRunInteractiveSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	PullImage(c, busyboxImage)
+}
+
+// TestRunInteractive test "-i" option works.
+//
+// FIXME(fuweid): when we start container, we need to save the pack into cache
+// before the start task. otherwise, the c.watch.get(containerID) will return
+// 404 and fail to stop container.
+// before we fix this issue, we set it flaky case.
+func (suite *PouchRunInteractiveSuite) TestRunInteractive(c *check.C) {
+	c.Skip("skip flaky test")
+
+	name := "TestRunInteractiveContainer"
+	DelContainerForceMultyTime(c, name)
+
+	// use pipe to act interactive
+	stdinR, stdinW := io.Pipe()
+	stdoutR, stdoutW := io.Pipe()
+	defer stdoutW.Close()
+
+	// need to start command before write
+	cmd := command.PouchCmd("run",
+		"-i", "--net", "none",
+		"--name", name, busyboxImage, "cat")
+	cmd.Stdin = stdinR
+	cmd.Stdout = stdoutW
+	res := icmd.StartCmd(cmd)
+
+	// send bye to cat
+	//
+	// FIXME(fuweid): when we remove ringbuffer, we can remove the
+	// stdoutW, stdoutR pipe.
+	fmt.Fprintf(stdinW, "hi\n")
+	got, _, err := bufio.NewReader(stdoutR).ReadLine()
+	c.Assert(err, check.IsNil)
+	c.Assert(string(got), check.Equals, "hi")
+
+	// send the EOF to stdin
+	//
+	// FIXME(fuweid): remove the timeout when we remove ringbuffer
+	stdinW.Close()
+	res = icmd.WaitOnCmd(1*time.Second, res)
+	res.Assert(c, icmd.Success)
+
+	// NOTE: container must be stopped.
+	{
+		output := command.PouchRun("inspect", name).Stdout()
+		result := []types.ContainerJSON{}
+		if err := json.Unmarshal([]byte(output), &result); err != nil {
+			c.Errorf("failed to decode inspect output: %v", err)
+		}
+		c.Assert(string(result[0].State.Status), check.Equals, "stopped")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

for now, the stream from client to container is like:

os.Stdin -> [pouchd] ContainerIO [hijack backend] -> [containerd] FIFO

When the client input EOF by control+D, the hijack backend will quit the
goroutin about reading data from client side and close.

The hijack backend is one of backends in stdin ContainerIO. But the
hajack backend closes without closing the stdin ContainerIO. The
container will wait for the data from FIFO.

pouch daemon needs to close the stdin ContainerIO when the backend, like
hijack, closes. Therefore, pouch daemon closes the write side of fifo.

Besides this, the containerd also open fifo with both write and read
modes. It's not enough to close write side of fifo in pouch daemon.
pouch daemon also calls the CloseIO rpc to close write side in the
containerd-shim.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

wait for #2257


### Ⅳ. Describe how to verify it

we should send the EOF to close to exit but typing exit command.

```
# vagrant @ ubuntu-xenial in ~/go/src/github.com/alibaba/pouch on git:bugfix_close_stdin o [1:32:02]
$ sudo pouch run -i --name testing busybox cat # ending by control+D
hi
hi
bye
bye



# vagrant @ ubuntu-xenial in ~/go/src/github.com/alibaba/pouch on git:bugfix_close_stdin o [1:32:26]
$ sudo pouch ps -a | grep testing
testing   2910e3   Exited (0) 10 seconds   17 seconds ago   registry.hub.docker.com/library/busybox:latest   runc
```

### Ⅴ. Special notes for reviews

1. we should close the conn by `CloseWriter` and waiting for the data in run/exec command
2. when we use `echo 1 | sudo pouch run -i busybox cat`, we got nothing but should get `1`. This is bug for us. Since we use ringbuffer to cache the input, when we close the ContainerIO, no one can touch the data in the ringbuffer. I will send other PR to fix this.

