### PR TITLE
bugfix: only list container stats which are created by cri

### DIFF
--- a/cri/utils/utils.go
+++ b/cri/utils/utils.go
@@ -1,0 +1,18 @@
+package utils
+
+// Move the public utility methods which are used by both v1alpha1
+// and v1alpha2 here to reduce the code duplication.
+
+// MatchLabelSelector returns true if labels cover selector.
+func MatchLabelSelector(selector, labels map[string]string) bool {
+	for k, v := range selector {
+		if val, ok := labels[k]; ok {
+			if v != val {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}

--- a/cri/utils/utils_test.go
+++ b/cri/utils/utils_test.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"testing"
+)
+
+func Test_MatchLabelSelector(t *testing.T) {
+	type args struct {
+		selector map[string]string
+		labels   map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Normal Test",
+			args: args{
+				selector: map[string]string{
+					"a1": "b1",
+					"a2": "b2",
+				},
+				labels: map[string]string{
+					"a1": "b1",
+					"a2": "b2",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Uncovered Test",
+			args: args{
+				selector: map[string]string{
+					"a1": "b1",
+					"a2": "b2",
+				},
+				labels: map[string]string{
+					"a2": "b2",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Unmatched Test",
+			args: args{
+				selector: map[string]string{
+					"a1": "b0",
+					"a2": "b2",
+				},
+				labels: map[string]string{
+					"a1": "b1",
+					"a2": "b2",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MatchLabelSelector(tt.args.selector, tt.args.labels); got != tt.want {
+				t.Errorf("matchLabelSelector() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cri/v1alpha1/cri.go
+++ b/cri/v1alpha1/cri.go
@@ -17,6 +17,7 @@ import (
 	anno "github.com/alibaba/pouch/cri/annotations"
 	cni "github.com/alibaba/pouch/cri/ocicni"
 	"github.com/alibaba/pouch/cri/stream"
+	criutils "github.com/alibaba/pouch/cri/utils"
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/daemon/mgr"
 	"github.com/alibaba/pouch/pkg/errtypes"
@@ -822,6 +823,20 @@ func (c *CriManager) ContainerStats(ctx context.Context, r *runtime.ContainerSta
 func (c *CriManager) ListContainerStats(ctx context.Context, r *runtime.ListContainerStatsRequest) (*runtime.ListContainerStatsResponse, error) {
 	opts := &mgr.ContainerListOption{All: true}
 	filter := func(c *mgr.Container) bool {
+		if c.Config.Labels[containerTypeLabelKey] != containerTypeLabelContainer {
+			return false
+		}
+
+		if r.GetFilter().GetId() != "" && c.ID != r.GetFilter().GetId() {
+			return false
+		}
+		if r.GetFilter().GetPodSandboxId() != "" && c.Config.Labels[sandboxIDLabelKey] != r.GetFilter().GetPodSandboxId() {
+			return false
+		}
+		if r.GetFilter().GetLabelSelector() != nil &&
+			!criutils.MatchLabelSelector(r.GetFilter().GetLabelSelector(), c.Config.Labels) {
+			return false
+		}
 		return true
 	}
 	opts.FilterFunc = filter


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

When CRI manager list container stats, filter the container which is not created by CRI.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

No

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


