### PR TITLE
enhance: add sync.Pool for logMessage

### DIFF
--- a/daemon/logger/copier.go
+++ b/daemon/logger/copier.go
@@ -70,11 +70,11 @@ func (lc *LogCopier) copy(source string, reader io.Reader) {
 			bs = append(bs, '\n')
 		}
 
-		if err = lc.dst.WriteLogMessage(&LogMessage{
-			Source:    source,
-			Line:      bs,
-			Timestamp: createdTime,
-		}); err != nil {
+		logMessage := NewMessage()
+		logMessage.Source = source
+		logMessage.Line = bs
+		logMessage.Timestamp = createdTime
+		if err = lc.dst.WriteLogMessage(logMessage); err != nil {
 			logrus.WithError(err).Errorf("failed to copy into %v-%v", lc.dst.Name(), source)
 		}
 	}

--- a/daemon/logger/jsonfile/jsonfile.go
+++ b/daemon/logger/jsonfile/jsonfile.go
@@ -78,6 +78,7 @@ func (lf *JSONLogFile) WriteLogMessage(msg *logger.LogMessage) error {
 	if err != nil {
 		return err
 	}
+	logger.PutMessage(msg)
 
 	lf.mu.Lock()
 	defer lf.mu.Unlock()

--- a/daemon/logger/logmessage.go
+++ b/daemon/logger/logmessage.go
@@ -14,6 +14,28 @@ type LogMessage struct {
 	Err       error
 }
 
+var messagePool = &sync.Pool{New: func() interface{} { return &LogMessage{Line: make([]byte, 0, 256)} }}
+
+// NewMessage returns a new message from the message sync.Pool
+func NewMessage() *LogMessage {
+	return messagePool.Get().(*LogMessage)
+}
+
+// PutMessage puts the specified message back n the message pool.
+// The message fields are reset before putting into the pool.
+func PutMessage(msg *LogMessage) {
+	msg.reset()
+	messagePool.Put(msg)
+}
+
+// reset sets the message back to default values
+// This is used when putting a message back into the message pool.
+func (m *LogMessage) reset() {
+	m.Line = m.Line[:0]
+	m.Source = ""
+	m.Err = nil
+}
+
 // LogWatcher is used to pass the log message to the reader.
 type LogWatcher struct {
 	Msgs chan *LogMessage

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -64,7 +64,10 @@ func (s *Syslog) Name() string {
 // WriteLogMessage will write the LogMessage.
 func (s *Syslog) WriteLogMessage(msg *logger.LogMessage) error {
 	line := string(msg.Line)
-	if msg.Source == "stderr" {
+	source := msg.Source
+	logger.PutMessage(msg)
+
+	if source == "stderr" {
 		return s.logError(line)
 	}
 	return s.logInfo(line)


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
As the title told, when consume and produce log message in pouch, the logMessage struct be deleted and constructed back and forth, this pr add a sync.Pool for logMessage to cache logMessage struct in memory to enhance gc performance. 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it
go test -check.f PouchAttachSuite

### Ⅴ. Special notes for reviews
None.

