### PR TITLE
bugfix: fix that cannot create network with --ipam-opt

### DIFF
--- a/cli/network.go
+++ b/cli/network.go
@@ -93,6 +93,7 @@ func (n *NetworkCreateCommand) addFlags() {
 	flagSet.StringVar(&n.ipRange, "ip-range", "", "the range of network's ip")
 	flagSet.StringVar(&n.subnet, "subnet", "", "the subnet of network")
 	flagSet.StringVar(&n.ipamDriver, "ipam-driver", "default", "the ipam driver of network")
+	flagSet.StringSliceVarP(&n.ipamOpts, "ipam-opt", "", nil, "the ipam driver options of network")
 	flagSet.BoolVar(&n.enableIPv6, "enable-ipv6", false, "enable ipv6 network")
 	flagSet.StringSliceVarP(&n.options, "option", "o", nil, "create network with options")
 	flagSet.StringSliceVarP(&n.labels, "label", "l", nil, "create network with labels")

--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -285,6 +285,27 @@ func (suite *PouchNetworkSuite) TestNetworkCreateWithOption(c *check.C) {
 	defer command.PouchRun("network", "remove", funcname)
 }
 
+// TestNetworkCreateWithIPAMOption creates network with ipam options
+func (suite *PouchNetworkSuite) TestNetworkCreateWithIPAMOption(c *check.C) {
+	gateway := "192.168.100.1"
+	subnet := "192.168.100.0/24"
+	networkName := "TestNetworkCreateWithIPAMOption"
+	command.PouchRun("network", "create",
+		"--name", networkName,
+		"-d", "bridge",
+		"--gateway", gateway,
+		"--subnet", subnet,
+		"--ipam-opt", "test=foo").Assert(c, icmd.Success)
+	defer command.PouchRun("network", "remove", networkName)
+	networkInfo := command.PouchRun("network", "inspect", networkName).Stdout()
+	networkJSON := []types.NetworkCreate{}
+	err := json.Unmarshal([]byte(networkInfo), &networkJSON)
+	if err != nil || len(networkJSON) == 0 {
+		c.Fatalf("fail to deserialize NetworkCreate: %v", err)
+	}
+	c.Assert(networkJSON[0].IPAM.Options["test"], check.Equals, "foo")
+}
+
 // TestNetworkCreateDup tests creating duplicate network return error.
 func (suite *PouchNetworkSuite) TestNetworkCreateDup(c *check.C) {
 	pc, _, _, _ := runtime.Caller(0)


### PR DESCRIPTION
Signed-off-by: Tim Xu <xiaoxubeii@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Fix that cannot create network with `--ipam-opt`

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2384 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

`pouch network create foo --ipam-driver mini --ipam-opt foo=bar`
