### PR TITLE
bugfix: return pid with 0 rather than -1

### DIFF
--- a/cri/v1alpha1/cri_utils.go
+++ b/cri/v1alpha1/cri_utils.go
@@ -790,8 +790,8 @@ func filterCRIContainers(containers []*runtime.Container, filter *runtime.Contai
 // containerNetns returns the network namespace of the given container.
 func containerNetns(container *mgr.Container) string {
 	pid := container.State.Pid
-	if pid == -1 {
-		// Pouch reports pid -1 for an exited container.
+	if pid == 0 {
+		// Pouch reports pid 0 for an exited container.
 		return ""
 	}
 

--- a/cri/v1alpha1/cri_utils_test.go
+++ b/cri/v1alpha1/cri_utils_test.go
@@ -1220,11 +1220,11 @@ func Test_containerNetns(t *testing.T) {
 			want: fmt.Sprintf("/proc/%v/ns/net", 1001),
 		},
 		{
-			name: "Pid EQ -1 Test",
+			name: "Pid EQ 0 Test",
 			args: args{
 				container: &mgr.Container{
 					State: &apitypes.ContainerState{
-						Pid: int64(-1),
+						Pid: int64(0),
 					},
 				},
 			},

--- a/cri/v1alpha2/cri_utils.go
+++ b/cri/v1alpha2/cri_utils.go
@@ -817,8 +817,8 @@ func filterCRIContainers(containers []*runtime.Container, filter *runtime.Contai
 // containerNetns returns the network namespace of the given container.
 func containerNetns(container *mgr.Container) string {
 	pid := container.State.Pid
-	if pid == -1 {
-		// Pouch reports pid -1 for an exited container.
+	if pid == 0 {
+		// Pouch reports pid 0 for an exited container.
 		return ""
 	}
 

--- a/cri/v1alpha2/cri_utils_test.go
+++ b/cri/v1alpha2/cri_utils_test.go
@@ -1207,11 +1207,11 @@ func Test_containerNetns(t *testing.T) {
 			want: fmt.Sprintf("/proc/%v/ns/net", 1001),
 		},
 		{
-			name: "Pid EQ -1 Test",
+			name: "Pid EQ 0 Test",
 			args: args{
 				container: &mgr.Container{
 					State: &apitypes.ContainerState{
-						Pid: int64(-1),
+						Pid: int64(0),
 					},
 				},
 			},

--- a/daemon/mgr/container_state.go
+++ b/daemon/mgr/container_state.go
@@ -97,7 +97,7 @@ func (c *Container) SetStatusRunning(pid int64) {
 // When a container's status turns to StatusStopped, the following fields need updated:
 // Status -> StatusStopped
 // FinishedAt -> time.Now()
-// Pid -> -1
+// Pid -> 0
 // ExitCode -> input param
 // Error -> input param
 func (c *Container) SetStatusStopped(exitCode int64, errMsg string) {


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Kubernetes  will check the value of pid when the container stopped and the pid is 0 when container stopped, so when we build network namespace, we should make a judgment according to whether `Pid` equals to `0` rather than `-1` in CRI Manager.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2255

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

Has been updated.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


