### PR TITLE
feature: add no-trunc flag for pouch images

### DIFF
--- a/cli/image_list.go
+++ b/cli/image_list.go
@@ -35,8 +35,9 @@ type ImagesCommand struct {
 	baseCommand
 
 	// flags for image command
-	flagQuiet  bool
-	flagDigest bool
+	flagQuiet   bool
+	flagDigest  bool
+	flagNoTrunc bool
 }
 
 // Init initialize images command.
@@ -61,6 +62,7 @@ func (i *ImagesCommand) addFlags() {
 	flagSet := i.cmd.Flags()
 	flagSet.BoolVarP(&i.flagQuiet, "quiet", "q", false, "Only show image numeric ID")
 	flagSet.BoolVar(&i.flagDigest, "digest", false, "Show images with digest")
+	flagSet.BoolVar(&i.flagNoTrunc, "no-trunc", false, "Do not truncate output")
 }
 
 // runImages is the entry of images container command.
@@ -76,7 +78,11 @@ func (i *ImagesCommand) runImages(args []string) error {
 
 	if i.flagQuiet {
 		for _, image := range imageList {
-			fmt.Println(utils.TruncateID(image.ID))
+			if i.flagNoTrunc {
+				fmt.Println(image.ID)
+			} else {
+				fmt.Println(utils.TruncateID(image.ID))
+			}
 		}
 		return nil
 	}
@@ -90,7 +96,7 @@ func (i *ImagesCommand) runImages(args []string) error {
 
 	dimgs := make([]displayImage, 0, len(imageList))
 	for _, img := range imageList {
-		dimgs = append(dimgs, imageInfoToDisplayImages(img)...)
+		dimgs = append(dimgs, imageInfoToDisplayImages(img, i.flagNoTrunc)...)
 	}
 
 	for _, dimg := range dimgs {
@@ -105,7 +111,7 @@ func (i *ImagesCommand) runImages(args []string) error {
 	return nil
 }
 
-func imageInfoToDisplayImages(img types.ImageInfo) []displayImage {
+func imageInfoToDisplayImages(img types.ImageInfo, noTrunc bool) []displayImage {
 	dimgs := make([]displayImage, 0)
 
 	nameTags := make(map[string][]string)
@@ -137,10 +143,15 @@ func imageInfoToDisplayImages(img types.ImageInfo) []displayImage {
 		}
 	}
 
+	imageDisplayID := utils.TruncateID(img.ID)
+	if noTrunc {
+		imageDisplayID = img.ID
+	}
+
 	for name, tags := range nameTags {
 		for _, tag := range tags {
 			dimg := displayImage{
-				id:   utils.TruncateID(img.ID),
+				id:   imageDisplayID,
 				name: name + ":" + tag,
 				size: imageSize(img.Size),
 			}
@@ -158,7 +169,7 @@ func imageInfoToDisplayImages(img types.ImageInfo) []displayImage {
 	if len(dimgs) == 0 {
 		for name, dig := range digestIndexByName {
 			dimgs = append(dimgs, displayImage{
-				id:     utils.TruncateID(img.ID),
+				id:     imageDisplayID,
 				name:   name + "@" + dig.String(),
 				digest: dig.String(),
 				size:   imageSize(img.Size),
@@ -168,7 +179,7 @@ func imageInfoToDisplayImages(img types.ImageInfo) []displayImage {
 		// if there is no repo digests
 		if len(dimgs) == 0 {
 			dimgs = append(dimgs, displayImage{
-				id:     utils.TruncateID(img.ID),
+				id:     imageDisplayID,
 				name:   "<none>",
 				digest: "<none>",
 				size:   imageSize(img.Size),
@@ -183,5 +194,15 @@ func imagesExample() string {
 	return `$ pouch images
 IMAGE ID             IMAGE NAME                                               SIZE
 bbc3a0323522         docker.io/library/busybox:latest                         703.14 KB
-b81f317384d7         docker.io/library/nginx:latest                           42.39 MB`
+b81f317384d7         docker.io/library/nginx:latest                           42.39 MB
+
+$ pouch images --digest
+IMAGE ID       IMAGE NAME                                           DIGEST                                                                    SIZE
+2cb0d9787c4d   registry.hub.docker.com/library/hello-world:latest   sha256:4b8ff392a12ed9ea17784bd3c9a8b1fa3299cac44aca35a85c90c5e3c7afacdc   6.30 KB
+4ab4c602aa5e   registry.hub.docker.com/library/hello-world:linux    sha256:d5c7d767f5ba807f9b363aa4db87d75ab030404a670880e16aedff16f605484b   5.25 KB
+
+$ pouch images --no-trunc
+IMAGE ID                                                                  IMAGE NAME                                           SIZE
+sha256:2cb0d9787c4dd17ef9eb03e512923bc4db10add190d3f84af63b744e353a9b34   registry.hub.docker.com/library/hello-world:latest   6.30 KB
+sha256:4ab4c602aa5eed5528a6620ff18a1dc4faef0e1ab3a5eddeddb410714478c67f   registry.hub.docker.com/library/hello-world:linux    5.25 KB`
 }

--- a/test/cli_images_test.go
+++ b/test/cli_images_test.go
@@ -72,6 +72,13 @@ func (suite *PouchImagesSuite) TestImagesWorks(c *check.C) {
 		items := imagesListToKV(res.Combined())[busyboxImage]
 		c.Assert(items[2], check.Equals, strings.TrimPrefix(image.RepoDigests[0], environment.BusyboxRepo+"@"))
 	}
+
+	// with --no-trunc
+	{
+		res := command.PouchRun("images", "--no-trunc").Assert(c, icmd.Success)
+		items := imagesListToKV(res.Combined())[busyboxImage]
+		c.Assert(items[0], check.Equals, image.ID)
+	}
 }
 
 // imagesListToKV parse "pouch images" into key-value mapping.


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
As the title desc， add a --no-trunc flag for pouch images cmd to show to whole image Id, also and cli samples to end-users.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2371 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add test.


### Ⅳ. Describe how to verify it
`go test -gocheck.f PouchImagesSuite`

### Ⅴ. Special notes for reviews
None.

