### PR TITLE
feature: support get security options in daemon

### DIFF
--- a/daemon/mgr/spec_seccomp_linux.go
+++ b/daemon/mgr/spec_seccomp_linux.go
@@ -12,6 +12,11 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// IsSeccompEnable return true since pouch support seccomp in build
+func IsSeccompEnable() bool {
+	return true
+}
+
 // setupSeccomp creates seccomp security settings spec.
 func setupSeccomp(ctx context.Context, c *Container, s *specs.Spec) error {
 	if c.HostConfig.Privileged {

--- a/daemon/mgr/spec_seccomp_unsupported.go
+++ b/daemon/mgr/spec_seccomp_unsupported.go
@@ -9,6 +9,11 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// IsSeccompEnable return false since pouch do not support seccomp in build
+func IsSeccompEnable() bool {
+	return false
+}
+
 func setupSeccomp(ctx context.Context, c *Container, s *specs.Spec) error {
 	if c.SeccompProfile != "" && c.SeccompProfile != "unconfined" {
 		return fmt.Errorf("Seccomp is not support by pouch, can not set seccomp profile %s", c.SeccompProfile)

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -19,6 +19,8 @@ import (
 	"github.com/alibaba/pouch/registry"
 	volumedriver "github.com/alibaba/pouch/storage/volume/driver"
 	"github.com/alibaba/pouch/version"
+	"github.com/opencontainers/runc/libcontainer/apparmor"
+	selinux "github.com/opencontainers/selinux/go-selinux"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -112,6 +114,19 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 	}
 	volumeDrivers := volumedriver.AllDriversName()
 
+	// security options get four part, seccomp, apparmor, selinux and userns
+	securityOpts := []string{}
+	sysInfo := system.NewInfo()
+	if sysInfo.Seccomp && IsSeccompEnable() {
+		securityOpts = append(securityOpts, "seccomp")
+	}
+	if sysInfo.AppArmor && apparmor.IsEnabled() {
+		securityOpts = append(securityOpts, "apparmor")
+	}
+	if selinux.GetEnabled() {
+		securityOpts = append(securityOpts, "selinux")
+	}
+
 	info := types.SystemInfo{
 		Architecture: runtime.GOARCH,
 		// CgroupDriver: ,
@@ -148,8 +163,8 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		PouchRootDir:       mgr.config.HomeDir,
 		RegistryConfig:     &mgr.config.RegistryService,
 		// RuncCommit: ,
-		Runtimes: mgr.config.Runtimes,
-		// SecurityOptions: ,
+		Runtimes:        mgr.config.Runtimes,
+		SecurityOptions: securityOpts,
 		ServerVersion:   version.Version,
 		ListenAddresses: mgr.config.Listen,
 	}


### PR DESCRIPTION
show daemon security options, include four part,
seccomp, apparmor, selinux and userns.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

support security information showed by pouch info , show daemon security options, include four part,
seccomp, apparmor, selinux and userns.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


