### PR TITLE
bugfix: remove set quota for container meta directory

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1168,17 +1168,9 @@ func (mgr *ContainerManager) updateContainerDiskQuota(ctx context.Context, c *Co
 			}
 		}()
 	}
-	newID, err := quota.SetRootfsDiskQuota(rootfs, defaultQuota, qid)
+	_, err := quota.SetRootfsDiskQuota(rootfs, defaultQuota, qid)
 	if err != nil {
 		return errors.Wrapf(err, "failed to set container rootfs diskquota")
-	}
-
-	// set container's metadata directory diskquota, for limit the size of container's logs
-	metaDir := mgr.Store.Path(c.ID)
-	err = quota.SetDiskQuota(metaDir, defaultQuota, newID)
-	if err != nil {
-		return errors.Wrapf(err, "failed to set container's log quota, dir: (%s), quota: (%s), quota id: (%d)",
-			metaDir, defaultQuota, newID)
 	}
 
 	return nil

--- a/daemon/mgr/container_storage.go
+++ b/daemon/mgr/container_storage.go
@@ -469,18 +469,10 @@ func (mgr *ContainerManager) setRootfsQuota(ctx context.Context, c *Container) e
 	}
 
 	// set rootfs quota
-	newID, err := quota.SetRootfsDiskQuota(c.MountFS, rootfsQuota, uint32(id))
+	_, err = quota.SetRootfsDiskQuota(c.MountFS, rootfsQuota, uint32(id))
 	if err != nil {
 		return errors.Wrapf(err, "failed to set rootfs quota, mountfs: (%s), quota: (%s), quota id: (%d)",
 			c.MountFS, rootfsQuota, id)
-	}
-
-	// set container's metadata directory diskquota, for limit the size of container's logs
-	metaDir := mgr.Store.Path(c.ID)
-	err = quota.SetDiskQuota(metaDir, rootfsQuota, newID)
-	if err != nil {
-		return errors.Wrapf(err, "failed to set container's log quota, dir: (%s), quota: (%s), quota id: (%d)",
-			metaDir, rootfsQuota, newID)
 	}
 
 	return nil

--- a/storage/quota/grpquota.go
+++ b/storage/quota/grpquota.go
@@ -201,7 +201,7 @@ func (quota *GrpQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 		}
 
 		// check the shortest mountpoint.
-		if mountPoint != "" && len(mountPoint) < len(parts[1]) && strings.Contains(parts[1], mountPoint) {
+		if mountPoint != "" && len(mountPoint) < len(parts[1]) {
 			continue
 		}
 

--- a/storage/quota/grpquota.go
+++ b/storage/quota/grpquota.go
@@ -181,8 +181,9 @@ func (quota *GrpQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 	}
 
 	var (
-		mountPoint string
-		fsType     string
+		enableQuota bool
+		mountPoint  string
+		fsType      string
 	)
 
 	// Two formats of group quota.
@@ -199,17 +200,25 @@ func (quota *GrpQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 			continue
 		}
 
+		// check the shortest mountpoint.
+		if mountPoint != "" && len(mountPoint) < len(parts[1]) && strings.Contains(parts[1], mountPoint) {
+			continue
+		}
+
 		// get device's mountpoint and fs type.
 		mountPoint = parts[1]
 		fsType = parts[2]
 
-		// check the device turn on the prpquota or not.
+		// check the device turn on the grpquota or not.
 		if strings.Contains(parts[3], "grpquota") || strings.Contains(parts[3], "grpjquota") {
-			return mountPoint, true, fsType
+			enableQuota = true
 		}
 	}
 
-	return mountPoint, false, fsType
+	logrus.Debugf("check device: (%d), mountpoint: (%s), enableQuota: (%v), fsType: (%s)",
+		devID, mountPoint, enableQuota, fsType)
+
+	return mountPoint, enableQuota, fsType
 }
 
 // SetDiskQuota is used to set quota for directory.

--- a/storage/quota/prjquota.go
+++ b/storage/quota/prjquota.go
@@ -180,8 +180,9 @@ func (quota *PrjQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 	}
 
 	var (
-		mountPoint string
-		fsType     string
+		enableQuota bool
+		mountPoint  string
+		fsType      string
 	)
 
 	// /dev/sdb1 /home/pouch ext4 rw,relatime,prjquota,data=ordered 0 0
@@ -196,6 +197,11 @@ func (quota *PrjQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 			continue
 		}
 
