### PR TITLE
bugfix: change build.sh to build_linux.sh in hack/install/install_cni.sh

### DIFF
--- a/hack/install/install_cni.sh
+++ b/hack/install/install_cni.sh
@@ -23,7 +23,7 @@ cni::install_cni() {
   go get -u -d "${pkg}"/...
 
   # build and copy into /opt/cni/bin
-  "${workdir}"/build.sh
+  "${workdir}"/build_linux.sh
   mkdir -p /etc/cni/net.d /opt/cni/bin
   cp "${workdir}"/bin/* /opt/cni/bin
 


### PR DESCRIPTION
Signed-off-by: mathspanda <mathspanda826@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
build.sh in https://github.com/containernetworking/plugins has been split into build_linux.sh and build_windows.sh. Corresponding changes should be made in [hack/install/install_cni.sh](https://github.com/alibaba/pouch/blob/master/hack/install/install_cni.sh#L26), or latest ci will fail.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None


### Ⅳ. Describe how to verify it
ci pass

### Ⅴ. Special notes for reviews
None

