### PR TITLE
oci: add pouch default runtime spec

### DIFF
--- a/ctrd/utils.go
+++ b/ctrd/utils.go
@@ -1,7 +1,6 @@
 package ctrd
 
 import (
-	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -10,21 +9,12 @@ import (
 	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/pkg/errtypes"
 
-	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
-
-// NewDefaultSpec new a template spec with default.
-func NewDefaultSpec(ctx context.Context, id string) (*specs.Spec, error) {
-	ctx = namespaces.WithNamespace(ctx, namespaces.Default)
-	return oci.GenerateSpec(ctx, nil, &containers.Container{ID: id})
-}
 
 func resolver(authConfig *types.AuthConfig) (remotes.Resolver, error) {
 	var (

--- a/daemon/mgr/spec.go
+++ b/daemon/mgr/spec.go
@@ -3,10 +3,9 @@ package mgr
 import (
 	"context"
 
-	"github.com/alibaba/pouch/ctrd"
+	"github.com/alibaba/pouch/oci"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 // SpecWrapper wraps the container's specs and add manager operations.
@@ -28,16 +27,9 @@ type SpecWrapper struct {
 func createSpec(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
 	c.Lock()
 	defer c.Unlock()
+
 	// new a default spec from containerd.
-	s, err := ctrd.NewDefaultSpec(ctx, c.ID)
-	if err != nil {
-		return errors.Wrapf(err, "failed to generate spec: %s", c.ID)
-	}
-
-	// fix https://github.com/opencontainers/runc/issues/705
-	// use ssh connect to container, can't use sudo command.
-	s.Process.NoNewPrivileges = false
-
+	s := oci.NewDefaultSpec()
 	specWrapper.s = s
 
 	s.Hostname = c.Config.Hostname.String()

--- a/daemon/mgr/spec_mount.go
+++ b/daemon/mgr/spec_mount.go
@@ -59,13 +59,6 @@ func setupMounts(ctx context.Context, c *Container, s *specs.Spec) error {
 		}
 		mounts = append(mounts, sm)
 	}
-	// TODO: we can suggest containerd to add the cgroup into the default spec.
-	mounts = append(mounts, specs.Mount{
-		Destination: "/sys/fs/cgroup",
-		Type:        "cgroup",
-		Source:      "cgroup",
-		Options:     []string{"ro", "nosuid", "noexec", "nodev"},
-	})
 
 	if c.HostConfig == nil {
 		return nil

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -20,9 +20,9 @@ import (
 	"github.com/alibaba/pouch/registry"
 	volumedriver "github.com/alibaba/pouch/storage/volume/driver"
 	"github.com/alibaba/pouch/version"
+
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	selinux "github.com/opencontainers/selinux/go-selinux"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/oci/spec_default.go
+++ b/oci/spec_default.go
@@ -1,0 +1,187 @@
+package oci
+
+import (
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func iPtr(i int64) *int64 { return &i }
+
+func defaultCaps() []string {
+	return []string{
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FOWNER",
+		"CAP_FSETID",
+		"CAP_KILL",
+		"CAP_SETGID",
+		"CAP_SETUID",
+		"CAP_SETPCAP",
+		"CAP_AUDIT_WRITE",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_NET_RAW",
+		"CAP_SYS_CHROOT",
+		"CAP_MKNOD",
+		"CAP_SETFCAP",
+	}
+}
+
+// NewDefaultSpec create a new spec.
+func NewDefaultSpec() *specs.Spec {
+	s := &specs.Spec{
+		Version: specs.Version,
+	}
+	s.Mounts = []specs.Mount{
+		{
+			Destination: "/proc",
+			Type:        "proc",
+			Source:      "proc",
+			Options:     []string{"nosuid", "noexec", "nodev"},
+		},
+		{
+			Destination: "/dev",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"nosuid", "strictatime", "mode=755"},
+		},
+		{
+			Destination: "/dev/pts",
+			Type:        "devpts",
+			Source:      "devpts",
+			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+		},
+		{
+			Destination: "/sys",
+			Type:        "sysfs",
+			Source:      "sysfs",
+			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+		},
+		{
+			Destination: "/dev/mqueue",
+			Type:        "mqueue",
+			Source:      "mqueue",
+			Options:     []string{"nosuid", "noexec", "nodev"},
+		},
+		{
+			Destination: "/dev/shm",
+			Type:        "tmpfs",
+			Source:      "shm",
+			Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+		},
+		{
+			Destination: "/sys/fs/cgroup",
+			Type:        "cgroup",
+			Source:      "cgroup",
+			Options:     []string{"ro", "nosuid", "noexec", "nodev"},
+		},
+	}
+
+	s.Process = &specs.Process{
+		Capabilities: &specs.LinuxCapabilities{
+			Bounding:    defaultCaps(),
+			Permitted:   defaultCaps(),
+			Inheritable: defaultCaps(),
+			Effective:   defaultCaps(),
+		},
+	}
+
+	s.Linux = &specs.Linux{
+		MaskedPaths: []string{
+			"/proc/kcore",
+			"/proc/latency_stats",
+			"/proc/timer_list",
+			"/proc/timer_stats",
+			"/proc/sched_debug",
+		},
+		ReadonlyPaths: []string{
+			"/proc/asound",
+			"/proc/bus",
+			"/proc/fs",
+			"/proc/irq",
+			"/proc/sys",
+			"/proc/sysrq-trigger",
+		},
+		Namespaces: []specs.LinuxNamespace{
+			{
+				Type: specs.PIDNamespace,
+			},
+			{
+				Type: specs.IPCNamespace,
+			},
+			{
+				Type: specs.UTSNamespace,
+			},
+			{
+				Type: specs.MountNamespace,
+			},
+			{
+				Type: specs.NetworkNamespace,
+			},
+		},
+		// Devices implicitly contains the following devices:
+		// null, zero, full, random, urandom, tty, console, and ptmx.
+		// ptmx is a bind-mount or symlink of the container's ptmx.
+		// See also: https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#default-devices
+		Devices: []specs.LinuxDevice{},
+		Resources: &specs.LinuxResources{
+			Devices: []specs.LinuxDeviceCgroup{
+				{
+					Allow:  false,
+					Access: "rwm",
+				},
+				{
+					Allow:  true,
+					Type:   "c",
+					Major:  iPtr(1),
+					Minor:  iPtr(5),
+					Access: "rwm",
+				},
+				{
+					Allow:  true,
+					Type:   "c",
+					Major:  iPtr(1),
+					Minor:  iPtr(3),
+					Access: "rwm",
+				},
+				{
+					Allow:  true,
+					Type:   "c",
+					Major:  iPtr(1),
+					Minor:  iPtr(9),
+					Access: "rwm",
+				},
+				{
+					Allow:  true,
+					Type:   "c",
+					Major:  iPtr(1),
+					Minor:  iPtr(8),
+					Access: "rwm",
+				},
+				{
+					Allow:  true,
+					Type:   "c",
+					Major:  iPtr(5),
+					Minor:  iPtr(0),
+					Access: "rwm",
+				},
+
+				{
+					Allow:  true,
+					Type:   "c",
+					Major:  iPtr(5),
+					Minor:  iPtr(1),
+					Access: "rwm",
+				},
+				{
+					Allow:  false,
+					Type:   "c",
+					Major:  iPtr(10),
+					Minor:  iPtr(229),
+					Access: "rwm",
+				},
+			},
+		},
+	}
+
+	return s
+
+}

--- a/test/cli_run_memory_test.go
+++ b/test/cli_run_memory_test.go
@@ -231,3 +231,16 @@ func (suite *PouchRunMemorySuite) TestRunWithShm(c *check.C) {
 
 	c.Assert(util.PartialEqual(res.Stdout(), "1048576"), check.IsNil)
 }
+
+// TestRunWithShm is to verify the container has default shm size equals 64m
+func (suite *PouchRunMemorySuite) TestRunWithDefaultShm(c *check.C) {
+	cname := "TestRunWithDefaultShm"
+	res := command.PouchRun("run", "-d", "--name", cname, busyboxImage, "top")
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
+
+	res = command.PouchRun("exec", cname, "df", "-k", "/dev/shm")
+	res.Assert(c, icmd.Success)
+
+	c.Assert(util.PartialEqual(res.Stdout(), "65536"), check.IsNil)
+}


### PR DESCRIPTION
use pouch default runtime spec, instead of containerd default spec,
compare to containerd spec, we remove Root, Process(Env Cmd
NoNewPrivileges User Rlimits), Linux(CgroupsPath), this should not
be exist in default spec, remove Mount(/run), this is not used, add
allowed device, add cgroup mount.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

use pouch default runtime spec, instead of containerd default spec,
compare to containerd spec, we remove Root, Process(Env Cmd
NoNewPrivileges User Rlimits), Linux(CgroupsPath), this should not
be exist in default spec, remove Mount(/run), this is not used, add
allowed device, add cgroup mount.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix #2116 , and base on PR #2271 ， close #2115 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

For the default runtime spec pouch used, I will post an explanation, if have doubt with the new spec , please wait some time.
