### PR TITLE
test: refactor the test code use inspect func

### DIFF
--- a/test/cli_rich_container_test.go
+++ b/test/cli_rich_container_test.go
@@ -118,13 +118,13 @@ func (suite *PouchRichContainerSuite) TestRichContainerDumbInitWorks(c *check.C)
 	defer DelContainerForceMultyTime(c, funcname)
 	res.Assert(c, icmd.Success)
 
-	output := command.PouchRun("inspect", funcname).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	c.Assert(result[0].Config.Rich, check.Equals, true)
-	c.Assert(result[0].Config.RichMode, check.Equals, "dumb-init")
+	rich, err := inspectFilter(funcname, ".Config.Rich")
+	c.Assert(err, check.IsNil)
+	c.Assert(rich, check.Equals, "true")
+
+	richMode, err := inspectFilter(funcname, ".Config.RichMode")
+	c.Assert(err, check.IsNil)
+	c.Assert(richMode, check.Equals, "dumb-init")
 
 	c.Assert(checkPidofProcessIsOne(funcname, "dumb-init"), check.Equals, true)
 
@@ -219,13 +219,13 @@ func (suite *PouchRichContainerSuite) TestRichContainerSystemdWorks(c *check.C) 
 	defer DelContainerForceMultyTime(c, funcname)
 	res.Assert(c, icmd.Success)
 
-	output := command.PouchRun("inspect", funcname).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	c.Assert(result[0].Config.Rich, check.Equals, true)
-	c.Assert(result[0].Config.RichMode, check.Equals, "systemd")
+	rich, err := inspectFilter(funcname, ".Config.Rich")
+	c.Assert(err, check.IsNil)
+	c.Assert(rich, check.Equals, "true")
+
+	richMode, err := inspectFilter(funcname, ".Config.RichMode")
+	c.Assert(err, check.IsNil)
+	c.Assert(richMode, check.Equals, "systemd")
 
 	c.Assert(checkPidofProcessIsOne(funcname, "/usr/lib/systemd/systemd"), check.Equals, true)
 	c.Assert(checkPPid(funcname, "sleep", "1"), check.Equals, true)

--- a/test/cli_run_cgroup_test.go
+++ b/test/cli_run_cgroup_test.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"encoding/json"
 	"os"
 	"os/exec"
 	"strings"
 
-	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
 
