### PR TITLE
feature: add support for maximum log size and max number of log files

### DIFF
--- a/daemon/logger/jsonfile/jsonfile.go
+++ b/daemon/logger/jsonfile/jsonfile.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 
 	"github.com/alibaba/pouch/daemon/logger"
+	"github.com/alibaba/pouch/pkg/bytefmt"
 )
 
 var jsonFilePathName = "json.log"
@@ -23,6 +25,9 @@ type JSONLogFile struct {
 	perms       os.FileMode
 	closed      bool
 	marshalFunc MarshalFunc
+	maxSize     uint64 // maximum size of log in byte
+	currentSize uint64 // current size of the latest log in byte
+	maxFile     int    // maximum number of logs
 }
 
 // Init initializes the jsonfile log driver.
@@ -47,16 +52,44 @@ func Init(info logger.Info) (logger.LogDriver, error) {
 		}
 	}
 
-	return NewJSONLogFile(logPath, 0644, func(msg *logger.LogMessage) ([]byte, error) {
+	return NewJSONLogFile(logPath, 0644, info.LogConfig, func(msg *logger.LogMessage) ([]byte, error) {
 		return Marshal(msg, extra)
 	})
 }
 
 // NewJSONLogFile returns new JSONLogFile instance.
-func NewJSONLogFile(logPath string, perms os.FileMode, marshalFunc MarshalFunc) (*JSONLogFile, error) {
+func NewJSONLogFile(logPath string, perms os.FileMode, logConfig map[string]string, marshalFunc MarshalFunc) (*JSONLogFile, error) {
+	var (
+		currentSize uint64
+		maxSize     uint64
+		maxFiles    = 1
+	)
 	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, perms)
 	if err != nil {
 		return nil, err
+	}
+
+	if logConfig != nil {
+		size, err := f.Seek(0, os.SEEK_END)
+		if err != nil {
+			return nil, err
+		}
+		currentSize = uint64(size)
+		if maxSizeString, ok := logConfig["max-size"]; ok {
+			maxSize, err = bytefmt.ToBytes(maxSizeString)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if maxFileString, ok := logConfig["max-file"]; ok {
+			maxFiles, err = strconv.Atoi(maxFileString)
+			if err != nil {
+				return nil, err
+			}
+			if maxFiles < 1 {
+				return nil, fmt.Errorf("max-file cannot be less than 1")
+			}
+		}
 	}
 
 	return &JSONLogFile{
@@ -64,6 +97,9 @@ func NewJSONLogFile(logPath string, perms os.FileMode, marshalFunc MarshalFunc) 
 		perms:       perms,
 		closed:      false,
 		marshalFunc: marshalFunc,
+		maxSize:     maxSize,
+		currentSize: currentSize,
+		maxFile:     maxFiles,
 	}, nil
 }
 
@@ -81,8 +117,61 @@ func (lf *JSONLogFile) WriteLogMessage(msg *logger.LogMessage) error {
 
 	lf.mu.Lock()
 	defer lf.mu.Unlock()
-	_, err = lf.f.Write(b)
+	if err = lf.checkRotate(); err != nil {
+		return err
+	}
+
+	n, err := lf.f.Write(b)
+	if err == nil {
+		lf.currentSize += uint64(n)
+	}
 	return err
+}
+
+// checkRotate rotates logs according to maxSize and maxFile parameters
+// TODO: after rotating logs, a notice should be made to the log reader
+func (lf *JSONLogFile) checkRotate() error {
+	if lf.maxSize == 0 || lf.maxFile < 2 || lf.currentSize < lf.maxSize {
+		// no need to rotate
+		return nil
+	}
+
+	logName := lf.f.Name()
+	// step1. close current log file
+	if err := lf.f.Close(); err != nil {
+		return err
+	}
+	// step2. rotate logs. move x.log.(n-1) to x.log.n
+	if err := rotate(logName, lf.maxFile); err != nil {
+		return err
+	}
+	// step3. reopen new log file with the same name
+	newfile, err := os.OpenFile(logName, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	lf.f = newfile
+	lf.currentSize = 0
+
+	return nil
+}
+
+func rotate(logName string, maxFiles int) error {
+	if maxFiles < 2 {
+		return nil
+	}
+	for i := maxFiles - 1; i > 1; i-- {
+		newName := logName + "." + strconv.Itoa(i)
+		oldName := logName + "." + strconv.Itoa(i-1)
+		if err := os.Rename(oldName, newName); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	if err := os.Rename(logName, logName+".1"); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 // Close closes the file.

--- a/daemon/logger/jsonfile/jsonfile_read_test.go
+++ b/daemon/logger/jsonfile/jsonfile_read_test.go
@@ -17,7 +17,7 @@ func TestReadLogMessagesWithRemoveFileInFollowMode(t *testing.T) {
 	defer f.Close()
 	defer os.RemoveAll(f.Name())
 
-	jf, err := NewJSONLogFile(f.Name(), 0640, nil)
+	jf, err := NewJSONLogFile(f.Name(), 0640, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error during create JSONLogFile: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestReadLogMessagesForEmptyFileWithoutFollow(t *testing.T) {
 	defer f.Close()
 	defer os.RemoveAll(f.Name())
 
-	jf, err := NewJSONLogFile(f.Name(), 0644, nil)
+	jf, err := NewJSONLogFile(f.Name(), 0644, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error during create JSONLogFile: %v", err)
 	}

--- a/daemon/mgr/container_logs.go
+++ b/daemon/mgr/container_logs.go
@@ -50,7 +50,7 @@ func (mgr *ContainerManager) Logs(ctx context.Context, name string, logOpt *type
 
 	fileName := filepath.Join(mgr.Store.Path(c.ID), "json.log")
 
-	jf, err := jsonfile.NewJSONLogFile(fileName, 0640, nil)
+	jf, err := jsonfile.NewJSONLogFile(fileName, 0640, nil, nil)
 
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
Add max-size and max-file flags followed by --log-opt in pouchd.
Example:
  pouchd --log-opt max-size=100m --log-opt max-file=5
This will rotate container log when its size exceeds 100Mb, and
it is saved in 5 log files at most.
Note that max-size and max-file flags are only supported in jsonfile
driver.

Signed-off-by: Wangrui <baijia.wr@antfin.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add two flags max-size and max-file followed by --log-opt to support container log rotate.
Only support jsonfile driver.

Add max-size and max-file flags followed by --log-opt in pouchd.
Example:
```
pouchd --log-opt max-size=100m --log-opt max-file=5
```
This will rotate container log when its size exceeds 100Mb, and it is saved in 5 log files at most.
Note that max-size and max-file flags are only supported in jsonfile driver.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2177 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Now some test cases are done manually.
Test code is absent. It's welcome and a "TODO" work.


### Ⅳ. Describe how to verify it
step1. launch pouchd with max-size and max-file flags
```
 pouchd --log-opt max-size=10k --log-opt max-file=2
```
step2. run a container which could write stdout to its log
```
 pouch run docker.io/library/busybox:latest top
```
step3. check container log is rotated

### Ⅴ. Special notes for reviews


