### PR TITLE
refactor: handle the error in advance to avoid useless requests

### DIFF
--- a/cri/v1alpha1/cri_utils.go
+++ b/cri/v1alpha1/cri_utils.go
@@ -891,9 +891,9 @@ func (c *CriManager) attachLog(logPath string, containerID string, openStdin boo
 func (c *CriManager) getContainerMetrics(ctx context.Context, meta *mgr.Container) (*runtime.ContainerStats, error) {
 	var usedBytes, inodesUsed uint64
 
-	stats, _, err := c.ContainerMgr.Stats(ctx, meta.ID)
+	metadata, err := parseContainerName(meta.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get stats of container %q: %v", meta.ID, err)
+		return nil, fmt.Errorf("failed to get metadata of container %q: %v", meta.ID, err)
 	}
 
 	// snapshot key may not equals container ID later
@@ -913,11 +913,6 @@ func (c *CriManager) getContainerMetrics(ctx context.Context, meta *mgr.Containe
 		InodesUsed: &runtime.UInt64Value{inodesUsed},
 	}
 
-	metadata, err := parseContainerName(meta.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get metadata of container %q: %v", meta.ID, err)
-	}
-
 	labels, annotations := extractLabels(meta.Config.Labels)
 
 	cs.Attributes = &runtime.ContainerAttributes{
@@ -925,6 +920,11 @@ func (c *CriManager) getContainerMetrics(ctx context.Context, meta *mgr.Containe
 		Metadata:    metadata,
 		Labels:      labels,
 		Annotations: annotations,
+	}
+
+	stats, _, err := c.ContainerMgr.Stats(ctx, meta.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stats of container %q: %v", meta.ID, err)
 	}
 
 	if stats != nil {


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

At present, we will send request `stats` to `containerd` even if the container name will not be parsed, as the result, it will send a lot of useless requests to `containerd` when there are many containers that are not created through CRI Manager, and tend to cause huge waste of resources.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


