### PR TITLE
bugfix: use netNSPath dynamically

### DIFF
--- a/cri/v1alpha2/cri_types.go
+++ b/cri/v1alpha2/cri_types.go
@@ -12,16 +12,13 @@ type SandboxMeta struct {
 	// Config is CRI sandbox config.
 	Config *runtime.PodSandboxConfig
 
-	// NetNSPath is the network namespace used by the sandbox.
-	NetNSPath string
-
 	// Runtime is the runtime of sandbox
 	Runtime string
 
 	// Runtime whether to enable lxcfs for a container
 	LxcfsEnabled bool
 
-	// Netns is the sandbox's network namespace
+	// NetNS is the sandbox's network namespace
 	NetNS string
 }
 

--- a/cri/v1alpha2/cri_utils.go
+++ b/cri/v1alpha2/cri_utils.go
@@ -455,28 +455,23 @@ func setupSandboxFiles(sandboxRootDir string, config *runtime.PodSandboxConfig) 
 
 // setupPodNetwork sets up the network of PodSandbox and return the netnsPath of PodSandbox
 // and do nothing when networkNamespaceMode equals runtime.NamespaceMode_NODE.
-func (c *CriManager) setupPodNetwork(ctx context.Context, id string, config *runtime.PodSandboxConfig) (string, error) {
+func (c *CriManager) setupPodNetwork(ctx context.Context, id string, config *runtime.PodSandboxConfig) error {
 	container, err := c.ContainerMgr.Get(ctx, id)
 	if err != nil {
-		return "", err
+		return err
 	}
 	netnsPath := containerNetns(container)
 	if netnsPath == "" {
-		return "", fmt.Errorf("failed to find network namespace path for sandbox %q", id)
+		return fmt.Errorf("failed to find network namespace path for sandbox %q", id)
 	}
 
-	err = c.CniMgr.SetUpPodNetwork(&ocicni.PodNetwork{
+	return c.CniMgr.SetUpPodNetwork(&ocicni.PodNetwork{
 		Name:         config.GetMetadata().GetName(),
 		Namespace:    config.GetMetadata().GetNamespace(),
 		ID:           id,
 		NetNS:        netnsPath,
 		PortMappings: toCNIPortMappings(config.GetPortMappings()),
 	})
-	if err != nil {
-		return "", err
-	}
-
-	return netnsPath, nil
 }
 
 // Container related tool functions.


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
The sandbox will be stopped due to various reasons ,such as the physical machine restart, if perform delete operations at this time which will cause the failure of network IP release. The reason for this is that can't find netnspath  because the pid has changed and the cache has not been updated. Eventually leading to pod has been terminating and IP leakage.
So instead of using cache, we use container's pid to splice netnspath which will ensure that the netNSPath is correct.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


