### PR TITLE
test: fix some integration tests which haven't deleted containers created before

### DIFF
--- a/test/api_container_list_test.go
+++ b/test/api_container_list_test.go
@@ -137,12 +137,12 @@ func (suite *APIContainerListSuite) TestListFilterEqual(c *check.C) {
 // TestListFilterUnEqual test label unequal filter.
 func (suite *APIContainerListSuite) TestListFilterUnEqual(c *check.C) {
 	containerA := "TestListFilterUnEqualContainerA"
-	resA := command.PouchRun("run", "-d", "-l", "label="+containerA, busyboxImage125, "top").Assert(c, icmd.Success)
+	resA := command.PouchRun("run", "-d", "--name", containerA, "-l", "label="+containerA, busyboxImage125, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, containerA)
 	containerAID := strings.TrimSpace(resA.Combined())
 
 	containerB := "TestListFilterUnEqualContainerB"
-	resB := command.PouchRun("run", "-d", "-l", "label="+containerB, busyboxImage125, "top").Assert(c, icmd.Success)
+	resB := command.PouchRun("run", "-d", "--name", containerB, "-l", "label="+containerB, busyboxImage125, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, containerB)
 	containerBID := strings.TrimSpace(resB.Combined())
 

--- a/test/api_version_parameter_test.go
+++ b/test/api_version_parameter_test.go
@@ -57,4 +57,5 @@ func (suite *APIVersionSuite) TestNoVersionParamsInURL(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	CheckRespStatus(c, resp, 201)
+	DelContainerForceMultyTime(c, cname)
 }


### PR DESCRIPTION
Signed-off-by: mathspanda mathspanda826@gmail.com
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Some of integration tests haven't correctly deleted containers created before at the end.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Just fix integration test.


### Ⅳ. Describe how to verify it
1. make integration-test
2. start pouchd
3. pouch ps -a and there is nothing

### Ⅴ. Special notes for reviews
None

