### PR TITLE
test: mv the start cli test into own test file

### DIFF
--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -339,3 +339,13 @@ func (suite *PouchStartSuite) TestStartMultiContainers(c *check.C) {
 	res = command.PouchRun("stop", containernames[0], containernames[1])
 	res.Assert(c, icmd.Success)
 }
+
+// TestStartContainerTwice tries to start a container twice
+func (suite *PouchStartSuite) TestStartContainerTwice(c *check.C) {
+	name := "TestStartContainerTwice"
+	defer DelContainerForceMultyTime(c, name)
+
+	command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	command.PouchRun("start", name).Assert(c, icmd.Success)
+	command.PouchRun("start", name).Assert(c, icmd.Success)
+}

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -159,12 +159,3 @@ func (suite *PouchStopSuite) TestAutoStopPidValue(c *check.C) {
 	}
 	c.Assert(result[0].State.Pid, check.Equals, int64(0))
 }
-
-// TestStartContainerTwice tries to start a container twice
-func (suite *PouchStartSuite) TestStartContainerTwice(c *check.C) {
-	name := "TestStartContainerTwice"
-
-	command.PouchRun("create", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
-	command.PouchRun("start", name).Assert(c, icmd.Success)
-	command.PouchRun("start", name).Assert(c, icmd.Success)
-}


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
As the title told, the checkpoint func named TestStartContainerTwice was leaved in cli_stop_test.go file, which was a wrong place to maintain，just fix it and add clean container operation.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it
None.

### Ⅴ. Special notes for reviews
None.

