### PR TITLE
fix dead code and clean code format

### DIFF
--- a/apis/opts/mountpoint.go
+++ b/apis/opts/mountpoint.go
@@ -10,11 +10,7 @@ import (
 
 // CheckBind is used to check the volume bind information.
 func CheckBind(b string) ([]string, error) {
-	if strings.Count(b, ":") > 2 {
-		return nil, fmt.Errorf("unknown volume bind: %s", b)
-	}
-
-	arr := strings.SplitN(b, ":", 3)
+	arr := strings.Split(b, ":")
 	switch len(arr) {
 	case 1:
 		if arr[0] == "" {

--- a/apis/opts/mountpoint_test.go
+++ b/apis/opts/mountpoint_test.go
@@ -20,15 +20,60 @@ func TestCheckBind(t *testing.T) {
 	}
 
 	parseds := []parsed{
-		{bind: "volume-test:/mnt", len: 2, err: false, expectErr: fmt.Errorf("")},
-		{bind: "volume-test:/mnt:rw", len: 3, err: false, expectErr: fmt.Errorf("")},
-		{bind: "/mnt", len: 1, err: false, expectErr: fmt.Errorf("")},
-		{bind: ":/mnt:rw", len: 3, err: false, expectErr: fmt.Errorf(":/mnt:rw")},
-		{bind: "volume-test:/mnt:/mnt:rw", len: 4, err: true, expectErr: fmt.Errorf("unknown volume bind: volume-test:/mnt:/mnt:rw")},
-		{bind: "", len: 0, err: true, expectErr: fmt.Errorf("unknown volume bind: ")},
-		{bind: "volume-test::rw", len: 3, err: true, expectErr: fmt.Errorf("unknown volume bind: volume-test::rw")},
-		{bind: "volume-test", len: 1, err: true, expectErr: fmt.Errorf("invalid bind path: volume-test")},
-		{bind: ":mnt:rw", len: 3, err: true, expectErr: fmt.Errorf("invalid bind path: mnt")},
+		{
+			bind:      "volume-test:/mnt",
+			len:       2,
+			err:       false,
+			expectErr: fmt.Errorf(""),
+		},
+		{
+			bind:      "volume-test:/mnt:rw",
+			len:       3,
+			err:       false,
+			expectErr: fmt.Errorf(""),
+		},
+		{
+			bind:      "/mnt",
+			len:       1,
+			err:       false,
+			expectErr: fmt.Errorf(""),
+		},
+		{
+			bind:      ":/mnt:rw",
+			len:       3,
+			err:       false,
+			expectErr: fmt.Errorf(":/mnt:rw"),
+		},
+		{
+			bind:      "volume-test:/mnt:/mnt:rw",
+			len:       4,
+			err:       true,
+			expectErr: fmt.Errorf("unknown volume bind: volume-test:/mnt:/mnt:rw"),
+		},
+		{
+			bind:      "",
+			len:       0,
+			err:       true,
+			expectErr: fmt.Errorf("unknown volume bind: "),
+		},
+		{
+			bind:      "volume-test::rw",
+			len:       3,
+			err:       true,
+			expectErr: fmt.Errorf("unknown volume bind: volume-test::rw"),
+		},
+		{
+			bind:      "volume-test",
+			len:       1,
+			err:       true,
+			expectErr: fmt.Errorf("invalid bind path: volume-test"),
+		},
+		{
+			bind:      ":mnt:rw",
+			len:       3,
+			err:       true,
+			expectErr: fmt.Errorf("invalid bind path: mnt"),
+		},
 	}
 
 	for _, p := range parseds {
@@ -53,14 +98,76 @@ func TestParseBindMode(t *testing.T) {
 	}
 
 	parseds := []parsed{
-		{mode: "dr", expectMountPoint: &types.MountPoint{Mode: "dr", RW: true, CopyData: true}, err: false, expectErr: nil},
-		{mode: "nocopy", expectMountPoint: &types.MountPoint{Mode: "nocopy", RW: true, CopyData: false}, err: false, expectErr: nil},
-		{mode: "ro", expectMountPoint: &types.MountPoint{Mode: "ro", RW: false, CopyData: true}, err: false, expectErr: nil},
-		{mode: "", expectMountPoint: &types.MountPoint{Mode: "", RW: true, CopyData: true}, err: false, expectErr: nil},
-		{mode: "dr,rr", err: true, expectErr: fmt.Errorf("invalid bind mode: dr,rr")},
-		{mode: "unknown", err: true, expectErr: fmt.Errorf("unknown bind mode: unknown")},
-		{mode: "rw", expectMountPoint: &types.MountPoint{Mode: "rw", RW: true, CopyData: true}, err: false, expectErr: nil},
-		{mode: "z,Z", expectMountPoint: &types.MountPoint{Mode: "z,Z", RW: true, CopyData: true}, err: false, expectErr: nil},
+		{
+			mode: "dr",
+			expectMountPoint: &types.MountPoint{
+				Mode:     "dr",
+				RW:       true,
+				CopyData: true,
+			},
+			err:       false,
+			expectErr: nil,
+		},
+		{
+			mode: "nocopy",
+			expectMountPoint: &types.MountPoint{
+				Mode:     "nocopy",
+				RW:       true,
+				CopyData: false,
+			},
+			err:       false,
+			expectErr: nil,
+		},
+		{
+			mode: "ro",
+			expectMountPoint: &types.MountPoint{
+				Mode:     "ro",
+				RW:       false,
+				CopyData: true,
+			},
+			err:       false,
+			expectErr: nil,
+		},
+		{
+			mode: "",
+			expectMountPoint: &types.MountPoint{
+				Mode:     "",
+				RW:       true,
+				CopyData: true,
+			},
+			err:       false,
+			expectErr: nil,
+		},
+		{
+			mode:      "dr,rr",
+			err:       true,
+			expectErr: fmt.Errorf("invalid bind mode: dr,rr"),
+		},
+		{
+			mode:      "unknown",
+			err:       true,
+			expectErr: fmt.Errorf("unknown bind mode: unknown"),
+		},
+		{
+			mode: "rw",
+			expectMountPoint: &types.MountPoint{
+				Mode:     "rw",
+				RW:       true,
+				CopyData: true,
+			},
+			err:       false,
+			expectErr: nil,
+		},
+		{
+			mode: "z,Z",
+			expectMountPoint: &types.MountPoint{
+				Mode:     "z,Z",
+				RW:       true,
+				CopyData: true,
+			},
+			err:       false,
+			expectErr: nil,
+		},
 	}
 
 	for _, p := range parseds {
@@ -89,11 +196,41 @@ func TestParseVolumesFrom(t *testing.T) {
 	}
 
 	parseds := []parsed{
-		{volumesFrom: "123456789", expectID: "123456789", expectMode: "", err: false, expectErr: nil},
-		{volumesFrom: "123456789:nocopy", expectID: "123456789", expectMode: "nocopy", err: false, expectErr: nil},
-		{volumesFrom: "123456789:", expectID: "123456789", expectMode: "", err: false, expectErr: nil},
-		{volumesFrom: "", expectID: "", expectMode: "", err: true, expectErr: fmt.Errorf("invalid argument volumes-from")},
-		{volumesFrom: ":", expectID: "", expectMode: "", err: true, expectErr: fmt.Errorf("failed to parse container's id")},
+		{
+			volumesFrom: "123456789",
+			expectID:    "123456789",
+			expectMode:  "",
+			err:         false,
+			expectErr:   nil,
+		},
+		{
+			volumesFrom: "123456789:nocopy",
+			expectID:    "123456789",
+			expectMode:  "nocopy",
+			err:         false,
+			expectErr:   nil,
+		},
+		{
+			volumesFrom: "123456789:",
+			expectID:    "123456789",
+			expectMode:  "",
+			err:         false,
+			expectErr:   nil,
+		},
+		{
+			volumesFrom: "",
+			expectID:    "",
+			expectMode:  "",
+			err:         true,
+			expectErr:   fmt.Errorf("invalid argument volumes-from"),
+		},
+		{
+			volumesFrom: ":",
+			expectID:    "",
+			expectMode:  "",
+			err:         true,
+			expectErr:   fmt.Errorf("failed to parse container's id"),
+		},
 	}
 
 	for _, p := range parseds {


### PR DESCRIPTION
default section is never hit due to Strings.Count
limitation and strings.SplitN slice, in other words,
the part is dead code, this patch will fix it.

apis.opts.mountpoint: fix dead code
apis.opts.mountpoint_test: clean code format

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


