### PR TITLE
bugfix: can't allow attach in non-tty client when container in ttyMode

### DIFF
--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
 	"github.com/kr/pty"
+	"github.com/stretchr/testify/assert"
 )
 
 // PouchStartSuite is the test suite for start CLI.
@@ -322,6 +323,18 @@ func (suite *PouchStartSuite) TestStartFromCheckpoint(c *check.C) {
 	command.PouchRun("stop", restoredContainer).Assert(c, icmd.Success)
 
 	command.PouchRun("start", "--checkpoint-dir", tmpDir, "--checkpoint", checkpoint, restoredContainer).Assert(c, icmd.Success)
+}
+
+// TestStartWithTty tests running container with -tty flag and attach stdin in a non-tty client.
+func (suite *PouchStartSuite) TestStartWithTty(c *check.C) {
+	name := "TestStartWithTty"
+	res := command.PouchRun("create", "-t", "--name", name, busyboxImage, "/bin/sh", "-c", "while true;do echo hello;done")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
+
+	attachRes := command.PouchRun("start", "-a", "-i", name)
+	errString := attachRes.Stderr()
+	assert.Equal(c, errString, "Error: the input device is not a TTY\n")
 }
 
 // TestStartMultiContainers tries to start more than one container.


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
As the title told. The current implementation have two problems:
1. setRawMode func didn't check container if in ttyMode or not.
2. if you start(with open stdin) a container from a non-tty client with container in tty mode, pouch didn't work and not return any error. this pr fix it by add a checktty func to throw error.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add an integration test TestStartInTTY.

### Ⅳ. Describe how to verify it
None.

### Ⅴ. Special notes for reviews
run cli also have same problems, will fix in another pr.

