### PR TITLE
bugfix: fix check annotation format

### DIFF
--- a/apis/opts/spec_annotation.go
+++ b/apis/opts/spec_annotation.go
@@ -10,7 +10,7 @@ func ParseAnnotation(annotations []string) (map[string]string, error) {
 	specAnnotation := make(map[string]string)
 
 	for _, annotation := range annotations {
-		splits := strings.Split(annotation, "=")
+		splits := strings.SplitN(annotation, "=", 2)
 		if len(splits) != 2 || splits[0] == "" || splits[1] == "" {
 			return nil, fmt.Errorf("invalid format for spec annotation: %s, correct format should be key=value, neither should be nil", annotation)
 		}

--- a/apis/opts/spec_annotation_test.go
+++ b/apis/opts/spec_annotation_test.go
@@ -19,7 +19,8 @@ func TestParseAnnotation(t *testing.T) {
 		{name: "test1", args: args{annotations: []string{""}}, want: nil, wantErr: true},
 		{name: "test2", args: args{annotations: []string{"=foo"}}, want: nil, wantErr: true},
 		{name: "test3", args: args{annotations: []string{"key="}}, want: nil, wantErr: true},
-		{name: "test4", args: args{annotations: []string{"key=foo=bar"}}, want: nil, wantErr: true},
+		{name: "test4", args: args{annotations: []string{"key=foo=bar"}}, want: map[string]string{"key": "foo=bar"}, wantErr: false},
+		{name: "test5", args: args{annotations: []string{"foo=bar"}}, want: map[string]string{"foo": "bar"}, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
fix format check in annotation, allow '=' in value.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

allow pouch run --annotation a="b=c", this format shoule be allowed, '=' is not a invalid charactor.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

add unit test.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


