### PR TITLE
test: make stopInWrong test complete

### DIFF
--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -91,9 +91,7 @@ func (suite *PouchStopSuite) TestStopInWrongWay(c *check.C) {
 	}{
 		{name: "unknown container name", args: "unknown"},
 		{name: "unknown flag", args: "-a"},
-
-		// TODO: should add the following cases if ready
-		// {name: "missing container name", args: ""},
+		{name: "Error: requires at least 1 arg(s), only received 0", args: ""},
 	} {
 		res := command.PouchRun("stop", tc.args)
 		c.Assert(res.Stderr(), check.NotNil, check.Commentf(tc.name))


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
As the title desc.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it
`go test -gocheck.f PouchStopSuite`

### Ⅴ. Special notes for reviews
Since We have limited args in stop cli with `cobra.MinimumNArgs(1)`, no need to leave a TODO.

