### PR TITLE
fix indentation and typo in command help description

### DIFF
--- a/cli/events.go
+++ b/cli/events.go
@@ -18,7 +18,7 @@ import (
 )
 
 // eventsDescription is used to describe events command in detail and auto generate command doc.
-var eventsDescription = "events cli tool is used to subscribe pouchd events." +
+var eventsDescription = "events cli tool is used to subscribe pouchd events. " +
 	"We support filter parameter to filter some events that we care about or not."
 
 // EventsCommand use to implement 'events' command.

--- a/cli/image_list.go
+++ b/cli/image_list.go
@@ -14,8 +14,8 @@ import (
 )
 
 // imagesDescription is used to describe image command in detail and auto generate command doc.
-var imagesDescription = "List all images in Pouchd." +
-	"This is useful when you wish to have a look at images and Pouchd will show all local images with their NAME and SIZE." +
+var imagesDescription = "List all images in Pouchd. " +
+	"This is useful when you wish to have a look at images and Pouchd will show all local images with their NAME and SIZE. " +
 	"All local images will be shown in a table format you can use."
 
 type imageSize int64

--- a/cli/info.go
+++ b/cli/info.go
@@ -13,7 +13,7 @@ import (
 
 // infoDespscription is used to describe info command in detail and auto generate command doc.
 var infoDescription = "Display the information of pouch, " +
-	"including Containers, Images, Storage Driver, Execution Driver, Logging Driver, Kernel Version," +
+	"including Containers, Images, Storage Driver, Execution Driver, Logging Driver, Kernel Version, " +
 	"Operating System, CPUs, Total Memory, Name, ID."
 
 // InfoCommand use to implement 'info' command.

--- a/cli/pause.go
+++ b/cli/pause.go
@@ -11,8 +11,8 @@ import (
 
 // pauseDescription is used to describe pause command in detail and auto generate command doc.
 var pauseDescription = "Pause one or more running containers in Pouchd. " +
-	"when pausing, the container will pause its running but hold all the relevant resource." +
-	"This is useful when you wish to pause a container for a while and to restore the running status later." +
+	"when pausing, the container will pause its running but hold all the relevant resource. " +
+	"This is useful when you wish to pause a container for a while and to restore the running status later. " +
 	"The container you paused will pause without being terminated."
 
 // PauseCommand use to implement 'pause' command, it pauses one or more containers.

--- a/cli/rmi.go
+++ b/cli/rmi.go
@@ -10,7 +10,7 @@ import (
 )
 
 var rmiDescription = "Remove one or more images by reference." +
-	"When the image is being used by a container, you must specify -f to delete it." +
+	"When the image is being used by a container, you must specify -f to delete it. " +
 	"But it is strongly discouraged, because the container will be in abnormal status."
 
 // RmiCommand use to implement 'rmi' command, it remove one or more images by reference

--- a/cli/start.go
+++ b/cli/start.go
@@ -16,7 +16,7 @@ import (
 
 // startDescription is used to describe start command in detail and auto generate command doc.
 var startDescription = "Start one or more created container objects in Pouchd. " +
-	"When starting, the relevant resource preserved during creating period comes into use." +
+	"When starting, the relevant resource preserved during creating period comes into use. " +
 	"This is useful when you wish to start a container which has been created in advance." +
 	"The container you started will be running if no error occurs."
 

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -11,7 +11,7 @@ import (
 )
 
 // stopDescription is used to describe stop command in detail and auto generate command doc.
-var stopDescription = "Stop one or more running containers in Pouchd. Waiting the given number of seconds before forcefully killing the container." +
+var stopDescription = "Stop one or more running containers in Pouchd. Waiting the given number of seconds before forcefully killing the container. " +
 	"This is useful when you wish to stop a container. And Pouchd will stop this running container and release the resource. " +
 	"The container that you stopped will be terminated. "
 

--- a/cli/top.go
+++ b/cli/top.go
@@ -11,7 +11,7 @@ import (
 )
 
 // topDescription
-var topDescription = "top command is to display the running processes of a container." +
+var topDescription = "top command is to display the running processes of a container. " +
 	"You can add options just like using Linux ps command."
 
 // TopCommand use to implement 'top' command, it displays all processes in a container.

--- a/cli/unpause.go
+++ b/cli/unpause.go
@@ -11,7 +11,7 @@ import (
 
 // unpauseDescription is used to describe unpause command in detail and auto generate command doc.
 var unpauseDescription = "Unpause one or more paused containers in Pouchd. " +
-	"when unpausing, the paused container will resumes the process execution within the container." +
+	"when unpausing, the paused container will resumes the process execution within the container. " +
 	"The container you unpaused will be running again if no error occurs."
 
 // UnpauseCommand use to implement 'unpause' command, it unpauses one or more containers.

--- a/cli/update_daemon.go
+++ b/cli/update_daemon.go
@@ -18,7 +18,7 @@ import (
 // daemonUpdateDescription is used to describe updatedaemon command in detail and auto generate command doc.
 var daemonUpdateDescription = "Update daemon's configurations, if daemon is stoped, it will just update config file. " +
 	"Online update just including: image proxy, label, offline update including: manager white list, debug level, " +
-	"execute root directory, bridge name, bridge IP, fixed CIDR, defaut gateway, iptables, ipforwark, userland proxy" +
+	"execute root directory, bridge name, bridge IP, fixed CIDR, defaut gateway, iptables, ipforwark, userland proxy. " +
 	"If pouchd is alive, you can only use --offline=true to update config file"
 
 // DaemonUpdateCommand use to implement 'updatedaemon' command, it modifies the configurations of a container.

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -11,9 +11,9 @@ import (
 )
 
 // upgradeDescription is used to describe upgrade command in detail and auto generate command doc.
-var upgradeDescription = "upgrade is a feature to replace a container's image." +
-	"You can specify the new Entrypoint and Cmd for the new container. When you want to update" +
-	"a container's image, but inherit the network and volumes of the old container, then you should" +
+var upgradeDescription = "upgrade is a feature to replace a container's image. " +
+	"You can specify the new Entrypoint and Cmd for the new container. When you want to update " +
+	"a container's image, but inherit the network and volumes of the old container, then you should " +
 	"think about the upgrade feature."
 
 // UpgradeCommand use to implement 'upgrade' command, it is used to upgrade a container.
@@ -90,5 +90,5 @@ func upgradeExample() string {
 	return ` $ pouch run -d -m 20m --name test  registry.hub.docker.com/library/busybox:latest
 4c58d27f58d38776dda31c01c897bbf554c802a9b80ae4dc20be1337f8a969f2
 $ pouch upgrade --image registry.hub.docker.com/library/hello-world:latest test
-test1`
+test`
 }


### PR DESCRIPTION
Signed-off-by: Wang Rui <baijia.wr@antfin.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Fix indentation and typo in command line help description,  such as "pouch upgrade --help"

> [root@acs-test3 ~]# pouch upgrade --help
> upgrade is a feature to replace a container's image.You can specify the new Entrypoint and Cmd for the new container. When you want to **updatea** container's image, but inherit the network and volumes of the old container, then you **shouldthink** about the upgrade feature.

This patch will also fix the command line docs (docs/commandline/*.md) because the docs are auto generated.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


