### PR TITLE
WIP bugfix: Fix that pouch don't support detach-keys when run "pouch run"

### DIFF
--- a/pkg/term/term.go
+++ b/pkg/term/term.go
@@ -7,6 +7,9 @@ import (
 	"github.com/pkg/term/termios"
 )
 
+// The default escape key sequence: ctrl-p, ctrl-q
+var DefaultEscapeKeys = []byte{16, 17}
+
 // StdinEcho enable or disable echoing standard terminal input.
 func StdinEcho(echo bool) error {
 	return TerminalEcho(os.Stdin.Fd(), echo)

--- a/vendor/github.com/docker/docker/pkg/term/ascii.go
+++ b/vendor/github.com/docker/docker/pkg/term/ascii.go
@@ -1,0 +1,66 @@
+package term // import "github.com/docker/docker/pkg/term"
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ASCII list the possible supported ASCII key sequence
+var ASCII = []string{
+	"ctrl-@",
+	"ctrl-a",
+	"ctrl-b",
+	"ctrl-c",
+	"ctrl-d",
+	"ctrl-e",
+	"ctrl-f",
+	"ctrl-g",
+	"ctrl-h",
+	"ctrl-i",
+	"ctrl-j",
+	"ctrl-k",
+	"ctrl-l",
+	"ctrl-m",
+	"ctrl-n",
+	"ctrl-o",
+	"ctrl-p",
+	"ctrl-q",
+	"ctrl-r",
+	"ctrl-s",
+	"ctrl-t",
+	"ctrl-u",
+	"ctrl-v",
+	"ctrl-w",
+	"ctrl-x",
+	"ctrl-y",
+	"ctrl-z",
+	"ctrl-[",
+	"ctrl-\\",
+	"ctrl-]",
+	"ctrl-^",
+	"ctrl-_",
+}
+
+// ToBytes converts a string representing a suite of key-sequence to the corresponding ASCII code.
+func ToBytes(keys string) ([]byte, error) {
+	codes := []byte{}
+next:
+	for _, key := range strings.Split(keys, ",") {
+		if len(key) != 1 {
+			for code, ctrl := range ASCII {
+				if ctrl == key {
+					codes = append(codes, byte(code))
+					continue next
+				}
+			}
+			if key == "DEL" {
+				codes = append(codes, 127)
+			} else {
+				return nil, fmt.Errorf("Unknown character: '%s'", key)
+			}
+		} else {
+			codes = append(codes, key[0])
+		}
+	}
+	return codes, nil
+}

--- a/vendor/github.com/docker/docker/pkg/term/proxy.go
+++ b/vendor/github.com/docker/docker/pkg/term/proxy.go
@@ -1,0 +1,78 @@
+package term // import "github.com/docker/docker/pkg/term"
+
+import (
+	"io"
+)
+
+// EscapeError is special error which returned by a TTY proxy reader's Read()
+// method in case its detach escape sequence is read.
+type EscapeError struct{}
+
+func (EscapeError) Error() string {
+	return "read escape sequence"
+}
+
+// escapeProxy is used only for attaches with a TTY. It is used to proxy
+// stdin keypresses from the underlying reader and look for the passed in
+// escape key sequence to signal a detach.
+type escapeProxy struct {
+	escapeKeys   []byte
+	escapeKeyPos int
+	r            io.Reader
+}
+
+// NewEscapeProxy returns a new TTY proxy reader which wraps the given reader
+// and detects when the specified escape keys are read, in which case the Read
+// method will return an error of type EscapeError.
+func NewEscapeProxy(r io.Reader, escapeKeys []byte) io.Reader {
+	return &escapeProxy{
+		escapeKeys: escapeKeys,
+		r:          r,
+	}
+}
+
+func (r *escapeProxy) Read(buf []byte) (int, error) {
+	nr, err := r.r.Read(buf)
+
+	if len(r.escapeKeys) == 0 {
+		return nr, err
+	}
+
+	preserve := func() {
+		// this preserves the original key presses in the passed in buffer
+		nr += r.escapeKeyPos
+		preserve := make([]byte, 0, r.escapeKeyPos+len(buf))
+		preserve = append(preserve, r.escapeKeys[:r.escapeKeyPos]...)
+		preserve = append(preserve, buf...)
+		r.escapeKeyPos = 0
+		copy(buf[0:nr], preserve)
+	}
+
+	if nr != 1 || err != nil {
+		if r.escapeKeyPos > 0 {
+			preserve()
+		}
+		return nr, err
+	}
+
+	if buf[0] != r.escapeKeys[r.escapeKeyPos] {
+		if r.escapeKeyPos > 0 {
+			preserve()
+		}
+		return nr, nil
+	}
+
+	if r.escapeKeyPos == len(r.escapeKeys)-1 {
+		return 0, EscapeError{}
+	}
+
+	// Looks like we've got an escape key, but we need to match again on the next
+	// read.
+	// Store the current escape key we found so we can look for the next one on
+	// the next read.
+	// Since this is an escape key, make sure we don't let the caller read it
+	// If later on we find that this is not the escape sequence, we'll add the
+	// keys back
+	r.escapeKeyPos++
+	return nr - r.escapeKeyPos, nil
+}

--- a/vendor/github.com/docker/docker/pkg/term/tc.go
+++ b/vendor/github.com/docker/docker/pkg/term/tc.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package term // import "github.com/docker/docker/pkg/term"
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func tcget(fd uintptr, p *Termios) syscall.Errno {
+	_, _, err := unix.Syscall(unix.SYS_IOCTL, fd, uintptr(getTermios), uintptr(unsafe.Pointer(p)))
+	return err
+}
+
+func tcset(fd uintptr, p *Termios) syscall.Errno {
+	_, _, err := unix.Syscall(unix.SYS_IOCTL, fd, setTermios, uintptr(unsafe.Pointer(p)))
+	return err
+}

--- a/vendor/github.com/docker/docker/pkg/term/term.go
+++ b/vendor/github.com/docker/docker/pkg/term/term.go
@@ -1,0 +1,124 @@
+// +build !windows
+
+// Package term provides structures and helper functions to work with
+// terminal (state, sizes).
+package term // import "github.com/docker/docker/pkg/term"
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+
+	"golang.org/x/sys/unix"
+)
+
+var (
+	// ErrInvalidState is returned if the state of the terminal is invalid.
+	ErrInvalidState = errors.New("Invalid terminal state")
+)
+
+// State represents the state of the terminal.
+type State struct {
+	termios Termios
+}
+
+// Winsize represents the size of the terminal window.
+type Winsize struct {
+	Height uint16
+	Width  uint16
+	x      uint16
+	y      uint16
+}
+
+// StdStreams returns the standard streams (stdin, stdout, stderr).
+func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
+	return os.Stdin, os.Stdout, os.Stderr
+}
+
+// GetFdInfo returns the file descriptor for an os.File and indicates whether the file represents a terminal.
+func GetFdInfo(in interface{}) (uintptr, bool) {
+	var inFd uintptr
+	var isTerminalIn bool
+	if file, ok := in.(*os.File); ok {
+		inFd = file.Fd()
+		isTerminalIn = IsTerminal(inFd)
+	}
+	return inFd, isTerminalIn
+}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios Termios
+	return tcget(fd, &termios) == 0
+}
+
+// RestoreTerminal restores the terminal connected to the given file descriptor
+// to a previous state.
+func RestoreTerminal(fd uintptr, state *State) error {
+	if state == nil {
+		return ErrInvalidState
+	}
+	if err := tcset(fd, &state.termios); err != 0 {
+		return err
+	}
+	return nil
+}
+
+// SaveState saves the state of the terminal connected to the given file descriptor.
+func SaveState(fd uintptr) (*State, error) {
+	var oldState State
+	if err := tcget(fd, &oldState.termios); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+// DisableEcho applies the specified state to the terminal connected to the file
+// descriptor, with echo disabled.
+func DisableEcho(fd uintptr, state *State) error {
+	newState := state.termios
+	newState.Lflag &^= unix.ECHO
+
+	if err := tcset(fd, &newState); err != 0 {
+		return err
+	}
+	handleInterrupt(fd, state)
+	return nil
+}
+
+// SetRawTerminal puts the terminal connected to the given file descriptor into
+// raw mode and returns the previous state. On UNIX, this puts both the input
+// and output into raw mode. On Windows, it only puts the input into raw mode.
+func SetRawTerminal(fd uintptr) (*State, error) {
+	oldState, err := MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	handleInterrupt(fd, oldState)
+	return oldState, err
+}
+
+// SetRawTerminalOutput puts the output of terminal connected to the given file
+// descriptor into raw mode. On UNIX, this does nothing and returns nil for the
+// state. On Windows, it disables LF -> CRLF translation.
+func SetRawTerminalOutput(fd uintptr) (*State, error) {
+	return nil, nil
+}
+
+func handleInterrupt(fd uintptr, state *State) {
+	sigchan := make(chan os.Signal, 1)
+	signal.Notify(sigchan, os.Interrupt)
+	go func() {
+		for range sigchan {
+			// quit cleanly and the new terminal item is on a new line
+			fmt.Println()
+			signal.Stop(sigchan)
+			close(sigchan)
+			RestoreTerminal(fd, state)
+			os.Exit(1)
+		}
+	}()
+}

--- a/vendor/github.com/docker/docker/pkg/term/term_windows.go
+++ b/vendor/github.com/docker/docker/pkg/term/term_windows.go
@@ -1,0 +1,228 @@
+package term // import "github.com/docker/docker/pkg/term"
+
+import (
+	"io"
+	"os"
+	"os/signal"
+	"syscall" // used for STD_INPUT_HANDLE, STD_OUTPUT_HANDLE and STD_ERROR_HANDLE
+
+	"github.com/Azure/go-ansiterm/winterm"
+	"github.com/docker/docker/pkg/term/windows"
+)
+
+// State holds the console mode for the terminal.
+type State struct {
+	mode uint32
+}
+
+// Winsize is used for window size.
+type Winsize struct {
+	Height uint16
+	Width  uint16
+}
+
+// vtInputSupported is true if winterm.ENABLE_VIRTUAL_TERMINAL_INPUT is supported by the console
+var vtInputSupported bool
+
+// StdStreams returns the standard streams (stdin, stdout, stderr).
+func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
+	// Turn on VT handling on all std handles, if possible. This might
+	// fail, in which case we will fall back to terminal emulation.
+	var emulateStdin, emulateStdout, emulateStderr bool
+	fd := os.Stdin.Fd()
+	if mode, err := winterm.GetConsoleMode(fd); err == nil {
+		// Validate that winterm.ENABLE_VIRTUAL_TERMINAL_INPUT is supported, but do not set it.
+		if err = winterm.SetConsoleMode(fd, mode|winterm.ENABLE_VIRTUAL_TERMINAL_INPUT); err != nil {
+			emulateStdin = true
+		} else {
+			vtInputSupported = true
+		}
+		// Unconditionally set the console mode back even on failure because SetConsoleMode
+		// remembers invalid bits on input handles.
+		winterm.SetConsoleMode(fd, mode)
+	}
+
+	fd = os.Stdout.Fd()
+	if mode, err := winterm.GetConsoleMode(fd); err == nil {
+		// Validate winterm.DISABLE_NEWLINE_AUTO_RETURN is supported, but do not set it.
+		if err = winterm.SetConsoleMode(fd, mode|winterm.ENABLE_VIRTUAL_TERMINAL_PROCESSING|winterm.DISABLE_NEWLINE_AUTO_RETURN); err != nil {
+			emulateStdout = true
+		} else {
+			winterm.SetConsoleMode(fd, mode|winterm.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+		}
+	}
+
+	fd = os.Stderr.Fd()
+	if mode, err := winterm.GetConsoleMode(fd); err == nil {
+		// Validate winterm.DISABLE_NEWLINE_AUTO_RETURN is supported, but do not set it.
+		if err = winterm.SetConsoleMode(fd, mode|winterm.ENABLE_VIRTUAL_TERMINAL_PROCESSING|winterm.DISABLE_NEWLINE_AUTO_RETURN); err != nil {
+			emulateStderr = true
+		} else {
+			winterm.SetConsoleMode(fd, mode|winterm.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+		}
+	}
+
+	if os.Getenv("ConEmuANSI") == "ON" || os.Getenv("ConsoleZVersion") != "" {
+		// The ConEmu and ConsoleZ terminals emulate ANSI on output streams well.
+		emulateStdin = true
+		emulateStdout = false
+		emulateStderr = false
+	}
+
+	// Temporarily use STD_INPUT_HANDLE, STD_OUTPUT_HANDLE and
+	// STD_ERROR_HANDLE from syscall rather than x/sys/windows as long as
+	// go-ansiterm hasn't switch to x/sys/windows.
+	// TODO: switch back to x/sys/windows once go-ansiterm has switched
+	if emulateStdin {
+		stdIn = windowsconsole.NewAnsiReader(syscall.STD_INPUT_HANDLE)
+	} else {
+		stdIn = os.Stdin
+	}
+
+	if emulateStdout {
+		stdOut = windowsconsole.NewAnsiWriter(syscall.STD_OUTPUT_HANDLE)
+	} else {
+		stdOut = os.Stdout
+	}
+
+	if emulateStderr {
+		stdErr = windowsconsole.NewAnsiWriter(syscall.STD_ERROR_HANDLE)
+	} else {
+		stdErr = os.Stderr
+	}
+
+	return
+}
+
+// GetFdInfo returns the file descriptor for an os.File and indicates whether the file represents a terminal.
+func GetFdInfo(in interface{}) (uintptr, bool) {
+	return windowsconsole.GetHandleInfo(in)
+}
+
+// GetWinsize returns the window size based on the specified file descriptor.
+func GetWinsize(fd uintptr) (*Winsize, error) {
+	info, err := winterm.GetConsoleScreenBufferInfo(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	winsize := &Winsize{
+		Width:  uint16(info.Window.Right - info.Window.Left + 1),
+		Height: uint16(info.Window.Bottom - info.Window.Top + 1),
+	}
+
+	return winsize, nil
+}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd uintptr) bool {
+	return windowsconsole.IsConsole(fd)
+}
+
+// RestoreTerminal restores the terminal connected to the given file descriptor
+// to a previous state.
+func RestoreTerminal(fd uintptr, state *State) error {
+	return winterm.SetConsoleMode(fd, state.mode)
+}
+
+// SaveState saves the state of the terminal connected to the given file descriptor.
+func SaveState(fd uintptr) (*State, error) {
+	mode, e := winterm.GetConsoleMode(fd)
+	if e != nil {
+		return nil, e
+	}
+
+	return &State{mode: mode}, nil
+}
+
+// DisableEcho disables echo for the terminal connected to the given file descriptor.
+// -- See https://msdn.microsoft.com/en-us/library/windows/desktop/ms683462(v=vs.85).aspx
+func DisableEcho(fd uintptr, state *State) error {
+	mode := state.mode
+	mode &^= winterm.ENABLE_ECHO_INPUT
+	mode |= winterm.ENABLE_PROCESSED_INPUT | winterm.ENABLE_LINE_INPUT
+	err := winterm.SetConsoleMode(fd, mode)
+	if err != nil {
+		return err
+	}
+
+	// Register an interrupt handler to catch and restore prior state
+	restoreAtInterrupt(fd, state)
+	return nil
+}
+
+// SetRawTerminal puts the terminal connected to the given file descriptor into
+// raw mode and returns the previous state. On UNIX, this puts both the input
+// and output into raw mode. On Windows, it only puts the input into raw mode.
+func SetRawTerminal(fd uintptr) (*State, error) {
+	state, err := MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Register an interrupt handler to catch and restore prior state
+	restoreAtInterrupt(fd, state)
+	return state, err
+}
+
+// SetRawTerminalOutput puts the output of terminal connected to the given file
+// descriptor into raw mode. On UNIX, this does nothing and returns nil for the
+// state. On Windows, it disables LF -> CRLF translation.
+func SetRawTerminalOutput(fd uintptr) (*State, error) {
+	state, err := SaveState(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ignore failures, since winterm.DISABLE_NEWLINE_AUTO_RETURN might not be supported on this
+	// version of Windows.
+	winterm.SetConsoleMode(fd, state.mode|winterm.DISABLE_NEWLINE_AUTO_RETURN)
+	return state, err
+}
+
+// MakeRaw puts the terminal (Windows Console) connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be restored.
+func MakeRaw(fd uintptr) (*State, error) {
+	state, err := SaveState(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	mode := state.mode
+
+	// See
+	// -- https://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
+	// -- https://msdn.microsoft.com/en-us/library/windows/desktop/ms683462(v=vs.85).aspx
+
+	// Disable these modes
+	mode &^= winterm.ENABLE_ECHO_INPUT
+	mode &^= winterm.ENABLE_LINE_INPUT
+	mode &^= winterm.ENABLE_MOUSE_INPUT
+	mode &^= winterm.ENABLE_WINDOW_INPUT
+	mode &^= winterm.ENABLE_PROCESSED_INPUT
+
+	// Enable these modes
+	mode |= winterm.ENABLE_EXTENDED_FLAGS
+	mode |= winterm.ENABLE_INSERT_MODE
+	mode |= winterm.ENABLE_QUICK_EDIT_MODE
+	if vtInputSupported {
+		mode |= winterm.ENABLE_VIRTUAL_TERMINAL_INPUT
+	}
+
+	err = winterm.SetConsoleMode(fd, mode)
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func restoreAtInterrupt(fd uintptr, state *State) {
+	sigchan := make(chan os.Signal, 1)
+	signal.Notify(sigchan, os.Interrupt)
+
+	go func() {
+		_ = <-sigchan
+		RestoreTerminal(fd, state)
+		os.Exit(0)
+	}()
+}

--- a/vendor/github.com/docker/docker/pkg/term/termios_bsd.go
+++ b/vendor/github.com/docker/docker/pkg/term/termios_bsd.go
@@ -1,0 +1,42 @@
+// +build darwin freebsd openbsd netbsd
+
+package term // import "github.com/docker/docker/pkg/term"
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	getTermios = unix.TIOCGETA
+	setTermios = unix.TIOCSETA
+)
+
+// Termios is the Unix API for terminal I/O.
+type Termios unix.Termios
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd uintptr) (*State, error) {
+	var oldState State
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, getTermios, uintptr(unsafe.Pointer(&oldState.termios))); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState.termios
+	newState.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
+	newState.Oflag &^= unix.OPOST
+	newState.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
+	newState.Cflag &^= (unix.CSIZE | unix.PARENB)
+	newState.Cflag |= unix.CS8
+	newState.Cc[unix.VMIN] = 1
+	newState.Cc[unix.VTIME] = 0
+
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, setTermios, uintptr(unsafe.Pointer(&newState))); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}

--- a/vendor/github.com/docker/docker/pkg/term/termios_linux.go
+++ b/vendor/github.com/docker/docker/pkg/term/termios_linux.go
@@ -1,0 +1,39 @@
+package term // import "github.com/docker/docker/pkg/term"
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+const (
+	getTermios = unix.TCGETS
+	setTermios = unix.TCSETS
+)
+
+// Termios is the Unix API for terminal I/O.
+type Termios unix.Termios
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd uintptr) (*State, error) {
+	termios, err := unix.IoctlGetTermios(int(fd), getTermios)
+	if err != nil {
+		return nil, err
+	}
+
+	var oldState State
+	oldState.termios = Termios(*termios)
+
+	termios.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
+	termios.Oflag &^= unix.OPOST
+	termios.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
+	termios.Cflag &^= (unix.CSIZE | unix.PARENB)
+	termios.Cflag |= unix.CS8
+	termios.Cc[unix.VMIN] = 1
+	termios.Cc[unix.VTIME] = 0
+
+	if err := unix.IoctlSetTermios(int(fd), setTermios, termios); err != nil {
+		return nil, err
+	}
+	return &oldState, nil
+}

