### PR TITLE
bugfix: not remove the metadata when remove container failed

### DIFF
--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -271,6 +271,7 @@ func (c *CriManager) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		if retErr != nil {
 			if err := c.ContainerMgr.Remove(ctx, id, &apitypes.ContainerRemoveOptions{Volumes: true, Force: true}); err != nil {
 				logrus.Errorf("failed to remove container when running sandbox failed %q: %v", id, err)
+				return
 			}
 			// should not remove the sandbox container metadata from sandboxStore
 			// until it was removed by pouchd.


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

We should not remove the sandbox container metadata from sandboxStore until it was removed by pouchd. If that happend, there will be uncontrolled containers, it's not make sense. CRI is responsible for the life cycle of all the containers it creates and ensure consistency of container states.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

None.
### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None.

### Ⅳ. Describe how to verify it

none

### Ⅴ. Special notes for reviews

none


