### PR TITLE
feature: support dns related flags when creating container through pouch cli

### DIFF
--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -32,6 +32,11 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	// device related options
 	flagSet.StringSliceVarP(&c.devices, "device", "", nil, "Add a host device to the container")
 
+	// dns
+	flagSet.StringArrayVar(&c.dns, "dns", nil, "Set DNS servers")
+	flagSet.StringSliceVar(&c.dnsOptions, "dns-option", nil, "Set DNS options")
+	flagSet.StringArrayVar(&c.dnsSearch, "dns-search", nil, "Set DNS search domains")
+
 	flagSet.BoolVar(&c.enableLxcfs, "enableLxcfs", false, "Enable lxcfs for the container, only effective when enable-lxcfs switched on in Pouchd")
 	flagSet.StringVar(&c.entrypoint, "entrypoint", "", "Overwrite the default ENTRYPOINT of the image")
 	flagSet.StringArrayVarP(&c.env, "env", "e", nil, "Set environment variables for container")

--- a/cli/container.go
+++ b/cli/container.go
@@ -7,7 +7,7 @@ import (
 	"github.com/alibaba/pouch/apis/opts/config"
 	"github.com/alibaba/pouch/apis/types"
 
-	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/strfmt"
 )
 
 type container struct {
@@ -48,6 +48,10 @@ type container struct {
 	memoryForceEmptyCtl int64
 	scheLatSwitch       int64
 	oomKillDisable      bool
+
+	dns        []string
+	dnsOptions []string
+	dnsSearch  []string
 
 	devices        []string
 	enableLxcfs    bool
@@ -233,6 +237,9 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 				Ulimits:       c.ulimit.Value(),
 				PidsLimit:     c.pidsLimit,
 			},
+			DNS:           c.dns,
+			DNSOptions:    c.dnsOptions,
+			DNSSearch:     c.dnsSearch,
 			EnableLxcfs:   c.enableLxcfs,
 			Privileged:    c.privileged,
 			RestartPolicy: restartPolicy,


### PR DESCRIPTION

Signed-off-by: mathspanda <mathspanda826@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Support dns related flags for pouch cli: dns, dns-option and dns-search.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fix #2356 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None

### Ⅳ. Describe how to verify it
```
$ pouch run --dns 1.2.3.4 --dns-search example.com --dns-option timeout:3 busybox cat /etc/resolv.conf
search example.com
nameserver 1.2.3.4
options timeout:3
```

### Ⅴ. Special notes for reviews
None

