### PR TITLE
feature: add rules for type validation

### DIFF
--- a/apis/opts/labels.go
+++ b/apis/opts/labels.go
@@ -26,9 +26,3 @@ func parseLabel(label string) ([]string, error) {
 	}
 	return fields, nil
 }
-
-// ValidateLabels verifies the correct of labels
-func ValidateLabels(map[string]string) error {
-	// TODO
-	return nil
-}

--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -330,6 +330,10 @@ func (s *Server) updateContainer(ctx context.Context, rw http.ResponseWriter, re
 	if err := json.NewDecoder(reader).Decode(config); err != nil {
 		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
+	// validate request body
+	if err := config.Validate(strfmt.NewFormats()); err != nil {
+		return httputils.NewHTTPError(err, http.StatusBadRequest)
+	}
 
 	name := mux.Vars(req)["name"]
 

--- a/apis/server/system_bridge.go
+++ b/apis/server/system_bridge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alibaba/pouch/pkg/utils"
 
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -41,18 +42,28 @@ func (s *Server) version(ctx context.Context, rw http.ResponseWriter, req *http.
 
 func (s *Server) updateDaemon(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
 	cfg := &types.DaemonUpdateConfig{}
+
+	// decode request body
 	if err := json.NewDecoder(req.Body).Decode(cfg); err != nil {
 		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
-
-	// TODO: validate cfg in details
+	// validate request body
+	if err := cfg.Validate(strfmt.NewFormats()); err != nil {
+		return httputils.NewHTTPError(err, http.StatusBadRequest)
+	}
 
 	return s.SystemMgr.UpdateDaemon(cfg)
 }
 
 func (s *Server) auth(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
 	auth := types.AuthConfig{}
+
+	// decode request body
 	if err := json.NewDecoder(req.Body).Decode(&auth); err != nil {
+		return httputils.NewHTTPError(err, http.StatusBadRequest)
+	}
+	// validate request body
+	if err := auth.Validate(strfmt.NewFormats()); err != nil {
 		return httputils.NewHTTPError(err, http.StatusBadRequest)
 	}
 

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2187,6 +2187,7 @@ definitions:
       StopTimeout:
         description: "Timeout to stop a container in seconds."
         type: "integer"
+        minimum: 0
         default: 10
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
@@ -3222,6 +3223,7 @@ definitions:
   ExecCreateConfig:
     type: "object"
     description: is a small subset of the Config struct that holds the configuration.
+    required: [Cmd]
     properties:
       User:
         type: "string"
@@ -3917,8 +3919,9 @@ definitions:
         type: "string"
         example: "127.0.0.1"
       HostPort:
-        description: "Host port number that the container's port is mapped to."
+        description: "Host port number that the container's port is mapped to. range (0,65535]"
         type: "string"
+        pattern: ^([1-9]|[1-9]\d{1,3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$
         example: "4443"
 
   RestartPolicy:

--- a/apis/types/container_config.go
+++ b/apis/types/container_config.go
@@ -123,6 +123,7 @@ type ContainerConfig struct {
 	StopSignal string `json:"StopSignal,omitempty"`
 
 	// Timeout to stop a container in seconds.
+	// Minimum: 0
 	StopTimeout *int64 `json:"StopTimeout,omitempty"`
 
 	// Attach standard streams to a TTY, including `stdin` if it is not closed.
@@ -155,6 +156,10 @@ func (m *ContainerConfig) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRichMode(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateStopTimeout(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -271,6 +276,19 @@ func (m *ContainerConfig) validateRichMode(formats strfmt.Registry) error {
 
 	// value enum
 	if err := m.validateRichModeEnum("RichMode", "body", m.RichMode); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ContainerConfig) validateStopTimeout(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.StopTimeout) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("StopTimeout", "body", int64(*m.StopTimeout), 0, false); err != nil {
 		return err
 	}
 

--- a/apis/types/exec_create_config.go
+++ b/apis/types/exec_create_config.go
@@ -26,6 +26,7 @@ type ExecCreateConfig struct {
 	AttachStdout bool `json:"AttachStdout,omitempty"`
 
 	// Execution commands and args
+	// Required: true
 	// Min Items: 1
 	Cmd []string `json:"Cmd"`
 
@@ -64,8 +65,8 @@ func (m *ExecCreateConfig) Validate(formats strfmt.Registry) error {
 
 func (m *ExecCreateConfig) validateCmd(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Cmd) { // not required
-		return nil
+	if err := validate.Required("Cmd", "body", m.Cmd); err != nil {
+		return err
 	}
 
 	iCmdSize := int64(len(m.Cmd))

--- a/apis/types/port_binding.go
+++ b/apis/types/port_binding.go
@@ -6,8 +6,10 @@ package types
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"github.com/go-openapi/errors"
 	strfmt "github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // PortBinding PortBinding represents a binding between a host IP address and a host port
@@ -17,12 +19,35 @@ type PortBinding struct {
 	// Host IP address that the container's port is mapped to.
 	HostIP string `json:"HostIp,omitempty"`
 
-	// Host port number that the container's port is mapped to.
+	// Host port number that the container's port is mapped to. range (0,65535]
+	// Pattern: ^([1-9]|[1-9]\d{1,3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$
 	HostPort string `json:"HostPort,omitempty"`
 }
 
 // Validate validates this port binding
 func (m *PortBinding) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateHostPort(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *PortBinding) validateHostPort(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.HostPort) { // not required
+		return nil
+	}
+
+	if err := validate.Pattern("HostPort", "body", string(m.HostPort), `^([1-9]|[1-9]\d{1,3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$`); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/test/api_container_create_test.go
+++ b/test/api_container_create_test.go
@@ -201,6 +201,29 @@ func (suite *APIContainerCreateSuite) TestBadParam(c *check.C) {
 	helpwantedForMissingCase(c, "container api create with bad request")
 }
 
+func testCreateContainerWithBadParam(c *check.C, cname string, obj map[string]interface{}) {
+	q := url.Values{}
+	q.Add("name", cname)
+	query := request.WithQuery(q)
+	body := request.WithJSONBody(obj)
+
+	resp, err := request.Post("/containers/create", query, body)
+	defer DelContainerForceMultyTime(c, cname)
+	c.Assert(err, check.IsNil)
+	defer resp.Body.Close()
+	CheckRespStatus(c, resp, 400)
+}
+
+// TestCreateWithBadStopTimeout using bad stopTimeout to create container.
+func (suite *APIContainerCreateSuite) TestCreateWithBadStopTimeout(c *check.C) {
+	testCreateContainerWithBadParam(c,
+		"TestCreateWithBadStopTimeout",
+		map[string]interface{}{
+			"Image":       busyboxImage,
+			"StopTimeout": -1,
+		})
+}
+
 func (suite *APIContainerCreateSuite) TestCreateNvidiaConfig(c *check.C) {
 	cname := "TestCreateNvidiaConfig"
 	q := url.Values{}

--- a/test/api_container_exec_create_test.go
+++ b/test/api_container_exec_create_test.go
@@ -62,7 +62,7 @@ func (suite *APIContainerExecSuite) TestContainerCreateExecWithEnvs(c *check.C) 
 	CheckRespStatus(c, resp, 201)
 }
 
-// TestContainerCreateExecNoCmd tests execing containers is OK.
+// TestContainerCreateExecNoCmd tests exec without cmd.
 func (suite *APIContainerExecSuite) TestContainerCreateExecNoCmd(c *check.C) {
 	cname := "TestContainerCreateExecNoCmd"
 
@@ -71,6 +71,7 @@ func (suite *APIContainerExecSuite) TestContainerCreateExecNoCmd(c *check.C) {
 
 	StartContainerOk(c, cname)
 
+	// test no Cmd
 	obj := map[string]interface{}{
 		"Detach": true,
 	}
@@ -78,7 +79,18 @@ func (suite *APIContainerExecSuite) TestContainerCreateExecNoCmd(c *check.C) {
 
 	resp, err := request.Post("/containers/"+cname+"/exec", body)
 	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 201)
+	CheckRespStatus(c, resp, 400)
+
+	// test empty Cmd
+	obj = map[string]interface{}{
+		"Detach": true,
+		"Cmd":    []string{},
+	}
+	body = request.WithJSONBody(obj)
+
+	resp, err = request.Post("/containers/"+cname+"/exec", body)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 400)
 }
 
 // TestExecCreatedContainer tests creating exec on created container return error.

--- a/test/cli_exec_test.go
+++ b/test/cli_exec_test.go
@@ -54,6 +54,18 @@ func (suite *PouchExecSuite) TestExecCommand(c *check.C) {
 	}
 }
 
+func (suite *PouchExecSuite) TestExecNoCommand(c *check.C) {
+	cname := "TestExecNoCommand"
+	res := command.PouchRun("run", "-d", "--name", cname, busyboxImage, "sleep", "100000").Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, cname)
+
+	res = command.PouchRun("exec", cname)
+	expectedError := "requires at least 2 arg(s), only received 1"
+	if out := res.Combined(); !strings.Contains(out, expectedError) {
+		c.Fatalf("unexpected output %s, expected %s", out, expectedError)
+	}
+}
+
 // TestExecMultiCommands is to verify the correctness of execing container with specified commands.
 func (suite *PouchExecSuite) TestExecMultiCommands(c *check.C) {
 	name := "exec-normal2"


### PR DESCRIPTION
Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add rules to validate post request body.

| Parameter |    type  | pattern |
------------| ------- | --------
StopTimeout | *int64 | >= 0 |

| Parameter |    type  | pattern |
------------| ------- | --------
ExecCreateConfig.Cmd | []string | len > 0|

| Parameter |    type  | pattern |
------------| ------- | --------
HostPort | string | ^([1-9]\|[1-9]\d{1,3}\|[1-5]\d{4}\|6[0-4]\d{3}\|65[0-4]\d{2}\|655[0-2]\d\|6553[0-5])$  (0-65535) |


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #443 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

added, but not complete. I would like to invite volunteers to complete test.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


