### PR TITLE
bugfix: add check for json-file log opt

### DIFF
--- a/daemon/logger/jsonfile/jsonfile.go
+++ b/daemon/logger/jsonfile/jsonfile.go
@@ -1,6 +1,7 @@
 package jsonfile
 
 import (
+	"fmt"
 	"os"
 	"sync"
 
@@ -56,5 +57,24 @@ func (lf *JSONLogFile) Close() error {
 		return err
 	}
 	lf.closed = true
+	return nil
+}
+
+var validLogOpt = []string{"max-file", "max-size", "compress", "labels", "env", "env-regex", "tag"}
+
+// ValidateLogOpt validate log options for json-file log driver
+func ValidateLogOpt(cfg map[string]string) error {
+	for key := range cfg {
+		isValid := false
+		for _, opt := range validLogOpt {
+			if key == opt {
+				isValid = true
+				break
+			}
+		}
+		if !isValid {
+			return fmt.Errorf("unknown log opt '%s' for json-file log driver", key)
+		}
+	}
 	return nil
 }

--- a/daemon/mgr/container_validation.go
+++ b/daemon/mgr/container_validation.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/daemon/logger/jsonfile"
 	"github.com/alibaba/pouch/daemon/logger/syslog"
 	"github.com/alibaba/pouch/pkg/system"
 
@@ -202,7 +203,7 @@ func (mgr *ContainerManager) validateLogConfig(c *Container) error {
 
 	switch logCfg.LogDriver {
 	case types.LogConfigLogDriverNone, types.LogConfigLogDriverJSONFile:
-		return nil
+		return jsonfile.ValidateLogOpt(logCfg.LogOpts)
 	case types.LogConfigLogDriverSyslog:
 		info := mgr.convContainerToLoggerInfo(c)
 		return syslog.ValidateSyslogOption(info)

--- a/test/cli_logs_test.go
+++ b/test/cli_logs_test.go
@@ -148,6 +148,28 @@ func (suite *PouchLogsSuite) TestFollowMode(c *check.C) {
 	}
 }
 
+// TestLogsOpt tests if log options could work.
+func (suite *PouchLogsSuite) TestLogsOpt(c *check.C) {
+	cname := "TestCLILogs_LogsOpt"
+	command.PouchRun(
+		"run",
+		"--log-opt", "env=test",
+		"--name", cname,
+		busyboxImage,
+	).Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, cname)
+
+	cnameOfUnsupported := "TestCLILogs_LogsOpt_Unsupported"
+	result := command.PouchRun(
+		"run",
+		"--log-opt", "env1=test",
+		"--name", cnameOfUnsupported,
+		busyboxImage,
+	)
+	c.Assert(result.Error, check.NotNil)
+	defer DelContainerForceMultyTime(c, cnameOfUnsupported)
+}
+
 func (suite *PouchLogsSuite) syncLogs(c *check.C, cname string, flags ...string) []string {
 	args := append([]string{"logs"}, flags...)
 


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
check the pouch if run with unsupported log options.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix issue #2276 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.

### Ⅳ. Describe how to verify it
`pouch run --name=test --log-opt env1=baz busybox echo hello`
Get
`Error: failed to run container: {"message":"unknown log opt 'env1' for json-file log driver"}`

### Ⅴ. Special notes for reviews
None.

