### PR TITLE
feature: add Close function for boltdb backend

### DIFF
--- a/pkg/meta/backend.go
+++ b/pkg/meta/backend.go
@@ -24,6 +24,10 @@ type Backend interface {
 
 	// Path returns the path with the specified key.
 	Path(key string) string
+
+	// Close releases all resources used by the store
+	// It does not make any changes to store.
+	Close() error
 }
 
 // Register registers a backend to be daemon's store.

--- a/pkg/meta/boltdb.go
+++ b/pkg/meta/boltdb.go
@@ -160,3 +160,9 @@ func (b *bolt) List(bucket string) ([][]byte, error) {
 
 	return values, err
 }
+
+// Close releases all database resources.
+// All transactions must be closed before closing the database.
+func (b *bolt) Close() error {
+	return b.db.Close()
+}

--- a/pkg/meta/local.go
+++ b/pkg/meta/local.go
@@ -177,6 +177,11 @@ func (s *localStore) Keys(fileName string) ([]string, error) {
 	return keys, nil
 }
 
+// Close do nothing in local store
+func (s *localStore) Close() error {
+	return nil
+}
+
 func mkdirIfNotExist(dir string) error {
 	if _, err := os.Stat(dir); err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/meta/store.go
+++ b/pkg/meta/store.go
@@ -270,3 +270,8 @@ func (s *Store) KeysWithPrefix(prefix string) ([]string, error) {
 func (s *Store) Path(key string) string {
 	return s.backend.Path(key)
 }
+
+// Shutdown releases all resources used by the backend
+func (s *Store) Shutdown() error {
+	return s.backend.Close()
+}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

When testing [d2p-migrator](https://github.com/pouchcontainer/d2p-migrator), I found I need close the `boltdb` store after used, so that the `pouchd` can take charge of the  volume store.

So I add a `Shutdown` function for the `Store`

### Ⅱ. Does this pull request fix one issue?
none

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add `TestBoltdbClose` case


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