--- a/vendor/github.com/docker/docker/pkg/term/winsize.go
+++ b/vendor/github.com/docker/docker/pkg/term/winsize.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package term // import "github.com/docker/docker/pkg/term"
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// GetWinsize returns the window size based on the specified file descriptor.
+func GetWinsize(fd uintptr) (*Winsize, error) {
+	uws, err := unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ)
+	ws := &Winsize{Height: uws.Row, Width: uws.Col, x: uws.Xpixel, y: uws.Ypixel}
+	return ws, err
+}
+
+// SetWinsize tries to set the specified window size for the specified file descriptor.
+func SetWinsize(fd uintptr, ws *Winsize) error {
+	uws := &unix.Winsize{Row: ws.Height, Col: ws.Width, Xpixel: ws.x, Ypixel: ws.y}
+	return unix.IoctlSetWinsize(int(fd), unix.TIOCSWINSZ, uws)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -762,6 +762,12 @@
 			"revisionTime": "2018-06-06T04:43:31Z"
 		},
 		{
+			"checksumSHA1": "E6YGk+mLX+kID6fxKWNN6gbH6eg=",
+			"path": "github.com/docker/docker/pkg/term",
+			"revision": "fd2f2a919e392b96de74795ae9af2dc5e510bc4c",
+			"revisionTime": "2018-06-06T04:43:31Z"
+		},
+		{
 			"checksumSHA1": "1IPGX6/BnX7QN4DjbBk0UafTB2U=",
 			"path": "github.com/docker/go-connections/nat",
 			"revision": "7395e3f8aa162843a74ed6d48e79627d9792ac55",


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
`pouch run` did't support `--detach-keys`

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2221

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)


### Ⅳ. Describe how to verify it
```
$ pouch run -it --detach-keys="ctrl-x" busybox
```

### Ⅴ. Special notes for reviews
It seems that pouch lacks a unified detach mechanism to capture custom detach keys. The following commands will be affected:
- pouch run 
- pouch exec
- pouch start

I will submit a series of pr to solve them later.