@@ -53,12 +51,8 @@ func testRunWithCgroupParent(c *check.C, cgroupParent, name string) {
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
-	output := command.PouchRun("inspect", name).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	containerID := result[0].ID
+	containerID, err := inspectFilter(name, ".ID")
+	c.Assert(err, check.IsNil)
 
 	// this code slice may not robust, but for this test case is enough.
 	if strings.HasPrefix(cgroupParent, "/") {

--- a/test/cli_run_working_dir_test.go
+++ b/test/cli_run_working_dir_test.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"strings"
 
-	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
 
@@ -43,14 +41,9 @@ func (suite *PouchRunWorkingDirSuite) TestRunWithExistWorkingDir(c *check.C) {
 	res.Assert(c, icmd.Success)
 
 	// test if the value is in inspect result
-	res = command.PouchRun("inspect", cname)
-	res.Assert(c, icmd.Success)
-
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(res.Stdout()), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	c.Assert(result[0].Config.WorkingDir, check.Equals, "/root")
+	workingDir, err := inspectFilter(cname, ".Config.WorkingDir")
+	c.Assert(err, check.IsNil)
+	c.Assert(workingDir, check.Equals, "/root")
 }
 
 // TestRunWithNotExistWorkingDir is to verify the valid running container
@@ -64,14 +57,9 @@ func (suite *PouchRunWorkingDirSuite) TestRunWithNotExistWorkingDir(c *check.C) 
 	res.Assert(c, icmd.Success)
 
 	// test if the value is in inspect result
-	res = command.PouchRun("inspect", cname)
-	res.Assert(c, icmd.Success)
-
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(res.Stdout()), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	c.Assert(result[0].Config.WorkingDir, check.Equals, "/tmp/notexist/dir")
+	workingDir, err := inspectFilter(cname, ".Config.WorkingDir")
+	c.Assert(err, check.IsNil)
+	c.Assert(workingDir, check.Equals, "/tmp/notexist/dir")
 }
 
 // TestRunWithWorkingDir is to verify the valid running container

--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"bufio"
-	"encoding/json"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
 
-	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
 
@@ -270,12 +268,9 @@ func (suite *PouchStartSuite) TestStartWithExitCode(c *check.C) {
 	ret.Assert(c, icmd.Expected{ExitCode: 101})
 
 	// test container ExitCode == 101
-	output := command.PouchRun("inspect", name).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	c.Assert(result[0].State.ExitCode, check.Equals, int64(101))
+	exitCode, err := inspectFilter(name, ".State.ExitCode")
+	c.Assert(err, check.IsNil)
+	c.Assert(exitCode, check.Equals, "101")
 }
 
 // TestStartWithUlimit starts a container with --ulimit.

--- a/test/cli_update_test.go
+++ b/test/cli_update_test.go
@@ -43,12 +43,8 @@ func (suite *PouchUpdateSuite) TestUpdateCpu(c *check.C) {
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
-	output := command.PouchRun("inspect", name).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	containerID := result[0].ID
+	containerID, err := inspectFilter(name, ".ID")
+	c.Assert(err, check.IsNil)
 
 	file := "/sys/fs/cgroup/cpu/default/" + containerID + "/cpu.shares"
 	if _, err := os.Stat(file); err != nil {
@@ -66,13 +62,9 @@ func (suite *PouchUpdateSuite) TestUpdateCpu(c *check.C) {
 		c.Fatalf("unexpected output %s expected %s\n", string(out), "40")
 	}
 
-	inspectInfo := command.PouchRun("inspect", name).Stdout()
-	metaJSON := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(inspectInfo), &metaJSON); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-
-	c.Assert(metaJSON[0].HostConfig.CPUShares, check.Equals, int64(40))
+	cpuShares, err := inspectFilter(name, ".HostConfig.CPUShares")
+	c.Assert(err, check.IsNil)
+	c.Assert(cpuShares, check.Equals, "40")
 }
 
 // TestUpdateCpuPeriod is to verify the correctness of updating container cpu-period.
@@ -83,12 +75,8 @@ func (suite *PouchUpdateSuite) TestUpdateCpuPeriod(c *check.C) {
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
-	output := command.PouchRun("inspect", name).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	containerID := result[0].ID
+	containerID, err := inspectFilter(name, ".ID")
+	c.Assert(err, check.IsNil)
 
 	file := "/sys/fs/cgroup/cpu/default/" + containerID + "/cpu.cfs_period_us"
 	if _, err := os.Stat(file); err != nil {
@@ -106,13 +94,9 @@ func (suite *PouchUpdateSuite) TestUpdateCpuPeriod(c *check.C) {
 		c.Fatalf("unexpected output %s expected %s\n", string(out), "2000")
 	}
 
-	inspectInfo := command.PouchRun("inspect", name).Stdout()
-	metaJSON := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(inspectInfo), &metaJSON); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-
-	c.Assert(metaJSON[0].HostConfig.CPUPeriod, check.Equals, int64(2000))
+	cpuPeriod, err := inspectFilter(name, ".HostConfig.CPUPeriod")
+	c.Assert(err, check.IsNil)
+	c.Assert(cpuPeriod, check.Equals, "2000")
 }
 
 // TestUpdateCpuMemoryFail is to verify the invalid value of updating container cpu and memory related flags will fail.
@@ -143,12 +127,8 @@ func (suite *PouchUpdateSuite) TestUpdateRunningContainer(c *check.C) {
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
-	output := command.PouchRun("inspect", name).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	containerID := result[0].ID
+	containerID, err := inspectFilter(name, ".ID")
+	c.Assert(err, check.IsNil)
 
 	file := "/sys/fs/cgroup/memory/default/" + containerID + "/memory.limit_in_bytes"
 	if _, err := os.Stat(file); err != nil {
@@ -166,13 +146,9 @@ func (suite *PouchUpdateSuite) TestUpdateRunningContainer(c *check.C) {
 		c.Fatalf("unexpected output %s expected %s\n", string(out), "524288000")
 	}
 
-	inspectInfo := command.PouchRun("inspect", name).Stdout()
-	metaJSON := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(inspectInfo), &metaJSON); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-
-	c.Assert(metaJSON[0].HostConfig.Memory, check.Equals, int64(524288000))
+	memory, err := inspectFilter(name, ".HostConfig.Memory")
+	c.Assert(err, check.IsNil)
+	c.Assert(memory, check.Equals, "524288000")
 }
 
 // TestUpdateStoppedContainer is to verify the correctness of updating a stopped container.
@@ -183,12 +159,8 @@ func (suite *PouchUpdateSuite) TestUpdateStoppedContainer(c *check.C) {
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
-	output := command.PouchRun("inspect", name).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	containerID := result[0].ID
+	containerID, err := inspectFilter(name, ".ID")
+	c.Assert(err, check.IsNil)
 
 	command.PouchRun("update", "-m", "500M", name).Assert(c, icmd.Success)
 
@@ -208,13 +180,9 @@ func (suite *PouchUpdateSuite) TestUpdateStoppedContainer(c *check.C) {
 		c.Fatalf("unexpected output %s expected %s\n", string(out), "524288000")
 	}
 
-	inspectInfo := command.PouchRun("inspect", name).Stdout()
-	metaJSON := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(inspectInfo), &metaJSON); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-
-	c.Assert(metaJSON[0].HostConfig.Memory, check.Equals, int64(524288000))
+	memory, err := inspectFilter(name, ".HostConfig.Memory")
+	c.Assert(err, check.IsNil)
+	c.Assert(memory, check.Equals, "524288000")
 }
 
 // TestUpdateContainerCPUQuota is to verify the correctness of updating cpu-quota of container.
