### PR TITLE
feature: support RunAsGroup of CRI Manager

### DIFF
--- a/hack/testing/run_daemon_cri_integration.sh
+++ b/hack/testing/run_daemon_cri_integration.sh
@@ -18,11 +18,9 @@ export PATH="${REPO_BASE}/bin:${PATH}"
 export PATH="${GOPATH}/bin:${PATH}"
 
 # CRI_SKIP skips the test to skip.
-DEFAULT_CRI_SKIP="RunAsUserName|seccomp localhost"
+DEFAULT_CRI_SKIP="seccomp localhost"
 DEFAULT_CRI_SKIP="${DEFAULT_CRI_SKIP}|should error on create with wrong options"
 DEFAULT_CRI_SKIP="${DEFAULT_CRI_SKIP}|runtime should support reopening container log"
-DEFAULT_CRI_SKIP="${DEFAULT_CRI_SKIP}|runtime should support RunAsGroup"
-DEFAULT_CRI_SKIP="${DEFAULT_CRI_SKIP}|runtime should return error if RunAsGroup is set without RunAsUser"
 CRI_SKIP="${CRI_SKIP:-"${DEFAULT_CRI_SKIP}"}"
 
 # CRI_FOCUS focuses the test to run.


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
In the version `v1alpha2` of CRI defined by Kubernetes,  `RunAsGroup` is supported.  We should also support it for compatibility. 


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Has updated the test cases.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
Please  refer to :    https://github.com/kubernetes/kubernetes/blob/d1111a57d9243c55e02e0e66af55c2ddb36f3767/pkg/kubelet/apis/cri/runtime/v1alpha2/api.pb.go#L566

