### PR TITLE
feature: add ineffassign in gometalinter

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -3,6 +3,7 @@
     "gofmt",
     "goimports",
     "golint",
+    "ineffassign",
     "misspell",
     "vet"
   ],

--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -357,11 +357,7 @@ func (s *Server) logsContainer(ctx context.Context, rw http.ResponseWriter, req 
 func (s *Server) statsContainer(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	name := mux.Vars(req)["name"]
 
-	var stream bool
-	if _, ok := req.Form["stream"]; !ok {
-		stream = true
-	}
-	stream = httputils.BoolValue(req, "stream")
+	stream := httputils.BoolValue(req, "stream")
 
 	if !stream {
 		rw.Header().Set("Content-Type", "application/json")

--- a/cli/events.go
+++ b/cli/events.go
@@ -36,6 +36,7 @@ func (e *EventsCommand) Init(c *Cli) {
 		Use:   "events [OPTIONS]",
 		Short: "Get real time events from the daemon",
 		Args:  cobra.NoArgs,
+		Long:  eventsDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return e.runEvents()
 		},

--- a/cli/info.go
+++ b/cli/info.go
@@ -28,6 +28,7 @@ func (v *InfoCommand) Init(c *Cli) {
 		Use:   "info [OPTIONS]",
 		Short: "Display system-wide information",
 		Args:  cobra.NoArgs,
+		Long:  infoDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return v.runInfo()
 		},

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -11,11 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var validDrivers = map[string]bool{
-	"json-file": true,
-	"journald":  true,
-}
-
 // logsDescription is used to describe logs command in detail and auto generate command doc.
 var logsDescription = "Get container's logs"
 

--- a/cli/network.go
+++ b/cli/network.go
@@ -479,6 +479,7 @@ func (nd *NetworkDisconnectCommand) Init(c *Cli) {
 		Use:   "disconnect [OPTIONS] NETWORK CONTAINER",
 		Short: "Disconnect a container from a network",
 		Args:  cobra.ExactArgs(2),
+		Long:  networkDisconnectDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return nd.runNetworkDisconnect(args)
 		},

--- a/cli/version.go
+++ b/cli/version.go
@@ -23,6 +23,7 @@ func (v *VersionCommand) Init(c *Cli) {
 		Use:   "version",
 		Short: "Print versions about Pouch CLI and Pouchd",
 		Args:  cobra.NoArgs,
+		Long:  versionDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return v.runVersion()
 		},

--- a/client/client.go
+++ b/client/client.go
@@ -45,7 +45,7 @@ func NewAPIClient(host string, tls TLSConfig) (CommonAPIClient, error) {
 		host = defaultHost
 	}
 
-	newURL, basePath, addr, err := httputils.ParseHost(host)
+	newURL, _, addr, err := httputils.ParseHost(host)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse host %s: %v", host, err)
 	}
@@ -54,7 +54,7 @@ func NewAPIClient(host string, tls TLSConfig) (CommonAPIClient, error) {
 
 	httpCli := httputils.NewHTTPClient(newURL, tlsConfig, defaultTimeout)
 
-	basePath = generateBaseURL(newURL, tls)
+	basePath := generateBaseURL(newURL, tls)
 
 	version := os.Getenv("POUCH_API_VERSION")
 	if version == "" {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	testHost = "unix:///var/run/pouchd.sock"
-)
-
 func TestNewAPIClient(t *testing.T) {
 	assert := assert.New(t)
 	kvs := map[string]bool{

--- a/cri/stream/httpstream/httpstream_test.go
+++ b/cri/stream/httpstream/httpstream_test.go
@@ -53,27 +53,27 @@ func TestHandshake(t *testing.T) {
 	serverProtocls := []string{}
 
 	// clientProtocols and serverProtocls both are empty.
-	protocol, err := Handshake(w, req, serverProtocls)
+	protocol, _ := Handshake(w, req, serverProtocls)
 	if protocol != "" {
 		t.Fatalf("clientProtocols and serverProtocls both are empty, returned protocol should be empty")
 	}
 
 	// clientProtocols is empty.
 	serverProtocls = []string{constant.StreamProtocolV3Name}
-	protocol, err = Handshake(w, req, serverProtocls)
+	protocol, _ = Handshake(w, req, serverProtocls)
 	if protocol != "" {
 		t.Fatalf("clientProtocols is empty, returned protocol should be empty")
 	}
 
 	// serverProtocls is empty.
 	req.Header.Add(http.CanonicalHeaderKey(HeaderProtocolVersion), constant.StreamProtocolV1Name)
-	protocol, err = Handshake(w, req, []string{})
+	protocol, _ = Handshake(w, req, []string{})
 	if protocol != "" {
 		t.Fatalf("serverProtocls is empty, returned protocol should be empty")
 	}
 
 	// clientProtocols and serverProtocls have no common protocol.
-	protocol, err = Handshake(w, req, serverProtocls)
+	protocol, _ = Handshake(w, req, serverProtocls)
 	if protocol != "" {
 		t.Fatalf("no common protocol, returned protocol should be empty")
 	}
@@ -89,7 +89,7 @@ func TestHandshake(t *testing.T) {
 	serverProtocls = []string{constant.StreamProtocolV2Name, constant.StreamProtocolV3Name}
 	req.Header.Add(http.CanonicalHeaderKey(HeaderProtocolVersion), constant.StreamProtocolV2Name)
 
-	protocol, err = Handshake(w, req, serverProtocls)
+	protocol, _ = Handshake(w, req, serverProtocls)
 	if protocol != constant.StreamProtocolV2Name {
 		t.Fatalf("Handshake should return the common protocol")
 	}

--- a/ctrd/client.go
+++ b/ctrd/client.go
@@ -372,8 +372,8 @@ func (c *Client) collectContainerdEvents() {
 			continue
 		}
 		var (
-			action      = ""
-			containerID = ""
+			action      string
+			containerID string
 			attributes  = map[string]string{}
 		)
 

--- a/daemon/logger/jsonfile/utils.go
+++ b/daemon/logger/jsonfile/utils.go
@@ -194,7 +194,7 @@ func seekOffsetByTailLines(rs io.ReadSeeker, n int) (int64, error) {
 		left  = int64(0)
 		b     []byte
 
-		readN = int64(0)
+		readN int64
 	)
 
 	for {

--- a/network/mode/bridge/bridge.go
+++ b/network/mode/bridge/bridge.go
@@ -59,7 +59,7 @@ func New(ctx context.Context, config network.BridgeConfig, manager mgr.NetworkMg
 	logrus.Debugf("initialize bridge network, bridge network: %s", subnet)
 
 	// get ip range
-	ipRange := DefaultIPRange
+	var ipRange string
 	if config.FixedCIDR != "" {
 		ipRange = config.FixedCIDR
 	} else {

--- a/pkg/serializer/serialize.go
+++ b/pkg/serializer/serialize.go
@@ -11,7 +11,6 @@ type ContentType string
 const (
 	// ContentTypeJSON is a json ContentType.
 	ContentTypeJSON ContentType = "application/json"
-	defaultType                 = "application/json"
 )
 
 // String return ContentType as string type.

--- a/pkg/utils/filters/filter.go
+++ b/pkg/utils/filters/filter.go
@@ -53,7 +53,7 @@ func Parse(filter []string) (map[string][]string, error) {
 		}
 
 		if v, exist := parsed[name]; exist {
-			v = append(v, strings.TrimSpace(splits[1]))
+			parsed[name] = append(v, strings.TrimSpace(splits[1]))
 		} else {
 			parsed[name] = []string{strings.TrimSpace(splits[1])}
 		}

--- a/registry/config.go
+++ b/registry/config.go
@@ -1,6 +1,5 @@
 package registry
 
 var (
-	defaultV1Registry = "index.docker.io"
 	defaultV2Registry = "registry-1.docker.io"
 )

--- a/storage/volume/core_test.go
+++ b/storage/volume/core_test.go
@@ -166,7 +166,7 @@ func TestListVolumes(t *testing.T) {
 		volmap[volName] = v
 	}
 
-	volarray, err := core.ListVolumes(nil)
+	volarray, _ := core.ListVolumes(nil)
 	for k := 0; k < len(volarray); k++ {
 		vol := volarray[k]
 		_, found := volmap[vol.Name]

--- a/storage/volume/driver/driver.go
+++ b/storage/volume/driver/driver.go
@@ -138,13 +138,13 @@ func (t *driverTable) GetAll() ([]Driver, error) {
 	}
 
 	for _, p := range pluginList {
-		d, ok := t.drivers[p.Name]
+		_, ok := t.drivers[p.Name]
 		if ok {
 			// the driver has existed, ignore it.
 			continue
 		}
 
-		d = NewRemoteDriverWrapper(p.Name, p)
+		d := NewRemoteDriverWrapper(p.Name, p)
 
 		t.drivers[p.Name] = d
 		driverList = append(driverList, d)

--- a/test/api_checkpoint_test.go
+++ b/test/api_checkpoint_test.go
@@ -124,4 +124,5 @@ func (suite *APIContainerCheckpointSuite) TestCheckpointDelAPI(c *check.C) {
 
 	resp, err = request.Delete("/containers/" + cname + "/checkpoints/" + "cp0")
 	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 204)
 }

--- a/test/api_daemon_update_test.go
+++ b/test/api_daemon_update_test.go
@@ -38,6 +38,8 @@ func (suite *APIDaemonUpdateSuite) TestUpdateDaemon(c *check.C) {
 	CheckRespStatus(c, resp, 200)
 
 	resp, err = request.Get("/info", body)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 200)
 
 	info := types.SystemInfo{}
 	err = request.DecodeBody(&info, resp.Body)


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add ineffassign check and varcheck in gometalinter to polish the code style.

Without ineffassign:
```
apis/server/container_bridge.go:362:3:warning: ineffectual assignment to stream (ineffassign)
client/client.go:48:10:warning: ineffectual assignment to basePath (ineffassign)
cri/stream/httpstream/httpstream_test.go:56:12:warning: ineffectual assignment to err (ineffassign)
cri/stream/httpstream/httpstream_test.go:63:12:warning: ineffectual assignment to err (ineffassign)
cri/stream/httpstream/httpstream_test.go:70:12:warning: ineffectual assignment to err (ineffassign)
cri/stream/httpstream/httpstream_test.go:76:12:warning: ineffectual assignment to err (ineffassign)
cri/stream/httpstream/httpstream_test.go:92:12:warning: ineffectual assignment to err (ineffassign)
ctrd/client.go:375:4:warning: ineffectual assignment to action (ineffassign)
ctrd/client.go:376:4:warning: ineffectual assignment to containerID (ineffassign)
daemon/logger/jsonfile/utils.go:197:3:warning: ineffectual assignment to readN (ineffassign)
network/mode/bridge/bridge.go:62:2:warning: ineffectual assignment to ipRange (ineffassign)
pkg/utils/filters/filter.go:56:4:warning: ineffectual assignment to v (ineffassign)
storage/volume/core_test.go:169:12:warning: ineffectual assignment to err (ineffassign)
storage/volume/driver/driver.go:141:3:warning: ineffectual assignment to d (ineffassign)
test/api_checkpoint_test.go:125:2:warning: ineffectual assignment to resp (ineffassign)
test/api_daemon_update_test.go:40:8:warning: ineffectual assignment to err (ineffassign)
```

Without varcheck:
```
client/client_test.go:12:2: `testHost` is unused (varcheck)
        testHost = "unix:///var/run/pouchd.sock"
        ^
cli/logs.go:14:5: `validDrivers` is unused (varcheck)
var validDrivers = map[string]bool{
    ^
cli/network.go:467:5: `networkDisconnectDescription` is unused (varcheck)
var networkDisconnectDescription = "Disconnect a container from a network"
    ^
registry/config.go:4:2: `defaultV1Registry` is unused (varcheck)
        defaultV1Registry = "index.docker.io"
        ^
cli/events.go:21:5: `eventsDescription` is unused (varcheck)
var eventsDescription = "events cli tool is used to subscribe pouchd events." +
    ^
cli/info.go:15:5: `infoDescription` is unused (varcheck)
var infoDescription = "Display the information of pouch, " +
    ^
pkg/serializer/serialize.go:14:2: `defaultType` is unused (varcheck)
        defaultType                 = "application/json"
        ^
cli/version.go:11:5: `versionDescription` is unused (varcheck)
var versionDescription = "Display the version information of pouch client and daemon， " +
    ^
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no need, it is only about the code style.


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

