### PR TITLE
bugfix: use a fixed version of cni instead of the branch of master

### DIFF
--- a/hack/install/install_cni.sh
+++ b/hack/install/install_cni.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+CNI_VERSION=v0.7
+
 # keep the first one only
 GOPATH="${GOPATH%%:*}"
 
@@ -20,7 +22,14 @@ cni::install_cni() {
   workdir="${GOPATH}/src/${pkg}"
 
   # downloads github.com/containernetworking/plugins
-  go get -u -d "${pkg}"/...
+  if [ ! -d "${workdir}" ]; then
+    mkdir -p "${workdir}"
+    cd "${workdir}"
+    git clone https://${pkg}.git .
+  fi
+  cd "${workdir}"
+  git fetch --all
+  git checkout "${CNI_VERSION}"
 
   # build and copy into /opt/cni/bin
   "${workdir}"/build.sh


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
We use the master branch of `containernetworking/plugins` when install cni , with this PR https://github.com/containernetworking/plugins/pull/219 submitted, we got error info when running the test about cri
```
install cni...
hack/install/install_cni.sh: line 26: /home/travis/gopath/src/github.com/containernetworking/plugins/build.sh: No such file or directory
make: *** [cri-v1alpha1-test] Error 1
```
It's so not make sense. We should fix the version that we use instead of relying heavily on the latest Pull Request and upgrade the version manually when we need it.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


