### PR TITLE
feature: support images filter flag

### DIFF
--- a/apis/filters/parse_test.go
+++ b/apis/filters/parse_test.go
@@ -149,3 +149,30 @@ func TestFromParam(t *testing.T) {
 		}
 	}
 }
+
+func TestFromFilterOpts(t *testing.T) {
+	filterOpts := []string{
+		"reference=img1",
+		"since=img2",
+		"before=img3",
+		"reference=img3",
+	}
+
+	args, err := FromFilterOpts(filterOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	images := args.Get("reference")
+	if len(images) != 2 {
+		t.Fatal("Expected two values of reference key, but got one.")
+	}
+
+	if !args.Contains("since") {
+		t.Fatal("Excepted get since key, but got none.")
+	}
+
+	if !args.Contains("before") {
+		t.Fatal("Excepted get before key, but got none.")
+	}
+}

--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alibaba/pouch/apis/filters"
 	"github.com/alibaba/pouch/apis/metrics"
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/daemon/mgr"
@@ -75,9 +76,12 @@ func (s *Server) getImage(ctx context.Context, rw http.ResponseWriter, req *http
 }
 
 func (s *Server) listImages(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
-	filters := req.FormValue("filters")
+	filter, err := filters.FromParam(req.FormValue("filters"))
+	if err != nil {
+		return err
+	}
 
-	imageList, err := s.ImageMgr.ListImages(ctx, filters)
+	imageList, err := s.ImageMgr.ListImages(ctx, filter)
 	if err != nil {
 		logrus.Errorf("failed to list images: %v", err)
 		return err
@@ -91,7 +95,7 @@ func (s *Server) searchImages(ctx context.Context, rw http.ResponseWriter, req *
 
 	searchResultItem, err := s.ImageMgr.SearchImages(ctx, searchPattern, registry)
 	if err != nil {
-		logrus.Errorf("failed to search images from resgitry: %v", err)
+		logrus.Errorf("failed to search images from registry: %v", err)
 		return err
 	}
 	return EncodeResponse(rw, http.StatusOK, searchResultItem)

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -348,8 +348,6 @@ paths:
             A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
 
             - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
-            - `dangling=true`
-            - `label=key` or `label="key=value"` of an image label
             - `reference`=(`<image-name>[:<tag>]`)
             - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
           type: "string"

--- a/cli/events.go
+++ b/cli/events.go
@@ -59,15 +59,9 @@ func (e *EventsCommand) runEvents() error {
 	ctx := context.Background()
 	apiClient := e.cli.Client()
 
-	eventFilterArgs := filters.NewArgs()
-
-	// TODO: parse params
-	for _, f := range e.filter {
-		var err error
-		eventFilterArgs, err = filters.ParseFlag(f, eventFilterArgs)
-		if err != nil {
-			return err
-		}
+	eventFilterArgs, err := filters.FromFilterOpts(e.filter)
+	if err != nil {
+		return err
 	}
 
 	responseBody, err := apiClient.Events(ctx, e.since, e.until, eventFilterArgs)

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -2,13 +2,26 @@ package client
 
 import (
 	"context"
+	"net/url"
 
+	"github.com/alibaba/pouch/apis/filters"
 	"github.com/alibaba/pouch/apis/types"
 )
 
 // ImageList requests daemon to list all images
-func (client *APIClient) ImageList(ctx context.Context) ([]types.ImageInfo, error) {
-	resp, err := client.get(ctx, "/images/json", nil, nil)
+func (client *APIClient) ImageList(ctx context.Context, filter filters.Args) ([]types.ImageInfo, error) {
+	query := url.Values{}
+
+	if filter.Len() > 0 {
+		filtersJSON, err := filters.ToParam(filter)
+		if err != nil {
+			return nil, err
+		}
+
+		query.Set("filters", filtersJSON)
+	}
+
+	resp, err := client.get(ctx, "/images/json", query, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -19,5 +32,4 @@ func (client *APIClient) ImageList(ctx context.Context) ([]types.ImageInfo, erro
 	ensureCloseReader(resp)
 
 	return imageList, err
-
 }

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alibaba/pouch/apis/filters"
 	"github.com/alibaba/pouch/apis/types"
 
 	"github.com/stretchr/testify/assert"
@@ -19,7 +20,7 @@ func TestImageListServerError(t *testing.T) {
 	client := &APIClient{
 		HTTPCli: newMockClient(errorMockResponse(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ImageList(context.Background())
+	_, err := client.ImageList(context.Background(), filters.NewArgs())
 	if err == nil || !strings.Contains(err.Error(), "Server error") {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -62,7 +63,7 @@ func TestImageList(t *testing.T) {
 		HTTPCli: httpClient,
 	}
 
-	image, err := client.ImageList(context.Background())
+	image, err := client.ImageList(context.Background(), filters.NewArgs())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -49,7 +49,7 @@ type ContainerAPIClient interface {
 
 // ImageAPIClient defines methods of Image client.
 type ImageAPIClient interface {
-	ImageList(ctx context.Context) ([]types.ImageInfo, error)
+	ImageList(ctx context.Context, filters filters.Args) ([]types.ImageInfo, error)
 	ImageInspect(ctx context.Context, name string) (types.ImageInfo, error)
 	ImagePull(ctx context.Context, name, tag, encodedAuth string) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, name string, force bool) error

--- a/cri/v1alpha1/cri.go
+++ b/cri/v1alpha1/cri.go
@@ -13,6 +13,7 @@ import (
 	goruntime "runtime"
 	"time"
 
+	"github.com/alibaba/pouch/apis/filters"
 	apitypes "github.com/alibaba/pouch/apis/types"
 	anno "github.com/alibaba/pouch/cri/annotations"
 	cni "github.com/alibaba/pouch/cri/ocicni"
@@ -1023,7 +1024,7 @@ func (c *CriManager) Status(ctx context.Context, r *runtime.StatusRequest) (*run
 // ListImages lists existing images.
 func (c *CriManager) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (*runtime.ListImagesResponse, error) {
 	// TODO: handle image list filters.
-	imageList, err := c.ImageMgr.ListImages(ctx, "")
+	imageList, err := c.ImageMgr.ListImages(ctx, filters.NewArgs())
 	if err != nil {
 		return nil, err
 	}

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/alibaba/pouch/apis/filters"
 	apitypes "github.com/alibaba/pouch/apis/types"
 	anno "github.com/alibaba/pouch/cri/annotations"
 	runtime "github.com/alibaba/pouch/cri/apis/v1alpha2"
@@ -1307,7 +1308,7 @@ func (c *CriManager) ListImages(ctx context.Context, r *runtime.ListImagesReques
 	}(time.Now())
 
 	// TODO: handle image list filters.
-	imageList, err := c.ImageMgr.ListImages(ctx, "")
+	imageList, err := c.ImageMgr.ListImages(ctx, filters.NewArgs())
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -106,7 +106,7 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		OSName = osName
 	}
 
-	images, err := mgr.imageMgr.ListImages(context.Background(), "")
+	images, err := mgr.imageMgr.ListImages(context.Background(), filters.NewArgs())
 	if err != nil {
 		logrus.Warnf("failed to get image info: %v", err)
 	}

--- a/test/cli_run_test.go
+++ b/test/cli_run_test.go
@@ -402,7 +402,7 @@ func (suite *PouchRunSuite) TestRunWithEnv(c *check.C) {
 	res := command.PouchRun("run", "--rm",
 		"--env", "A=a,b,c", // should not split args by comma
 		"--env", "B=b1",
-		"docker.io/library/alpine",
+		busyboxImage,
 		"sh", "-c", "echo ${A}-${B}",
 	)
 	res.Assert(c, icmd.Success)

--- a/test/environment/cleanup.go
+++ b/test/environment/cleanup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/alibaba/pouch/apis/filters"
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/client"
 
@@ -13,7 +14,7 @@ import (
 // PruneAllImages deletes all images from pouchd.
 func PruneAllImages(apiClient client.ImageAPIClient) error {
 	ctx := context.Background()
-	images, err := apiClient.ImageList(ctx)
+	images, err := apiClient.ImageList(ctx, filters.NewArgs())
 	if err != nil {
 		return errors.Wrap(err, "fail to list images")
 	}


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
add filter flag support for `pouch images`, support three filters: since/before/reference

- before (<image-name>[:<tag>], <image id> or <image@digest>) - filter images created before given id or references
- since (<image-name>[:<tag>], <image id> or <image@digest>) - filter images created since given id or references
- The reference filter shows only images whose reference matches the specified pattern. may have multi reference filter. the relationship between multi reference filter is or.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Related to #2405 
fix #2371 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add api testcase and cli testcase.


### Ⅳ. Describe how to verify it
`pouch images`
```
IMAGE ID       IMAGE NAME                                          SIZE
8c811b4aec35   registry.hub.docker.com/library/busybox:1.28        710.81 KB
4ab4c602aa5e   registry.hub.docker.com/library/hello-world:linux   5.25 KB
```

`pouch images -f reference=registry.hub.docker.com/library/busybox:*`
```
IMAGE ID       IMAGE NAME                                     SIZE
8c811b4aec35   registry.hub.docker.com/library/busybox:1.28   710.81 KB
```

`pouch images -f after=registry.hub.docker.com/library/busybox:1.28`
Got
`Error: failed to get image list: {"message":"Invalid filter after"}`

`pouch images -f before=registry.hub.docker.com/library/hello-world:linux`
```
IMAGE ID       IMAGE NAME                                     SIZE
8c811b4aec35   registry.hub.docker.com/library/busybox:1.28   710.81 KB
```

### Ⅴ. Special notes for reviews
Use the same filter package as `pouch events`

