### PR TITLE
bugfix: fix pouch inspect does not return Ports in NetworkSettings

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -396,6 +396,7 @@ func (mgr *ContainerManager) Create(ctx context.Context, name string, config *ty
 		container.NetworkSettings.Networks = make(map[string]*types.EndpointSettings)
 		container.NetworkSettings.Networks[config.HostConfig.NetworkMode] = new(types.EndpointSettings)
 	}
+	container.NetworkSettings.Ports = config.HostConfig.PortBindings
 
 	if err := parseSecurityOpts(container, config.HostConfig.SecurityOpt); err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
`Pouch inspect` does not return `Ports` in `NetworkSettings`.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2386

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
NONE

### Ⅳ. Describe how to verify it
```
pouch run -dt -p 8080:80 nginx
pouch inspect <container_id>
```

### Ⅴ. Special notes for reviews
This pr will add `Ports` in `NetworkSettings` when creates new container, it does not work on original containers.


