### PR TITLE
feature: add logs cli details opt support and add more cli tests

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -396,9 +396,7 @@ func (s *Server) logsContainer(ctx context.Context, rw http.ResponseWriter, req 
 		Until:      req.Form.Get("until"),
 		Follow:     httputils.BoolValue(req, "follow"),
 		Timestamps: httputils.BoolValue(req, "timestamps"),
-
-		// TODO: support the details
-		// Details:    httputils.BoolValue(r, "details"),
+		Details:    httputils.BoolValue(req, "details"),
 	}
 
 	name := mux.Vars(req)["name"]
@@ -406,7 +404,6 @@ func (s *Server) logsContainer(ctx context.Context, rw http.ResponseWriter, req 
 	if err != nil {
 		return err
 	}
-
 	writeLogStream(ctx, rw, tty, opts, msgCh)
 	return nil
 }

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -49,8 +49,7 @@ func (lc *LogsCommand) addFlags() {
 	flagSet.StringVarP(&lc.until, "until", "", "", "Show logs before timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)")
 	flagSet.StringVarP(&lc.tail, "tail", "", "all", "Number of lines to show from the end of the logs default \"all\"")
 	flagSet.BoolVarP(&lc.timestamps, "timestamps", "t", false, "Show timestamps")
-
-	// TODO(fuwei): support the detail functionality
+	flagSet.BoolVar(&lc.details, "details", false, "Show extra details provided to logs")
 }
 
 // runLogs is the entry of LogsCommand command.
@@ -68,6 +67,7 @@ func (lc *LogsCommand) runLogs(args []string) error {
 		Timestamps: lc.timestamps,
 		Follow:     lc.follow,
 		Tail:       lc.tail,
+		Details:    lc.details,
 	}
 
 	body, err := apiClient.ContainerLogs(ctx, containerName, opts)

--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -46,6 +46,10 @@ func (client *APIClient) ContainerLogs(ctx context.Context, name string, options
 	if options.Follow {
 		query.Set("follow", "1")
 	}
+
+	if options.Details {
+		query.Set("details", "1")
+	}
 	query.Set("tail", options.Tail)
 
 	resp, err := client.get(ctx, "/containers/"+name+"/logs", query, nil)

--- a/daemon/logger/jsonfile/encode.go
+++ b/daemon/logger/jsonfile/encode.go
@@ -12,9 +12,10 @@ import (
 )
 
 type jsonLog struct {
-	Stream    string    `json:"stream,omitempty"`
-	Log       string    `json:"log,omitempty"`
-	Timestamp time.Time `json:"time"`
+	Stream    string            `json:"stream,omitempty"`
+	Log       string            `json:"log,omitempty"`
+	Timestamp time.Time         `json:"time"`
+	Attrs     map[string]string `json:"attrs,omitempty"`
 }
 
 func newUnmarshal(r io.Reader) func() (*logger.LogMessage, error) {
@@ -30,11 +31,13 @@ func newUnmarshal(r io.Reader) func() (*logger.LogMessage, error) {
 			Source:    jl.Stream,
 			Line:      []byte(jl.Log),
 			Timestamp: jl.Timestamp,
+			Attrs:     jl.Attrs,
 		}, nil
 	}
 }
 
