### PR TITLE
bugfix: fix some meaningless cli option type

### DIFF
--- a/apis/opts/config/blkio.go
+++ b/apis/opts/config/blkio.go
@@ -58,7 +58,7 @@ func (w *WeightDevice) String() string {
 
 // Type implement WeightDevice as pflag.Value interface
 func (w *WeightDevice) Type() string {
-	return "value"
+	return "strings"
 }
 
 // Value returns all values as type WeightDevice
@@ -116,7 +116,7 @@ func (t *ThrottleBpsDevice) String() string {
 
 // Type implement ThrottleBpsDevice as pflag.Value interface
 func (t *ThrottleBpsDevice) Type() string {
-	return "value"
+	return "strings"
 }
 
 // Value returns all values as type ThrottleDevice
@@ -174,7 +174,7 @@ func (t *ThrottleIOpsDevice) String() string {
 
 // Type implement ThrottleIOpsDevice as pflag.Value interface
 func (t *ThrottleIOpsDevice) Type() string {
-	return "value"
+	return "strings"
 }
 
 // Value returns all values

--- a/apis/opts/config/runtime.go
+++ b/apis/opts/config/runtime.go
@@ -55,5 +55,5 @@ func (r *Runtime) String() string {
 
 // Type implement Runtime as pflag.Value interface
 func (r *Runtime) Type() string {
-	return "value"
+	return "runtime"
 }

--- a/apis/opts/config/ulimit.go
+++ b/apis/opts/config/ulimit.go
@@ -40,7 +40,7 @@ func (u *Ulimit) String() string {
 
 // Type implement Ulimit as pflag.Value interface.
 func (u *Ulimit) Type() string {
-	return "value"
+	return "ulimit"
 }
 
 // Value return ulimit values as type Ulimit


### PR DESCRIPTION
Signed-off-by: mathspanda <mathspanda826@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Some cli option type is `value`, which is meaningless.
```
# pouch cli
      --blkio-weight-device value    Block IO weight (relative device weight), need CFQ IO Scheduler enable (default [])
      --device-read-bps value        Limit read rate (bytes per second) from a device (default [])
      --device-read-iops value       Limit read rate (IO per second) from a device (default [])
      --device-write-bps value       Limit write rate (bytes per second) from a device (default [])
      --device-write-iops value      Limit write rate (IO per second) from a device (default [])
      --ulimit value                 Set container ulimit (default [])
# pouchd
      --add-runtime value                   register a OCI runtime to daemon (default [])
```
In docker:
```
# docker cli
      --device-read-bps list           Limit read rate (bytes per second) from a device (default [])
      --device-write-bps list          Limit write rate (bytes per second) to a device (default [])
      --device-read-iops list          Limit read rate (IO per second) from a device (default [])
      --device-write-iops list         Limit write rate (IO per second) to a device (default [])
      --ulimit ulimit                  Ulimit options (default [])
# dockerd
      --add-runtime runtime                     Register an additional OCI compatible runtime (default [])
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
issue #2445 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None


### Ⅳ. Describe how to verify it
```
pouch run --help
pouchd --help
```

### Ⅴ. Special notes for reviews
None

