### PR TITLE
bugfix: can't recover the container whose restart-policy is always when host restart

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -187,7 +187,9 @@ func (d *Daemon) Run() error {
 	}
 	d.containerMgr = containerMgr
 
-	if err := containerMgr.Restore(ctx); err != nil {
+	// just register containers information here to let
+	// networkMgr to use.
+	if err := containerMgr.Load(ctx); err != nil {
 		return err
 	}
 
@@ -197,6 +199,12 @@ func (d *Daemon) Run() error {
 	}
 	d.networkMgr = networkMgr
 	containerMgr.(*mgr.ContainerManager).NetworkMgr = networkMgr
+
+	// after initialize network manager, try to recover all
+	// running containers
+	if err := containerMgr.Restore(ctx); err != nil {
+		return err
+	}
 
 	if err := d.addSystemLabels(); err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
Fix the bug: can't recover the container whose `restart-policy` is `always` when host restart

### Ⅱ. Does this pull request fix one issue?
none


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add test case: `PouchDaemonSuite.TestRecoverContainerWhenHostDown`

### Ⅳ. Describe how to verify it

1、create a container whose `restart-policy` is `always`
```
$ pouch run --restart always --name test -t -d registry.hub.docker.com/library/busybox:latest top
e6aad288c1a5941061aa4c94039d51f9b264e706881e937270d04d5dba890593

$ pouch ps
Name   ID       Status         Created         Image                                            Runtime
test   e6aad2   Up 2 seconds   2 seconds ago   registry.hub.docker.com/library/busybox:latest   runc
```
2、stop the pouch service

```
$ systemctl stop pouch
```

3、kill the container process
```
$ ps aux | grep e6aad288c1a5941061aa4c94039d51f9b264e706881e937270d04d5dba890593
root     15805  0.0  0.1   7524  2940 ?        Sl   21:29   0:00 containerd-shim -namespace default -workdir /var/lib/pouch/containerd/root/io.containerd.runtime.v1.linux/default/e6aad288c1a5941061aa4c94039d51f9b264e706881e937270d04d5dba890593 -address /var/run/containerd.sock -containerd-binary /usr/local/bin/containerd -runtime-root /run

$ kill -9 15805
```

4、restart pouch service, we should see the container is running again
```
pouch ps
Name   ID       Status         Created          Image                                            Runtime
test   e6aad2   Up 4 seconds   41 seconds ago   registry.hub.docker.com/library/busybox:latest   runc
```


### Ⅴ. Special notes for reviews


