### PR TITLE
fix: fail to resolve correct target directory from home-dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,17 +168,12 @@ func runDaemon(cmd *cobra.Command) error {
 		debug.SetupDumpStackTrap()
 	}
 
-	// initialize home dir.
-	dir := cfg.HomeDir
-
-	if dir == "" || !path.IsAbs(dir) {
-		return fmt.Errorf("invalid pouchd's home dir: %s", dir)
+	// resolve home dir.
+	dir, err := utils.ResolveHomeDir(cfg.HomeDir)
+	if err != nil {
+		return err
 	}
-	if _, err := os.Stat(dir); err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(dir, 0666); err != nil {
-			return fmt.Errorf("failed to mkdir: %v", err)
-		}
-	}
+	cfg.HomeDir = dir
 
 	// saves daemon pid to pidfile.
 	if cfg.Pidfile != "" {


### PR DESCRIPTION
resolve a correct target path from home dir, home dir must not be
a relative path, must not be a file, create directory if is not
exist, returns the target directory if directory is symlink.
Symlink container rootfs will cause setting quota error.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

unit test add.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


