### PR TITLE
fix: remove fifo path if stdio is not initail

### DIFF
--- a/daemon/containerio/cio.go
+++ b/daemon/containerio/cio.go
@@ -198,6 +198,10 @@ func WithAttach(stdin io.Reader, stdout, stderr io.Writer) containerdio.Attach {
 		if paths == nil {
 			return nil, fmt.Errorf("cannot attach to existing fifos")
 		}
+		// judge stdin is initial, make logic same with copyIO.
+		if i, ok := stdin.(*ContainerIO); (ok && i == nil) || (stdin == nil) {
+			paths.In = ""
+		}
 		cfg := containerdio.Config{
 			Terminal: paths.Terminal,
 			Stdout:   paths.Out,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
remove fifo path if stdio is not initail

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


