### PR TITLE
cni: fix plugin build failure

### DIFF
--- a/hack/install/install_cni.sh
+++ b/hack/install/install_cni.sh
@@ -23,7 +23,7 @@ cni::install_cni() {
   go get -u -d "${pkg}"/...
 
   # build and copy into /opt/cni/bin
-  "${workdir}"/build.sh
+  "${workdir}"/build_linux.sh
   mkdir -p /etc/cni/net.d /opt/cni/bin
   cp "${workdir}"/bin/* /opt/cni/bin
 


### PR DESCRIPTION
Recently, there is change for upstream plugins project of containernetworking,
the original build.sh is splitted into two OS-specific scripts build_linux.sh
and build_windows.sh, this patch will synchronize this change and make cni
plugin build happy.

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