-func marshal(msg *logger.LogMessage) ([]byte, error) {
+//Marshal used to marshal LogMessage to byte[]
+func Marshal(msg *logger.LogMessage, rawAttrs []byte) ([]byte, error) {
 	var (
 		first = true
 		buf   bytes.Buffer
@@ -62,6 +65,13 @@ func marshal(msg *logger.LogMessage) ([]byte, error) {
 
 	buf.WriteString(`"time":`)
 	buf.WriteString(msg.Timestamp.UTC().Format(`"` + utils.TimeLayout + `"`))
+
+	if len(rawAttrs) > 0 {
+		buf.WriteString(`,`)
+		buf.WriteString(`"attrs":`)
+		buf.Write(rawAttrs)
+	}
+
 	buf.WriteString(`}`)
 
 	// NOTE: add newline here to make the decoder easier

--- a/daemon/logger/jsonfile/encode_test.go
+++ b/daemon/logger/jsonfile/encode_test.go
@@ -2,6 +2,7 @@ package jsonfile
 
 import (
 	"bytes"
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -10,13 +11,20 @@ import (
 )
 
 func TestMarshalAndUnmarshal(t *testing.T) {
+
+	attrs := map[string]string{"env": "test"}
+	extra, err := json.Marshal(attrs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	expectedMsg := &logger.LogMessage{
 		Source:    "stdout",
 		Line:      []byte("hello pouch"),
 		Timestamp: time.Now().UTC(),
+		Attrs:     attrs,
 	}
 
-	bs, err := marshal(expectedMsg)
+	bs, err := Marshal(expectedMsg, extra)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/daemon/logger/jsonfile/jsonfile.go
+++ b/daemon/logger/jsonfile/jsonfile.go
@@ -8,32 +8,37 @@ import (
 	"github.com/alibaba/pouch/daemon/logger"
 )
 
+//MarshalFunc is the function of marshal the logMessage
+type MarshalFunc func(message *logger.LogMessage) ([]byte, error)
+
 // JSONLogFile is uses to log the container's stdout and stderr.
 type JSONLogFile struct {
 	mu sync.Mutex
 
-	f      *os.File
-	perms  os.FileMode
-	closed bool
+	f           *os.File
+	perms       os.FileMode
+	closed      bool
+	marshalFunc MarshalFunc
 }
 
 // NewJSONLogFile returns new JSONLogFile instance.
-func NewJSONLogFile(logPath string, perms os.FileMode) (*JSONLogFile, error) {
+func NewJSONLogFile(logPath string, perms os.FileMode, marshalFunc MarshalFunc) (*JSONLogFile, error) {
 	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, perms)
 	if err != nil {
 		return nil, err
 	}
 
 	return &JSONLogFile{
-		f:      f,
-		perms:  perms,
-		closed: false,
+		f:           f,
+		perms:       perms,
+		closed:      false,
+		marshalFunc: marshalFunc,
 	}, nil
 }
 
 // WriteLogMessage will write the LogMessage into the file.
 func (lf *JSONLogFile) WriteLogMessage(msg *logger.LogMessage) error {
-	b, err := marshal(msg)
+	b, err := lf.marshalFunc(msg)
 	if err != nil {
 		return err
 	}

--- a/daemon/logger/jsonfile/jsonfile_read_test.go
+++ b/daemon/logger/jsonfile/jsonfile_read_test.go
@@ -17,7 +17,7 @@ func TestReadLogMessagesWithRemoveFileInFollowMode(t *testing.T) {
 	defer f.Close()
 	defer os.RemoveAll(f.Name())
 
-	jf, err := NewJSONLogFile(f.Name(), 0640)
+	jf, err := NewJSONLogFile(f.Name(), 0640, nil)
 	if err != nil {
 		t.Fatalf("unexpected error during create JSONLogFile: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestReadLogMessagesForEmptyFileWithoutFollow(t *testing.T) {
 	defer f.Close()
 	defer os.RemoveAll(f.Name())
 
-	jf, err := NewJSONLogFile(f.Name(), 0644)
+	jf, err := NewJSONLogFile(f.Name(), 0644, nil)
 	if err != nil {
 		t.Fatalf("unexpected error during create JSONLogFile: %v", err)
 	}

--- a/daemon/logger/logmessage.go
+++ b/daemon/logger/logmessage.go
@@ -10,8 +10,8 @@ type LogMessage struct {
 	Source    string    // Source means stdin, stdout or stderr
 	Line      []byte    // Line means the log content, but it maybe partial
 	Timestamp time.Time // Timestamp means the created time of line
-
-	Err error
+	Attrs     map[string]string
+	Err       error
 }
 
 // LogWatcher is used to pass the log message to the reader.
@@ -48,8 +48,9 @@ func (w *LogWatcher) WatchClose() <-chan struct{} {
 
 // ReadConfig is used to
 type ReadConfig struct {
-	Since  time.Time
-	Until  time.Time
-	Tail   int
-	Follow bool
+	Since   time.Time
+	Until   time.Time
+	Tail    int
+	Follow  bool
+	Details bool
 }

--- a/daemon/mgr/container_logs.go
+++ b/daemon/mgr/container_logs.go
@@ -49,7 +49,9 @@ func (mgr *ContainerManager) Logs(ctx context.Context, name string, logOpt *type
 	}
 
 	fileName := filepath.Join(mgr.Store.Path(c.ID), "json.log")
-	jf, err := jsonfile.NewJSONLogFile(fileName, 0640)
+
+	jf, err := jsonfile.NewJSONLogFile(fileName, 0640, nil)
+
 	if err != nil {
 		return nil, false, err
 	}
@@ -137,9 +139,10 @@ func convContainerLogsOptionsToReadConfig(logOpt *types.ContainerLogsOptions) (*
 	}
 
 	return &logger.ReadConfig{
-		Since:  since,
-		Until:  until,
-		Follow: logOpt.Follow,
-		Tail:   lines,
+		Since:   since,
+		Until:   until,
+		Follow:  logOpt.Follow,
+		Tail:    lines,
+		Details: logOpt.Details,
 	}, nil
 }


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
As title mentioned, as two parts:
1. add pouch logs --details support
2. add more logs cli integration tests

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add more cli integration test.


### Ⅳ. Describe how to verify it
`$ pouch run --name=test --label foo=bar -e baz=qux -e qq=we --log-opt labels=foo --log-opt env=baz,qq busybox echo hello`
Run
`$ pouch logs --details test`
Got
`baz=qux qq=we foo=bar hello`


### Ⅴ. Special notes for reviews
None.

