### PR TITLE
bugfix: fix incorrect mountpoint size if running container with tmpfs volume

### DIFF
--- a/storage/volume/modules/tmpfs/tmpfs.go
+++ b/storage/volume/modules/tmpfs/tmpfs.go
@@ -98,7 +98,7 @@ func (p *Tmpfs) Attach(ctx driver.Context, v *types.Volume) error {
 	reqID := v.Option("reqID")
 
 	size := v.Size()
-	sizeInt, err := bytefmt.ToKilobytes(size)
+	sizeInt, err := bytefmt.ToBytes(size)
 	if err != nil {
 		return err
 	}

--- a/test/cli_run_volume_test.go
+++ b/test/cli_run_volume_test.go
@@ -64,6 +64,24 @@ func (suite *PouchRunVolumeSuite) TestRunWithLocalVolume(c *check.C) {
 		DefaultVolumeMountPath+"/"+funcname+"/test").Assert(c, icmd.Success)
 }
 
+// TestRunWithTmpFSVolume tests running container with tmpfs volume.
+func (suite *PouchRunVolumeSuite) TestRunWithTmpFSVolume(c *check.C) {
+	cname := "TestRunWithTmpfsVolume"
+
+	command.PouchRun("volume", "create", "--name", cname, "--driver", "tmpfs",
+		"-o", "opt.size=1m").Assert(c, icmd.Success)
+	defer func() {
+		command.PouchRun("volume", "rm", cname).Assert(c, icmd.Success)
+	}()
+
+	res := command.PouchRun("run", "-v", cname+":/opt", "--name", cname,
+		busyboxImage, "df", "-h", "/opt")
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
+
+	c.Assert(strings.Contains(res.Stdout(), "1.0M"), check.Equals, true)
+}
+
 // TestRunWithHostFileVolume tests binding a host file as a volume into container.
 // fixes https://github.com/alibaba/pouch/issues/813
 func (suite *PouchRunVolumeSuite) TestRunWithHostFileVolume(c *check.C) {


### PR DESCRIPTION
Signed-off-by: mathspanda <mathspanda826@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Fix  incorrect mountpoint size if running container attached with tmpfs volume.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Issue #2475 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Added.


### Ⅳ. Describe how to verify it
```
root@lin-dev-vm:~# pouch volume create --name tmpfsv --driver tmpfs -o opt.size=1m
Status:       map[opt.size:1m size:1048576]
CreatedAt:    2018-11-20 20:57:36
Driver:       tmpfs
Labels:       map[]
Mountpoint:   /mnt/tmpfs/tmpfsv
Name:         tmpfsv
Scope:
root@lin-dev-vm:~# pouch run -v tmpfsv:/opt busybox mount | grep /opt
shm on /opt type tmpfs (rw,nosuid,nodev,noexec,relatime,size=1024k)
```

### Ⅴ. Special notes for reviews
None
