### PR TITLE
bugfix: fix deadcode reports by gometalinter

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -32,8 +32,7 @@ import (
 )
 
 var (
-	runtimeRoot           = "/run"
-	defaultTrylockTimeout = 5 * time.Second
+	runtimeRoot = "/run"
 )
 
 type containerPack struct {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
-	"plugin"
 	"reflect"
 
 	"github.com/alibaba/pouch/apis/server"
@@ -24,8 +23,6 @@ import (
 
 	systemddaemon "github.com/coreos/go-systemd/daemon"
 	systemdutil "github.com/coreos/go-systemd/util"
-	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -50,12 +47,6 @@ type Daemon struct {
 	volumePlugin    hookplugins.VolumePlugin
 	criPlugin       hookplugins.CriPlugin
 	eventsService   *events.Events
-}
-
-// router represents the router of daemon.
-type router struct {
-	daemon *Daemon
-	*mux.Router
 }
 
 // NewDaemon constructs a brand new server.
@@ -115,14 +106,6 @@ func NewDaemon(cfg *config.Config) *Daemon {
 		ctrdDaemon:     ctrdDaemon,
 		containerStore: containerStore,
 	}
-}
-
-func loadSymbolByName(p *plugin.Plugin, name string) (plugin.Symbol, error) {
-	s, err := p.Lookup(name)
-	if err != nil {
-		return nil, errors.Wrapf(err, "lookup plugin with name %s error", name)
-	}
-	return s, nil
 }
 
 func (d *Daemon) loadPlugin() error {

--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -373,43 +373,15 @@ func setupNamespaces(ctx context.Context, c *Container, specWrapper *SpecWrapper
 	return setupUtsNamespace(ctx, c, specWrapper)
 }
 
-// isEmpty indicates whether namespace mode is empty.
-func isEmpty(mode string) bool {
-	return mode == ""
-}
-
-// isNone indicates whether container's namespace mode is set to "none".
-func isNone(mode string) bool {
-	return mode == "none"
-}
-
 // isHost indicates whether the container shares the host's corresponding namespace.
 func isHost(mode string) bool {
 	return mode == "host"
-}
-
-// isShareable indicates whether the containers namespace can be shared with another container.
-func isShareable(mode string) bool {
-	return mode == "shareable"
 }
 
 // isContainer indicates whether the container uses another container's corresponding namespace.
 func isContainer(mode string) bool {
 	parts := strings.SplitN(mode, ":", 2)
 	return len(parts) > 1 && parts[0] == "container"
-}
-
-// isPrivate indicates whether the container uses its own namespace.
-func isPrivate(ns specs.LinuxNamespaceType, mode string) bool {
-	switch ns {
-	case specs.IPCNamespace:
-		return mode == "private"
-	case specs.NetworkNamespace, specs.PIDNamespace:
-		return !(isHost(mode) || isContainer(mode))
-	case specs.UserNamespace, specs.UTSNamespace:
-		return !(isHost(mode))
-	}
-	return false
 }
 
 // connectedContainer is the id or name of the container whose namespace this container share with.

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/lxcfs"
 	"github.com/alibaba/pouch/pkg/debug"
-	"github.com/alibaba/pouch/pkg/exec"
 	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/storage/quota"
 	"github.com/alibaba/pouch/version"
@@ -256,23 +255,6 @@ func initLog() {
 		TimestampFormat: time.RFC3339Nano,
 	}
 	logrus.SetFormatter(formatter)
-}
-
-// define lxcfs processe.
-func setLxcfsProcess(processes exec.Processes) exec.Processes {
-	if !cfg.IsLxcfsEnabled {
-		return processes
-	}
-
-	p := &exec.Process{
-		Path: cfg.LxcfsBinPath,
-		Args: []string{
-			cfg.LxcfsHome,
-		},
-	}
-	processes = append(processes, p)
-
-	return processes
 }
 
 // check lxcfs config

--- a/pkg/utils/metrics/unit.go
+++ b/pkg/utils/metrics/unit.go
@@ -5,8 +5,6 @@ package metrics
 type Unit string
 
 const (
-	nanoseconds Unit = "nanoseconds"
-	seconds     Unit = "seconds"
-	bytes       Unit = "bytes"
-	total       Unit = "total"
+	seconds Unit = "seconds"
+	total   Unit = "total"
 )

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -70,11 +70,6 @@ func genRegistryEndpoints(addr string) (endpoints []registryEndpoint) {
 	return endpoints
 }
 
-// TODO: generate v2 registry endpoint for login
-func genV1Endpoints(addr string) registryEndpoint {
-	return registryEndpoint{}
-}
-
 func genV2Endpoints(addr string) registryEndpoint {
 	if addr == "" {
 		addr = defaultV2Registry

--- a/storage/quota/grpquota.go
+++ b/storage/quota/grpquota.go
@@ -18,10 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	grpQuotaType = "grpquota"
-)
-
 // GrpQuotaDriver represents group quota driver.
 type GrpQuotaDriver struct {
 	lock sync.Mutex

--- a/storage/quota/prjquota.go
+++ b/storage/quota/prjquota.go
@@ -18,10 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	prjQuotaType = "prjquota"
-)
-
 // PrjQuotaDriver represents project quota driver.
 type PrjQuotaDriver struct {
 	lock sync.Mutex

--- a/test/util_api.go
+++ b/test/util_api.go
@@ -124,15 +124,6 @@ func CheckContainerRunning(c *check.C, cname string, isRunning bool) {
 	c.Assert(gotRunning, check.Equals, isRunning)
 }
 
-// DelContainerForceOk forcely deletes the container and asserts success.
-func DelContainerForceOk(c *check.C, cname string) {
-	resp, err := delContainerForce(cname)
-	c.Assert(err, check.IsNil)
-
-	defer resp.Body.Close()
-	CheckRespStatus(c, resp, 204)
-}
-
 func delContainerForce(cname string) (*http.Response, error) {
 	q := url.Values{}
 	q.Add("force", "true")
@@ -154,7 +145,6 @@ func PauseContainerOk(c *check.C, cname string) {
 func UnpauseContainerOk(c *check.C, cname string) {
 	resp, err := request.Post("/containers/" + cname + "/unpause")
 	c.Assert(err, check.IsNil)
-
 	defer resp.Body.Close()
 	CheckRespStatus(c, resp, 204)
 }

--- a/test/util_daemon.go
+++ b/test/util_daemon.go
@@ -64,13 +64,6 @@ func StartDefaultDaemon(args ...string) (*daemon.Config, error) {
 	return &cfg, cfg.StartDaemon()
 }
 
-// StartDaemonBareWithArgs starts a deamon with all user specified parameter.
-func StartDaemonBareWithArgs(cfg *daemon.Config, args ...string) error {
-	cfg.NewArgs(args...)
-
-	return cfg.StartDaemon()
-}
-
 // RestartDaemon restart daemon
 func RestartDaemon(cfg *daemon.Config) error {
 	cfg.KillDaemon()


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
As the title desc.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #2423 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it
None.

### Ⅴ. Special notes for reviews
The go tool's report about the deadcode have many errors, such as `PullImage` and `inspectFilter` func obviously being used in other code, maybe caused by lacking of `--tests` opt when use gometalinter.
I have double-check based on the reports.

updated:
still have errors even if use `gometalinter --tests --enable=deadcode ./...`
more deadcode not included in the report, such as `rootFSToAPIType` in `pouch/ctrd/utils.go`

