### PR TITLE
ci: add deadcode checking in gometalinter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,11 @@ jobs:
           name: validate go code with gometalinter
           command: |
             gometalinter --disable-all --skip vendor -E gofmt -E goimports -E golint -E ineffassign -E misspell -E vet -E megacheck ./...
+      
+      - run:
+          name: detect deadcode without test folder
+          command: |
+            gometalinter --disable-all --skip vendor --skip test -E deadcode ./...
 
 notify:
   webhooks:

--- a/ctrd/utils.go
+++ b/ctrd/utils.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
@@ -75,18 +74,6 @@ func resolver(authConfig *types.AuthConfig) (remotes.Resolver, error) {
 	}
 
 	return docker.NewResolver(options), nil
-}
-
-// rootFSToAPIType transfer the rootfs from OCI format to Pouch format.
-func rootFSToAPIType(rootFs *v1.RootFS) types.ImageInfoRootFS {
-	var layers []string
-	for _, l := range rootFs.DiffIDs {
-		layers = append(layers, l.String())
-	}
-	return types.ImageInfoRootFS{
-		Type:   rootFs.Type,
-		Layers: layers,
-	}
 }
 
 // toLinuxResources transfers Pouch Resources to LinuxResources.


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Since https://github.com/alibaba/pouch/pull/2426 has been merged, then we could add deadcode checking in gometalinter CIs.

If we directly use the following command without `--skip test`,
```
gometalinter --disable-all --skip vendor  -E deadcode ./...
```

It will show result like
```
test/util_api.go:34:1:warning: CreateBusyboxContainerOk is unused (deadcode)
test/util_api.go:68:1:warning: CreateBusybox125Container is unused (deadcode)
test/util_api.go:85:1:warning: StartContainerOk is unused (deadcode)
test/util_api.go:94:1:warning: StopContainerOk is unused (deadcode)
test/util_api.go:103:1:warning: CheckContainerStatus is unused (deadcode)
test/util_api.go:115:1:warning: CheckContainerRunning is unused (deadcode)
test/util_api.go:136:1:warning: PauseContainerOk is unused (deadcode)
test/util_api.go:145:1:warning: UnpauseContainerOk is unused (deadcode)
test/util_api.go:153:1:warning: DelContainerForceMultyTime is unused (deadcode)
```
But the function `CreateBusyboxContainerOk` and so on is not deadcode at all. We checked that in test code. So, I am wondering if tool `deadcode` does not work well in `test` directory.

So I add `--skip test`.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none, but related with https://github.com/alibaba/pouch/issues/2423.


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no need


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

