### PR TITLE
bugfix: judge enablement of libnetwork resolver by network mode

### DIFF
--- a/daemon/mgr/network_utils.go
+++ b/daemon/mgr/network_utils.go
@@ -30,9 +30,9 @@ func IsBridge(mode string) bool {
 	return mode == "bridge"
 }
 
-// IsUserDefined is used to check if network mode is bridge mode.
+// IsUserDefined is used to check if network mode is user-created.
 func IsUserDefined(mode string) bool {
-	return !isContainer(mode) && !isHost(mode) && isNone(mode)
+	return !IsBridge(mode) && !IsContainer(mode) && !IsHost(mode) && !IsNone(mode)
 }
 
 // IsDefault indicates whether container uses the default network stack.

--- a/test/cli_run_dns_test.go
+++ b/test/cli_run_dns_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// PouchRunDNSSuite is the test suite for run CLI.
+type PouchRunDNSSuite struct{}
+
+func init() {
+	check.Suite(&PouchRunDNSSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each test suite.
+func (suite *PouchRunDNSSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	environment.PruneAllContainers(apiClient)
+
+	PullImage(c, busyboxImage)
+}
+
+// TearDownTest does cleanup work in the end of each test.
+func (suite *PouchRunDNSSuite) TearDownTest(c *check.C) {
+}
+
+// TestRunWithUserDefinedNetwork tests enabling libnetwork resolver if user-defined network.
+func (suite *PouchRunSuite) TestRunWithUserDefinedNetwork(c *check.C) {
+	cname := "TestRunWithUserDefinedNetwork"
+
+	// Create a user-defined network
+	command.PouchRun("network", "create", "--name", cname,
+		"-d", "bridge",
+		"--gateway", GateWay,
+		"--subnet", Subnet).Assert(c, icmd.Success)
+	defer command.PouchRun("network", "remove", cname)
+
+	// Assign the user-defined network to a container
+	res := command.PouchRun("run", "--name", cname,
+		"--net", cname, busyboxImage,
+		"cat", "/etc/resolv.conf")
+	res.Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, cname)
+
+	c.Assert(strings.Contains(res.Stdout(), "nameserver 127.0.0.11"), check.Equals, true)
+}
+
+// TestRunWithBridgeNetwork tests disabling libnetwork resolver if not user-defined network.
+func (suite *PouchRunSuite) TestRunWithBridgeNetwork(c *check.C) {
+	cname := "TestRunWithBridgeNetwork"
+
+	// Use bridge network if not set --net.
+	res := command.PouchRun("run", "--name", cname, busyboxImage,
+		"cat", "/etc/resolv.conf")
+	res.Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, cname)
+
+	hostRes := icmd.RunCommand("cat", "/etc/resolv.conf")
+	hostRes.Assert(c, icmd.Success)
+
+	c.Assert(res.Stdout(), check.Equals, hostRes.Stdout())
+}


### PR DESCRIPTION
Signed-off-by: mathspanda <mathspanda826@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
The PR is to judge whether enabling embedded dns server by network mode. 
If network mode is user-defined, container uses embedded dns server.
If not, container uses resolv.conf file on host directly.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Issue #2362 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None


### Ⅳ. Describe how to verify it
```
# content of resolv.conf file is the same with one on host
pouch run busybox cat /etc/resolv.conf
```
```
# content of resolv.conf file contains "nameserver 127.0.0.11"
pouch run --net ns1 busybox cat /etc/resolv.conf
```

### Ⅴ. Special notes for reviews
None
