### PR TITLE
test: Add the unit-test called `APIContainerStopSuite.TestInvalidParam`

### DIFF
--- a/test/api_container_stop_test.go
+++ b/test/api_container_stop_test.go
@@ -62,8 +62,19 @@ func (suite *APIContainerStopSuite) TestStopWait(c *check.C) {
 
 // TestInvalidParam tests using invalid parameter return.
 func (suite *APIContainerStopSuite) TestInvalidParam(c *check.C) {
-	// TODO: missing case
-	helpwantedForMissingCase(c, "container api stop bad request case")
+	cname := "TestInvalidParam"
+
+	CreateBusyboxContainerOk(c, cname)
+	defer DelContainerForceMultyTime(c, cname)
+	StartContainerOk(c, cname)
+
+	q := url.Values{}
+	q.Add("t", "invalidParam")
+	query := request.WithQuery(q)
+
+	resp, err := request.Post("/containers/"+cname+"/stop", query)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 400)
 }
 
 // TestStopPausedContainer tests stop a paused container.


### PR DESCRIPTION
Signed-off-by: fengzixu <hnustphoenix@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Add the unit-test called `APIContainerStopSuite.TestInvalidParam`, It can test that whether the function of stopping the container is run normally when the param is invalid

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

#1603 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

That is the unit-test.

### Ⅳ. Describe how to verify it

I run the command as below:

```
/home/xr/workspace/go-project/src/github.com/alibaba/pouch/test# go test -v -check.f APIContainerStopSuite.TestInvalidParam
```

The result of that commend:

```
=== RUN   Test
OK: 1 passed
--- PASS: Test (3.24s)
PASS
ok
```


### Ⅴ. Special notes for reviews
