### PR TITLE
circleci: disable megacheck since it consumes more memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,12 @@ jobs:
       - run: 
           name: validate go code with gometalinter
           command: |
-            gometalinter --disable-all --skip vendor -E gofmt -E goimports -E golint -E goconst -E ineffassign -E misspell -E vet -E megacheck ./...
+            gometalinter --disable-all --skip vendor -E gofmt -E goimports -E golint -E goconst -E ineffassign -E misspell -E vet -d ./...
       
       - run:
           name: detect deadcode without test folder
           command: |
-            gometalinter --disable-all --skip vendor --skip test -E deadcode ./...
+            gometalinter --disable-all --skip vendor --skip test -E deadcode -d ./...
 
 notify:
   webhooks:


### PR DESCRIPTION
Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

The megacheck will consume more memory than 4GB. But the circleci limits
container with 4GB and 2CPU.

We can't add the checker into travis-job since there are so many jobs
here. For now, I want to remove this check.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no need

### Ⅳ. Describe how to verify it

if we open the megacheck, we got more than 4GB.
```
$ /usr/bin/time -v gometalinter --disable-all --skip vendor -E gofmt -E goimports -E golint -E goconst -E ineffassign -E misspell -E vet -E megacheck  ./...

Command exited with non-zero status 1
        Command being timed: "gometalinter --disable-all --skip vendor -E gofmt -E goimports -E golint -E goconst -E ineffassign -E misspell -E vet -E megacheck ./..."
        User time (seconds): 78.09
        System time (seconds): 8.96
        Percent of CPU this job got: 132%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:05.73
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 4730768 <--------------
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 2246232
        Voluntary context switches: 35134
        Involuntary context switches: 20155
        Swaps: 0
        File system inputs: 0
        File system outputs: 3656
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 1
```

But if we disable it, we only need 50MB.

```
# vagrant @ ubuntu-xenial in ~/go/src/github.com/alibaba/pouch on git:testing o [16:39:12] C:1
$ /usr/bin/time -v gometalinter --disable-all --skip vendor -E gofmt -E goimports -E golint -E goconst -E ineffassign -E misspell -E vet ./...
        Command being timed: "gometalinter --disable-all --skip vendor -E gofmt -E goimports -E golint -E goconst -E ineffassign -E misspell -E vet ./..."
        User time (seconds): 18.87
        System time (seconds): 2.23
        Percent of CPU this job got: 228%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:09.22
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 50396 <-------- LOL
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 343382
        Voluntary context switches: 19837
        Involuntary context switches: 12216
        Swaps: 0
        File system inputs: 0
        File system outputs: 1136
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

### Ⅴ. Special notes for reviews

add `-d` to show the detail in console
