### PR TITLE
refactor: modify the definition of ContainerPlugin interface

### DIFF
--- a/apis/plugins/ContainerPlugin.go
+++ b/apis/plugins/ContainerPlugin.go
@@ -1,12 +1,16 @@
 package plugins
 
-import "io"
+import (
+	"io"
+
+	"github.com/alibaba/pouch/apis/types"
+)
 
 // ContainerPlugin defines places where a plugin will be triggered in container lifecycle
 type ContainerPlugin interface {
 	// PreCreate defines plugin point where receives a container create request, in this plugin point user
 	// could change the container create body passed-in by http request body
-	PreCreate(io.ReadCloser) (io.ReadCloser, error)
+	PreCreate(*types.ContainerCreateConfig) error
 
 	// PreStart returns an array of priority and args which will pass to runc, the every priority
 	// used to sort the pre start array that pass to runc, network plugin hook always has priority value 0.

--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -31,13 +31,6 @@ func (s *Server) createContainer(ctx context.Context, rw http.ResponseWriter, re
 
 	config := &types.ContainerCreateConfig{}
 	reader := req.Body
-	var ex error
-	if s.ContainerPlugin != nil {
-		logrus.Infof("invoke container pre-create hook in plugin")
-		if reader, ex = s.ContainerPlugin.PreCreate(req.Body); ex != nil {
-			return errors.Wrapf(ex, "pre-create plugin point execute failed")
-		}
-	}
 	// decode request body
 	if err := json.NewDecoder(reader).Decode(config); err != nil {
 		return httputils.NewHTTPError(err, http.StatusBadRequest)

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -268,6 +268,13 @@ func (mgr *ContainerManager) Restore(ctx context.Context) error {
 
 // Create checks passed in parameters and create a Container object whose status is set at Created.
 func (mgr *ContainerManager) Create(ctx context.Context, name string, config *types.ContainerCreateConfig) (resp *types.ContainerCreateResp, err error) {
+	if mgr.containerPlugin != nil {
+		logrus.Infof("invoke container pre-create hook in plugin")
+		if ex := mgr.containerPlugin.PreCreate(config); ex != nil {
+			return nil, errors.Wrapf(ex, "pre-create plugin point execute failed")
+		}
+	}
+
 	// cleanup allocated resources when failed
 	cleanups := []func() error{}
 	defer func() {

--- a/daemon/mgr/spec_hook.go
+++ b/daemon/mgr/spec_hook.go
@@ -6,9 +6,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 //setup hooks specified by user via plugins, if set rich mode and init-script exists set init-script


### PR DESCRIPTION
Signed-off-by: zhuangqh <zhuangqhc@gmail.com>
Signed-off-by: Wei Fu fhfuwei@163.com
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
modify the definition of ContainerPlugin interface: PreCreate

Type `*types.ContainerCreateConfig` would be more generic, while `io.ReadCloser` read only stream data.

The CRI need to support the rich-mode container so that the create_hook_plugin should be handled in container_mgr.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
redesign the interface


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


