### PR TITLE
bugfix: jsonfile log should be compatible with moby

### DIFF
--- a/daemon/logger/jsonfile/encode.go
+++ b/daemon/logger/jsonfile/encode.go
@@ -12,9 +12,9 @@ import (
 )
 
 type jsonLog struct {
-	Source    string    `json:"source,omitempty"`
-	Line      string    `json:"line,omitempty"`
-	Timestamp time.Time `json:"timestamp,omitempty"`
+	Stream    string    `json:"stream,omitempty"`
+	Log       string    `json:"log,omitempty"`
+	Timestamp time.Time `json:"time"`
 }
 
 func newUnmarshal(r io.Reader) func() (*logger.LogMessage, error) {
@@ -27,8 +27,8 @@ func newUnmarshal(r io.Reader) func() (*logger.LogMessage, error) {
 		}
 
 		return &logger.LogMessage{
-			Source:    jl.Source,
-			Line:      []byte(jl.Line),
+			Source:    jl.Stream,
+			Line:      []byte(jl.Log),
 			Timestamp: jl.Timestamp,
 		}, nil
 	}
@@ -43,7 +43,7 @@ func marshal(msg *logger.LogMessage) ([]byte, error) {
 	buf.WriteString("{")
 	if len(msg.Source) != 0 {
 		first = false
-		buf.WriteString(`"source":`)
+		buf.WriteString(`"stream":`)
 		bytesIntoJSONString(&buf, []byte(msg.Source))
 	}
 
@@ -52,7 +52,7 @@ func marshal(msg *logger.LogMessage) ([]byte, error) {
 			buf.WriteString(`,`)
 		}
 		first = false
-		buf.WriteString(`"line":`)
+		buf.WriteString(`"log":`)
 		bytesIntoJSONString(&buf, msg.Line)
 	}
 
@@ -60,7 +60,7 @@ func marshal(msg *logger.LogMessage) ([]byte, error) {
 		buf.WriteString(`,`)
 	}
 
-	buf.WriteString(`"timestamp":`)
+	buf.WriteString(`"time":`)
 	buf.WriteString(msg.Timestamp.UTC().Format(`"` + utils.TimeLayout + `"`))
 	buf.WriteString(`}`)
 

--- a/daemon/logger/jsonfile/utils_test.go
+++ b/daemon/logger/jsonfile/utils_test.go
@@ -84,16 +84,16 @@ func TestSeekOffsetByTailLines(t *testing.T) {
 }
 
 const (
-	logContentPart1 = `{"source":"stdout","line":"#1","timestamp":"2018-05-09T10:00:01Z"}
-{"source":"stdout","line":"#2","timestamp":"2018-05-09T10:00:02Z"}
-{"source":"stdout","line":"#3","timestamp":"2018-05-09T10:00:03Z"}
+	logContentPart1 = `{"stream":"stdout","log":"#1","time":"2018-05-09T10:00:01Z"}
+{"stream":"stdout","log":"#2","time":"2018-05-09T10:00:02Z"}
+{"stream":"stdout","log":"#3","time":"2018-05-09T10:00:03Z"}
 `
 
-	logContentPart2 = `{"source":"stdout","line":"#4","timestamp":"2018-05-09T10:00:04Z"}
+	logContentPart2 = `{"stream":"stdout","log":"#4","time":"2018-05-09T10:00:04Z"}
 `
 
-	logContentPart3 = `{"source":"stderr","line":"#5","timestamp":"2018-05-09T10:00:05Z"}
-{"source":"stderr","line":"#6","timestamp":"2018-05-09T10:00:06Z"}
+	logContentPart3 = `{"stream":"stderr","log":"#5","time":"2018-05-09T10:00:05Z"}
+{"stream":"stderr","log":"#6","time":"2018-05-09T10:00:06Z"}
 `
 )
 


### PR DESCRIPTION
Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

source in jsonfile log should be marshaled to stream

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no need 

### Ⅳ. Describe how to verify it

The `stream` will replace the `source` in the json.

```
# vagrant @ ubuntu-xenial in ~/go/src/github.com/alibaba/pouch on git:bugfix_jsonfile_marshal_field o [16:35:48]
$ sudo pouch run -it registry.hub.docker.com/library/busybox:latest echo hello
hello

# vagrant @ ubuntu-xenial in ~/go/src/github.com/alibaba/pouch on git:bugfix_jsonfile_marshal_field o [16:36:33]
$ sudo cat /var/lib/pouch/containers/9a420911f1371f9abce896fa3d21b1c4f879e151b1d96f01a64a35232579804c/json.log
{"stream":"stdout","log":"hello\n","time":"2018-10-08T13:15:29.603009864Z"}
```


### Ⅴ. Special notes for reviews

For the existing container, the jsonfile will contain two types json formats, like:

```
# vagrant @ ubuntu-xenial in ~/go/src/github.com/alibaba/pouch on git:master x [16:46:56]
$ sudo cat /var/lib/pouch/containers/9a420911f1371f9abce896fa3d21b1c4f879e151b1d96f01a64a35232579804c/json.log
{"stream":"stdout","log":"hello\n","time":"2018-10-08T13:15:29.603009864Z"}
{"source":"stdout","line":"hello\n","timestamp":"2018-10-08T08:46:06.605697918Z"}
```
it will impact the `pouch log` command and `pouch log api` to fetch the logs. The log API will not parse the existing data so that it will show empty to the user.
