### PR TITLE
fix: kata: workaround passthru net mode when get pod ip

### DIFF
--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -74,6 +74,12 @@ const (
 
 	// networkNotReadyReason is the reason reported when network is not ready.
 	networkNotReadyReason = "NetworkPluginNotReady"
+
+	// passthruKey to specify whether a interface is passthru to qemu
+	passthruKey = "io.alibaba.pouch.runv.passthru"
+
+	// passthruIP is the IP for container
+	passthruIP = "io.alibaba.pouch.runv.passthru.ip"
 )
 
 var (
@@ -606,6 +612,10 @@ func (c *CriManager) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 			// Maybe the pod has been stopped.
 			logrus.Warnf("failed to get ip of sandbox %q: %v", podSandboxID, err)
 		}
+	}
+
+	if v, exist := annotations[passthruKey]; exist && v == "true" {
+		ip = annotations[passthruIP]
 	}
 
 	status := &runtime.PodSandboxStatus{


### PR DESCRIPTION
Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
kata: workaround passthru net mode when get pod ip

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
cherry-pick

