### PR TITLE
feature: support multiple containerd-shim

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2004,6 +2004,11 @@ definitions:
         items:
           type: "string"
         example: ["--debug", "--systemd-cgroup=false"]
+      shim:
+        description: |
+          shim name, pass to containerd to choose which shim is used for container.
+        type: "string"
+
 
   Commit:
     description: |
@@ -2421,6 +2426,10 @@ definitions:
           Runtime:
             type: "string"
             description: "Runtime to use with this container."
+          Shim:
+            description: |
+              Shim name, pass to containerd to choose which shim is used for container.
+            type: "string"
           # Applicable to Windows
           ConsoleSize:
             type: "array"

--- a/apis/types/host_config.go
+++ b/apis/types/host_config.go
@@ -135,6 +135,10 @@ type HostConfig struct {
 	// A list of string values to customize labels for MLS systems, such as SELinux.
 	SecurityOpt []string `json:"SecurityOpt"`
 
+	// Shim name, pass to containerd to choose which shim is used for container.
+	//
+	Shim string `json:"Shim,omitempty"`
+
 	// Size of `/dev/shm` in bytes. If omitted, the system uses 64MB.
 	// Minimum: 0
 	ShmSize *int64 `json:"ShmSize,omitempty"`
@@ -230,6 +234,8 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 
 		SecurityOpt []string `json:"SecurityOpt"`
 
+		Shim string `json:"Shim,omitempty"`
+
 		ShmSize *int64 `json:"ShmSize,omitempty"`
 
 		StorageOpt map[string]string `json:"StorageOpt,omitempty"`
@@ -309,6 +315,8 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 	m.Runtime = dataAO0.Runtime
 
 	m.SecurityOpt = dataAO0.SecurityOpt
+
+	m.Shim = dataAO0.Shim
 
 	m.ShmSize = dataAO0.ShmSize
 
@@ -401,6 +409,8 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 
 		SecurityOpt []string `json:"SecurityOpt"`
 
+		Shim string `json:"Shim,omitempty"`
+
 		ShmSize *int64 `json:"ShmSize,omitempty"`
 
 		StorageOpt map[string]string `json:"StorageOpt,omitempty"`
@@ -477,6 +487,8 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 	dataAO0.Runtime = m.Runtime
 
 	dataAO0.SecurityOpt = m.SecurityOpt
+
+	dataAO0.Shim = m.Shim
 
 	dataAO0.ShmSize = m.ShmSize
 

--- a/apis/types/runtime.go
+++ b/apis/types/runtime.go
@@ -30,6 +30,10 @@ type Runtime struct {
 	// List of command-line arguments to pass to the runtime when invoked.
 	//
 	RuntimeArgs []string `json:"runtimeArgs"`
+
+	// shim name, pass to containerd to choose which shim is used for container.
+	//
+	Shim string `json:"shim,omitempty"`
 }
 
 // Validate validates this runtime

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -76,6 +76,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.BoolVar(&c.privileged, "privileged", false, "Give extended privileges to the container")
 
 	flagSet.StringVar(&c.restartPolicy, "restart", "", "Restart policy to apply when container exits")
+	flagSet.StringVar(&c.shim, "shim", "io.containerd.runtime.v1.linux", "containerd shim used for this container")
 	flagSet.StringVar(&c.runtime, "runtime", "", "OCI runtime to use for this container")
 
 	flagSet.StringSliceVar(&c.securityOpt, "security-opt", nil, "Security Options")

--- a/cli/container.go
+++ b/cli/container.go
@@ -16,6 +16,7 @@ type container struct {
 	tty                 bool
 	volume              []string
 	volumesFrom         []string
+	shim                string
 	runtime             string
 	env                 []string
 	entrypoint          string
@@ -206,6 +207,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 			Binds:       c.volume,
 			VolumesFrom: c.volumesFrom,
 			Runtime:     c.runtime,
+			Shim:        c.shim,
 			Resources: types.Resources{
 				// cpu
 				CPUShares:  c.cpushare,

--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -504,7 +503,7 @@ func (c *Client) createContainer(ctx context.Context, ref, id, checkpointDir str
 	// create container
 	options := []containerd.NewContainerOpts{
 		containerd.WithContainerLabels(container.Labels),
-		containerd.WithRuntime(fmt.Sprintf("io.containerd.runtime.v1.%s", runtime.GOOS), &runctypes.RuncOptions{
+		containerd.WithRuntime(container.Shim, &runctypes.RuncOptions{
 			Runtime:     container.Runtime,
 			RuntimeRoot: runtimeRoot,
 		}),

--- a/ctrd/container_types.go
+++ b/ctrd/container_types.go
@@ -13,11 +13,15 @@ import (
 type Container struct {
 	ID         string
 	Image      string
-	Runtime    string
 	Labels     map[string]string
 	IO         *containerio.IO
 	Spec       *specs.Spec
 	SnapshotID string
+
+	// Shim is shim name, specify shim used for container
+	Shim string
+	// Runtime is runtime name, specify runtime used for container
+	Runtime string
 
 	// BaseFS is rootfs used by containerd container
 	BaseFS string

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -688,11 +688,17 @@ func (mgr *ContainerManager) createContainerdContainer(ctx context.Context, c *C
 		return err
 	}
 
+	// shim always need for containerd.
+	if c.HostConfig.Shim == "" {
+		c.HostConfig.Shim = DefaultShim
+	}
+
 	c.Lock()
 	ctrdContainer := &ctrd.Container{
 		ID:             c.ID,
 		Image:          c.Config.Image,
 		Labels:         c.Config.Labels,
+		Shim:           c.HostConfig.Shim,
 		Runtime:        runtime,
 		Spec:           sw.s,
 		IO:             mgr.IOs.Get(c.ID),

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -33,6 +33,9 @@ var (
 
 	// ProfileUnconfined means run a container without the default seccomp profile.
 	ProfileUnconfined = "unconfined"
+
+	// DefaultShim is default shim used for container.
+	DefaultShim = "io.containerd.runtime.v1.linux"
 )
 
 var (


### PR DESCRIPTION
different runtime can have a specified containerd-shim, especially for
vm runtime like kata/runv.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

### what the pr want to do

First we see how pouch run a container, `pouch` -> `containerd` -> `containerd-shim` -> `runtime`. The PR specify the shim can be choosed for the runtime, this is useful for vm runtime like kata/runv, since vm containers have many different with runc container cause they running in a vm machine. 

containerd 1.2 have support a shim v2 API(https://github.com/containerd/containerd/pull/2434), this allowed a runtime to specify itself shim, they can do more custom then.

### what the PR status

The PR is compele finished in function, we pass a shim interface to containerd to choose the shim, this is supported by containerd 1.0.3, so it can be merged now, no need to wait for containerd 1.2. And all process in create container in pouch is keeping same.

### TODO list

1.  kata implement about containerd-shim-v2 is waiting for merged (https://github.com/kata-containers/runtime/pull/572), I have testd it with containerd 1.2, it works good. Kata test may not easy to add in pouch , but we can add some v2 test after we support containerd 1.2. 


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


