### PR TITLE
bugfix: print error info twice when cmd unknown

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -12,6 +12,7 @@ func main() {
 	cli.SetFlags()
 
 	base := &baseCommand{cmd: cli.rootCmd, cli: cli}
+	base.Cmd().SilenceErrors = true
 
 	// Add all subcommands.
 	cli.AddCommand(base, &PullCommand{})


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
pouchContainer will  print error info twice when command was unknown.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1529

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
No needed.


### Ⅳ. Describe how to verify it
```
# pouch foo
Error: unknown command "foo" for "pouch"

Did you mean this?
	top

Run 'pouch --help' for usage.
```


### Ⅴ. Special notes for reviews

Cobra will print automatic suggestions when "unknown command" errors happen. 
