### PR TITLE
bugfix: distinct init process exit and exec process exit

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -107,7 +107,7 @@ paths:
       description: |
         Stream real-time events from the server.
         Report various object events of pouchd when something happens to them.
-        Containers report these events: create`, `destroy`, `die`, `oom`, `pause`, `rename`, `resize`, `restart`, `start`, `stop`, `top`, `unpause`, and `update`
+        Containers report these events: create`, `destroy`, `die`, `oom`, `pause`, `rename`, `resize`, `restart`, `start`, `stop`, `top`, `unpause`, `update` and `exec_die`
         Images report these events: `pull`, `untag`
         Volumes report these events: `create`, `destroy`
         Networks report these events: `create`, `connect`, `disconnect`, `destroy`

--- a/ctrd/client.go
+++ b/ctrd/client.go
@@ -231,9 +231,14 @@ func (c *Client) collectContainerdEvents() {
 				logrus.Warnf("failed to parse %s event: %#v", TaskExitEventTopic, out)
 				continue
 			}
-			action = "die"
+			if exitEvent.ID == exitEvent.ContainerID {
+				action = "die"
+			} else {
+				action = "exec_die"
+				attributes["execID"] = exitEvent.ID
+			}
 			containerID = exitEvent.ContainerID
-			attributes["exitcode"] = strconv.Itoa(int(exitEvent.ExitStatus))
+			attributes["exitCode"] = strconv.Itoa(int(exitEvent.ExitStatus))
 		case TaskOOMEventTopic:
 			oomEvent, ok := out.(*eventstypes.TaskOOM)
 			if !ok {

--- a/test/cli_events_test.go
+++ b/test/cli_events_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -50,4 +51,96 @@ func (suite *PouchEventsSuite) TestEventsWorks(c *check.C) {
 	if out := res.Combined(); !(strings.Contains(out, "create") && strings.Contains(out, "start")) {
 		c.Errorf("unexpected output %s: should contains create and start events\n", out)
 	}
+}
+
+func delEmptyStrInSlice(strSlice []string) []string {
+	if len(strSlice) == 0 {
+		return strSlice
+	}
+
+	newSlice := []string{}
+	for _, v := range strSlice {
+		if v != "" {
+			newSlice = append(newSlice, v)
+		}
+	}
+
+	return newSlice
+}
+
+// TestExecDieEventWorks tests exec_die event work.
+func (suite *PouchEventsSuite) TestExecDieEventWorks(c *check.C) {
+	name := "test-exec-die-event-works"
+
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
+
+	// only works when test case run on the same machine with pouchd
+	time.Sleep(1100 * time.Millisecond)
+	start := time.Now()
+	command.PouchRun("exec", name, "echo", "test").Assert(c, icmd.Success)
+	time.Sleep(1100 * time.Millisecond)
+	end := time.Now()
+
+	since, until := start.Format(time.RFC3339), end.Format(time.RFC3339)
+	res = command.PouchRun("events", "--since", since, "--until", until)
+	output := res.Combined()
+
+	// check output contains exec_die event
+	lines := delEmptyStrInSlice(strings.Split(output, "\n"))
+	if len(lines) != 1 {
+		c.Errorf("unexpected output %s: should just contains 1 line", output)
+	}
+
+	if err := checkContainerEvent(lines[0], "exec_die"); err != nil {
+		c.Errorf("exec_die event check error: %v", err)
+	}
+}
+
+// TestDieEventWorks tests container die event work.
+func (suite *PouchEventsSuite) TestDieEventWorks(c *check.C) {
+	name := "test-die-event-works"
+
+	res := command.PouchRun("run", "-d", "--name", name, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, name)
+	res.Assert(c, icmd.Success)
+
+	// only works when test case run on the same machine with pouchd
+	time.Sleep(1100 * time.Millisecond)
+	start := time.Now()
+	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	time.Sleep(1100 * time.Millisecond)
+	end := time.Now()
+
+	since, until := start.Format(time.RFC3339), end.Format(time.RFC3339)
+	res = command.PouchRun("events", "--since", since, "--until", until)
+	output := res.Combined()
+
+	// check events when stop a container
+	lines := delEmptyStrInSlice(strings.Split(output, "\n"))
+	if len(lines) != 2 {
+		c.Errorf("unexpected output %s: should contains 2 event line when stop a container", output)
+	}
+
+	if err := checkContainerEvent(lines[0], "die"); err != nil {
+		c.Errorf("die event check error: %v", err)
+	}
+
+	if err := checkContainerEvent(lines[1], "stop"); err != nil {
+		c.Errorf("exec_die event check error: %v", err)
+	}
+}
+
+func checkContainerEvent(eventStr, eventType string) error {
+	strSlice := strings.Split(eventStr, " ")
+	if len(strSlice) < 4 {
+		return fmt.Errorf("unexpected output %s: output line may not be container event", eventStr)
+	}
+
+	if strSlice[1] != "container" || strSlice[2] != eventType {
+		return fmt.Errorf("unexpected output %s: should be %s events", eventStr, eventType)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
Fix the process `exit` events not distinct the `exec` process exit and the container exit.

Now when a container exit we got events below:
```
2018-10-23T04:11:57.950502774-04:00 container die 33c6c770fa45fc45db7ebe64732cb623e365c67b9e7f30ea7f830410bbac0608 (exitCode=137, image=registry.hub.docker.com/library/centos:latest, name=33c6c7, org.label-schema.build-date=20180804, org.label-schema.license=GPLv2, org.label-schema.name=CentOS Base Image, org.label-schema.schema-version=1.0, org.label-schema.vendor=CentOS)
2018-10-23T04:11:58.138978923-04:00 container stop 33c6c770fa45fc45db7ebe64732cb623e365c67b9e7f30ea7f830410bbac0608 (image=registry.hub.docker.com/library/centos:latest, name=33c6c7, org.label-schema.build-date=20180804, org.label-schema.license=GPLv2, org.label-schema.name=CentOS Base Image, org.label-schema.schema-version=1.0, org.label-schema.vendor=CentOS)
```

when we execute an exec command, also got a container `die` event:
```
2018-10-23T04:14:23.727936681-04:00 container die 33c6c770fa45fc45db7ebe64732cb623e365c67b9e7f30ea7f830410bbac0608 (exitCode=137, image=registry.hub.docker.com/library/centos:latest, name=33c6c7, org.label-schema.build-date=20180804, org.label-schema.license=GPLv2, org.label-schema.name=CentOS Base Image, org.label-schema.schema-version=1.0, org.label-schema.vendor=CentOS)
```

### Ⅱ. Does this pull request fix one issue?

none
### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

add `TestExecDieEventWorks`, `TestDieEventWorks` cases

### Ⅳ. Describe how to verify it
![image](https://user-images.githubusercontent.com/10414039/47347949-f4a1d680-d6e2-11e8-8d82-37da5bf46b60.png)


### Ⅴ. Special notes for reviews

none 
