### PR TITLE
bugfix: make the time period of cri collecting stats from containerd configurable or just disable it

### DIFF
--- a/cri/config/config.go
+++ b/cri/config/config.go
@@ -21,4 +21,8 @@ type Config struct {
 	StreamServerPort string `json:"stream-server-port,omitempty"`
 	// StreamServerReusePort specify whether cri stream server share port with pouchd.
 	StreamServerReusePort bool `json:"stream-server-reuse-port,omitempty"`
+	// CriStatsCollectPeriod specify the time duration (in time.Second) cri collect stats from containerd.
+	CriStatsCollectPeriod int `json:"cri-stats-collect-period,omitempty"`
+	// DisableCriStatsCollect specify whether cri collect stats from containerd.
+	DisableCriStatsCollect bool `json:"disable-cri-stats-collect,omitempty"`
 }

--- a/main.go
+++ b/main.go
@@ -78,6 +78,8 @@ func setupFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.CriConfig.SandboxImage, "sandbox-image", "registry.cn-hangzhou.aliyuncs.com/google-containers/pause-amd64:3.0", "The image used by sandbox container.")
 	flagSet.StringVar(&cfg.CriConfig.StreamServerPort, "stream-server-port", "10010", "The port stream server of cri is listening on.")
 	flagSet.BoolVar(&cfg.CriConfig.StreamServerReusePort, "stream-server-reuse-port", false, "Specify whether cri stream server share port with pouchd. If this is true, the listen option of pouchd should specify a tcp socket and its port should be same with stream-server-port.")
+	flagSet.IntVar(&cfg.CriConfig.CriStatsCollectPeriod, "cri-stats-collect-period", 10, "The time duration (in time.Second) cri collect stats from containerd.")
+	flagSet.BoolVar(&cfg.CriConfig.DisableCriStatsCollect, "disable-cri-stats-collect", false, "Specify whether cri collect stats from containerd.If this is true, option CriStatsCollectPeriod will take no effect.")
 	flagSet.BoolVarP(&cfg.Debug, "debug", "D", false, "Switch daemon log level to DEBUG mode")
 	flagSet.StringVarP(&cfg.ContainerdAddr, "containerd", "c", "/var/run/containerd.sock", "Specify listening address of containerd")
 	flagSet.StringVar(&cfg.ContainerdPath, "containerd-path", "", "Specify the path of containerd binary")


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Now the time period which cri collect stats from containerd is fixed with 10s.

However it may occupy too much cpu time

So we make it configurable.

Maybe we could just disable it.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

No

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


