### PR TITLE
bugfix: fix images filter when show multi-tag images

### DIFF
--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -196,6 +196,7 @@ func (mgr *ImageManager) ListImages(ctx context.Context, filter filters.Args) ([
 
 	beforeImages := filter.Get("before")
 	sinceImages := filter.Get("since")
+	referenceFilter := filter.Get("reference")
 
 	// refuse undefined behavior
 	if len(beforeImages) > 1 {
@@ -249,35 +250,32 @@ func (mgr *ImageManager) ListImages(ctx context.Context, filter filters.Args) ([
 			}
 		}
 
-		if filter.Contains("reference") {
-			var found bool
-			referenceFilters := filter.Get("reference")
-			for _, ref := range mgr.localStore.GetReferences(img.ID) {
-				for _, pattern := range referenceFilters {
-					matched, err := filters.FamiliarMatch(pattern, ref.String())
-					if err != nil {
-						return nil, err
-					}
-					if matched {
-						found = true
-						break
-					}
-				}
-				if found {
-					break
-				}
-			}
-			if !found {
-				continue
-			}
-		}
-
 		imgInfo, err := mgr.containerdImageToImageInfo(ctx, img.ID)
 		if err != nil {
 			logrus.Warnf("failed to convert containerd image(%v) to ImageInfo during list images: %v", img.ID, err)
 			continue
 		}
-		imgInfos = append(imgInfos, imgInfo)
+
+		if len(referenceFilter) == 0 {
+			imgInfos = append(imgInfos, imgInfo)
+			continue
+		}
+
+		// do reference filter
+		imgInfo.RepoDigests, err = filterReference(referenceFilter, imgInfo.RepoDigests)
+		if err != nil {
+			return []types.ImageInfo{}, err
+		}
+
+		imgInfo.RepoTags, err = filterReference(referenceFilter, imgInfo.RepoTags)
+		if err != nil {
+			return []types.ImageInfo{}, err
+		}
+
+		if len(imgInfo.RepoTags) > 0 || len(imgInfo.RepoDigests) > 0 {
+			imgInfos = append(imgInfos, imgInfo)
+		}
+
 	}
 	return imgInfos, nil
 }
@@ -712,4 +710,27 @@ func parseTagReference(targetTag string) (reference.Named, error) {
 	}
 
 	return reference.WithDefaultTagIfMissing(ref), nil
+}
+
+func filterReference(filter, ref []string) ([]string, error) {
+	if len(filter) == 0 {
+		return ref, nil
+	}
+
+	var err error
+	filteredRefs := make([]string, 0)
+	for _, ref := range ref {
+		var found bool
+		for _, pattern := range filter {
+			found, err = filters.FamiliarMatch(pattern, ref)
+			if err != nil {
+				return []string{}, err
+			}
+			if found {
+				filteredRefs = append(filteredRefs, ref)
+				break
+			}
+		}
+	}
+	return filteredRefs, nil
 }

--- a/test/api_image_list_test.go
+++ b/test/api_image_list_test.go
@@ -61,7 +61,6 @@ func (suite *APIImageListSuite) TestImageListDigest(c *check.C) {
 func (suite *APIImageListSuite) TestImageListFilter(c *check.C) {
 	q := url.Values{}
 
-	repoDigest := environment.BusyboxRepo + "@" + environment.BusyboxDigest
 	repoTag := environment.BusyboxRepo + ":" + environment.BusyboxTag
 
 	f := filters.NewArgs()
@@ -88,7 +87,6 @@ func (suite *APIImageListSuite) TestImageListFilter(c *check.C) {
 	c.Assert(got[0].Size, check.NotNil)
 	c.Assert(got[0].Os, check.NotNil)
 	c.Assert(reflect.DeepEqual(got[0].RepoTags, []string{repoTag}), check.Equals, true)
-	c.Assert(reflect.DeepEqual(got[0].RepoDigests, []string{repoDigest}), check.Equals, true)
 }
 
 // TestImageListInvalidFilter tests listing images with invalid filter.


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
In current impl, when pouch images filter occur multi-tag images, the result will include all images ref, since there image id was same. For example

```
$ pouch images
IMAGE ID       IMAGE NAME                                          SIZE
8c811b4aec35   registry.hub.docker.com/library/pouch:test          710.81 KB
8c811b4aec35   registry.hub.docker.com/library/busybox:1.28        710.81 KB
4ab4c602aa5e   registry.hub.docker.com/library/hello-world:linux   5.25 KB

```
```
$ pouch images -f reference=registry.hub.docker.com/library/busybox:* 
IMAGE ID       IMAGE NAME                                     SIZE
8c811b4aec35   registry.hub.docker.com/library/busybox:1.28   710.81 KB
8c811b4aec35   registry.hub.docker.com/library/pouch:test          710.81 KB
```
It's was not accurate. 
This pr will fix it.
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
None.


### Ⅳ. Describe how to verify it
```
$ pouch images
IMAGE ID       IMAGE NAME                                          SIZE
8c811b4aec35   registry.hub.docker.com/library/pouch:test          710.81 KB
8c811b4aec35   registry.hub.docker.com/library/busybox:1.28        710.81 KB
4ab4c602aa5e   registry.hub.docker.com/library/hello-world:linux   5.25 KB

```
```
$ pouch images -f reference=registry.hub.docker.com/library/busybox:* 
IMAGE ID       IMAGE NAME                                     SIZE
8c811b4aec35   registry.hub.docker.com/library/busybox:1.28   710.81 KB
```

### Ⅴ. Special notes for reviews
None.

