### PR TITLE
fix(kata): use `vm` other than `runv` as annotations

### DIFF
--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -76,10 +76,10 @@ const (
 	networkNotReadyReason = "NetworkPluginNotReady"
 
 	// passthruKey to specify whether a interface is passthru to qemu
-	passthruKey = "io.alibaba.pouch.runv.passthru"
+	passthruKey = "io.alibaba.pouch.vm.passthru"
 
 	// passthruIP is the IP for container
-	passthruIP = "io.alibaba.pouch.runv.passthru.ip"
+	passthruIP = "io.alibaba.pouch.vm.passthru.ip"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: flyer103 flyer103@gmail.com

### Ⅰ. Describe what this PR did

Kata and RunV are two different hypervisor-based runtimes. Use a
more general name as annotations.

### Ⅱ. Does this pull request fix one issue?
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

Discussed in https://github.com/alibaba/pouch/pull/2437