@@ -228,12 +196,8 @@ func (suite *PouchUpdateSuite) TestUpdateContainerCPUQuota(c *check.C) {
 	// ensure update cpu-quota is ok
 	command.PouchRun("update", "--cpu-quota", "1100", name).Assert(c, icmd.Success)
 
-	output := command.PouchRun("inspect", name).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	containerID := result[0].ID
+	containerID, err := inspectFilter(name, ".ID")
+	c.Assert(err, check.IsNil)
 
 	file := "/sys/fs/cgroup/cpu/default/" + containerID + "/cpu.cfs_quota_us"
 	if _, err := os.Stat(file); err != nil {
@@ -249,13 +213,9 @@ func (suite *PouchUpdateSuite) TestUpdateContainerCPUQuota(c *check.C) {
 		c.Fatalf("unexpected output %s expected %s\n", string(out), "524288000")
 	}
 
-	inspectInfo := command.PouchRun("inspect", name).Stdout()
-	metaJSON := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(inspectInfo), &metaJSON); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-
-	c.Assert(metaJSON[0].HostConfig.CPUQuota, check.Equals, int64(1100))
+	cpuQuota, err := inspectFilter(name, ".HostConfig.CPUQuota")
+	c.Assert(err, check.IsNil)
+	c.Assert(cpuQuota, check.Equals, "1100")
 }
 
 // TestUpdateContainerWithoutFlag is to verify the correctness of updating a container without any flag.

--- a/test/cli_upgrade_test.go
+++ b/test/cli_upgrade_test.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"strings"
 
-	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
 
@@ -48,12 +46,9 @@ func (suite *PouchUpgradeSuite) TestPouchUpgrade(c *check.C) {
 	}
 
 	// check if the new container is running after upgade a running container
-	output := command.PouchRun("inspect", name).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	c.Assert(result[0].State.Running, check.Equals, true)
+	state, err := inspectFilter(name, ".State.Running")
+	c.Assert(err, check.IsNil)
+	c.Assert(state, check.Equals, "true")
 
 	// double check if container is running by executing a exec command
 	out := command.PouchRun("exec", name, "echo", "test").Stdout()
@@ -96,12 +91,9 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeStoppedContainer(c *check.C) {
 	}
 
 	// check if the new container is running after upgade a running container
-	output := command.PouchRun("inspect", name).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	c.Assert(result[0].State.Status, check.Equals, types.StatusStopped)
+	status, err := inspectFilter(name, ".State.Status")
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, "stopped")
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 }
@@ -138,12 +130,9 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeCheckVolume(c *check.C) {
 	}
 
 	// check if the new container is running after upgade a running container
-	output := command.PouchRun("inspect", name).Stdout()
-	result := []types.ContainerJSON{}
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		c.Errorf("failed to decode inspect output: %v", err)
-	}
-	c.Assert(result[0].State.Running, check.Equals, true)
+	state, err := inspectFilter(name, ".State.Running")
+	c.Assert(err, check.IsNil)
+	c.Assert(state, check.Equals, "true")
 
 	// double check if container is running by executing a exec command
 	out := command.PouchRun("exec", name, "cat", "/data/test").Stdout()


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
1. Use inspect func added in pr #2372 to refactor part of cli test code
2. adjust the position of some testcase which locate in wrong place or bad name.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it
wait for the CI.

### Ⅴ. Special notes for reviews
Only refactor the part of code which use` json.Unmarshal` Since the inspectFilter func only return string type. When the test code need a struct type, keep it, using ` json.Unmarshal`.

