### PR TITLE
feature: add LogPath in Inspect Response

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -81,6 +81,7 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 		State:        c.State,
 		Config:       c.Config,
 		HostConfig:   c.HostConfig,
+		LogPath:      c.LogPath,
 		Snapshotter:  c.Snapshotter,
 		RestartCount: c.RestartCount,
 		GraphDriver: &types.GraphDriverData{

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -654,6 +654,9 @@ func (mgr *ContainerManager) createContainerdContainer(ctx context.Context, c *C
 		return errors.Wrap(err, "failed to open io")
 	}
 
+	// set container's LogPath
+	mgr.SetContainerLogPath(c)
+
 	runtime, err := mgr.getRuntime(c.HostConfig.Runtime)
 	if err != nil {
 		return err

--- a/daemon/mgr/container_logger.go
+++ b/daemon/mgr/container_logger.go
@@ -1,6 +1,8 @@
 package mgr
 
 import (
+	"path/filepath"
+
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/daemon/containerio"
 	"github.com/alibaba/pouch/daemon/logger"
@@ -47,4 +49,19 @@ func (mgr *ContainerManager) convContainerToLoggerInfo(c *Container) logger.Info
 		ContainerRootDir: mgr.Store.Path(c.ID),
 		DaemonName:       "pouchd",
 	}
+}
+
+// SetContainerLogPath sets the log path of container.
+// LogPath would be as a field in `Inspect` response.
+func (mgr *ContainerManager) SetContainerLogPath(c *Container) {
+	if c.HostConfig.LogConfig == nil {
+		return
+	}
+
+	// If the logdriver is json-file, the LogPath should be like
+	// /var/lib/pouch/containers/5804ee42e505a5d9f30128848293fcb72d8cbc7517310bd24895e82a618fa454/json.log
+	if c.HostConfig.LogConfig.LogDriver == "json-file" {
+		c.LogPath = filepath.Join(mgr.Config.HomeDir, "containers", c.ID, "json.log")
+	}
+	return
 }

--- a/test/cli_inspect_test.go
+++ b/test/cli_inspect_test.go
@@ -33,10 +33,11 @@ func (suite *PouchInspectSuite) SetUpSuite(c *check.C) {
 func (suite *PouchInspectSuite) TearDownTest(c *check.C) {
 }
 
-// TestInspectFormat is to verify the format flag of inspect command.
-func (suite *PouchInspectSuite) TestInspectFormat(c *check.C) {
-	name := "inspect-format-print"
+// TestInspectCreateAndStartedFormat is to verify the format flag of inspect command.
+func (suite *PouchInspectSuite) TestInspectCreateAndStartedFormat(c *check.C) {
+	name := "TestInspectCreateAndStartedFormat"
 
+	// create a raw container
 	res := command.PouchRun("create", "-m", "30M", "--name", name, busyboxImage, "top")
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
@@ -55,6 +56,20 @@ func (suite *PouchInspectSuite) TestInspectFormat(c *check.C) {
 	// inspect Memory
 	output = command.PouchRun("inspect", "-f", "{{.HostConfig.Memory}}", name).Stdout()
 	c.Assert(output, check.Equals, fmt.Sprintf("%d\n", result[0].HostConfig.Memory))
+
+	// Inspect LogPath, LogPath should be empty before container's start
+	output = command.PouchRun("inspect", "-f", "{{.LogPath}}", name).Stdout()
+	c.Assert(strings.TrimSpace(output), check.Equals, "")
+
+	// start the created container
+	res = command.PouchRun("start", name)
+	res.Assert(c, icmd.Success)
+
+	// Inspect LogPath, LogPath should not be empty after container's start.
+	// by default, the container has log type of json-file.
+	output = command.PouchRun("inspect", "-f", "{{.LogPath}}", name).Stdout()
+	expectedLogPath := fmt.Sprintf("/var/lib/pouch/containers/%s/json.log", containerID)
+	c.Assert(strings.TrimSpace(output), check.Equals, expectedLogPath)
 }
 
 // TestInspectWrongFormat is to verify using wrong format flag of inspect command.


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This pull request tries to add `LogPath` field in container instance and return this field in `/containers/{id}/json` API.

We know only when log driver is `json-file`, the LogPath is not empty, so the function does this:
```
// SetContainerLogPath sets the log path of container.
// LogPath would be as a field in `Inspect` response.
func (mgr *ContainerManager) SetContainerLogPath(c *Container) {
	if c.HostConfig.LogConfig == nil {
		return
	}

	// If the logdriver is json-file, the LogPath should be like
	// /var/lib/pouch/containers/5804ee42e505a5d9f30128848293fcb72d8cbc7517310bd24895e82a618fa454/json.log
	if c.HostConfig.LogConfig.LogDriver == "json-file" {
		c.LogPath = filepath.Join(mgr.Config.HomeDir, "containers", c.ID, "json.log")
	}
	return
}
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes https://github.com/alibaba/pouch/issues/2283


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
test cases added.


### Ⅳ. Describe how to verify it

execute command
```
root@ubuntu:~# pouch inspect -f {{.LogPath}} 4e6aa
/var/lib/pouch/containers/4e6aad08d0961071c12faa0f137a44cd547d64958ff2c93c5aeb4c53f3b64a84/json.log
```

### Ⅴ. Special notes for reviews