+		// check the shortest mountpoint.
+		if mountPoint != "" && len(mountPoint) < len(parts[1]) && strings.Contains(parts[1], mountPoint) {
+			continue
+		}
+
 		// get device's mountpoint and fs type.
 		mountPoint = parts[1]
 		fsType = parts[2]
@@ -203,12 +209,16 @@ func (quota *PrjQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 		// check the device turn on the prjquota or not.
 		for _, value := range strings.Split(parts[3], ",") {
 			if value == "prjquota" {
-				return mountPoint, true, fsType
+				enableQuota = true
+				break
 			}
 		}
 	}
 
-	return mountPoint, false, fsType
+	logrus.Debugf("check device: (%d), mountpoint: (%s), enableQuota: (%v), fsType: (%s)",
+		devID, mountPoint, enableQuota, fsType)
+
+	return mountPoint, enableQuota, fsType
 }
 
 // setQuota uses system tool "setquota" to set project quota for binding of limit and mountpoint and quotaID.

--- a/storage/quota/prjquota.go
+++ b/storage/quota/prjquota.go
@@ -198,7 +198,7 @@ func (quota *PrjQuotaDriver) CheckMountpoint(devID uint64) (string, bool, string
 		}
 
 		// check the shortest mountpoint.
-		if mountPoint != "" && len(mountPoint) < len(parts[1]) && strings.Contains(parts[1], mountPoint) {
+		if mountPoint != "" && len(mountPoint) < len(parts[1]) {
 			continue
 		}
 

--- a/test/cli_run_volume_test.go
+++ b/test/cli_run_volume_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -13,7 +12,6 @@ import (
 
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
-	"github.com/pkg/errors"
 )
 
 // PouchRunVolumeSuite is the test suite for run CLI.
@@ -332,59 +330,4 @@ func (suite *PouchRunVolumeSuite) TestRunWithDiskQuota(c *check.C) {
 	}
 
 	c.Assert(found, check.Equals, true)
-}
-
-// TestRunWithDiskQuotaForLog tests limit the size of container's log.
-func (suite *PouchRunVolumeSuite) TestRunWithDiskQuotaForLog(c *check.C) {
-	if !environment.IsDiskQuota() {
-		c.Skip("Host does not support disk quota")
-	}
-
-	cname := "TestRunWithDiskQuotaForLog"
-	command.PouchRun("run", "-d", "--disk-quota", "10m",
-		"--name", cname, busyboxImage, "top").Assert(c, icmd.Success)
-
-	defer DelContainerForceMultyTime(c, cname)
-
-	containerMetaDir, err := getContainerMetaDir(cname)
-	c.Assert(err, check.Equals, nil)
-
-	testFile := filepath.Join(containerMetaDir, "diskquota_testfile")
-	expct := icmd.Expected{
-		ExitCode: 1,
-		Err:      "Disk quota exceeded",
-	}
-	err = icmd.RunCommand("dd", "if=/dev/zero", "of="+testFile, "bs=1M", "count=20", "oflag=direct").Compare(expct)
-	c.Assert(err, check.IsNil)
-}
-
-func getContainerMetaDir(name string) (string, error) {
-	ret := command.PouchRun("inspect", name)
-
-	mergedDir := ""
-	for _, line := range strings.Split(ret.Stdout(), "\n") {
-		if strings.Contains(line, "MergedDir") {
-			mergedDir = strings.Split(line, "\"")[3]
-			break
-		}
-	}
-
-	var (
-		graph string
-		cid   string
-	)
-	if mergedDir == "" {
-		return "", errors.Errorf("failed to get container metadata directory")
-	}
-
-	parts := strings.Split(mergedDir, "/")
-	for i, part := range parts {
-		if part == "containerd" {
-			graph = "/" + filepath.Join(parts[:i]...)
-			cid = parts[i+4]
-			break
-		}
-	}
-
-	return filepath.Join(graph, "containers", cid), nil
 }


### PR DESCRIPTION
Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Remove set quota for container's metadata directory:
`$graph/containers/$id/`

fix the method to get the device mount point, just get the shortest path
of mount point, such as:
```
/dev/sdb1 /home/pouch ext4 rw,relatime,prjquota,data=ordered 0 0
/dev/sdb1 /home/pouch/overlay ext4 rw,relatime,prjquota,data=ordered 0 0
```
We will choose `/home/pouch` as the mountpoint instead of
`/home/pouch/overlay`.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
remove a test case: TestRunWithDiskQuotaForLog


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


