### PR TITLE
bugfix: generate sandboxId to be stored advanced

### DIFF
--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"reflect"
 	goruntime "runtime"
-	"strconv"
 	"time"
 
 	"github.com/alibaba/pouch/apis/filters"
@@ -244,34 +243,50 @@ func (c *CriManager) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	}
 
 	// Step 2: Create the sandbox container.
+
+	// prepare the sandboxID and store it.
+	id, err := c.generateSandboxID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sandboxMeta := &SandboxMeta{
+		ID: id,
+	}
+	if err := c.SandboxStore.Put(sandboxMeta); err != nil {
+		return nil, err
+	}
+
+	// If running sandbox failed, clean up the sandboxMeta from sandboxStore.
+	// We should clean it until the container has been removed successfully by Pouchd.
+	removeContainerErr := false
+	defer func() {
+		if retErr != nil && !removeContainerErr {
+			if err := c.SandboxStore.Remove(id); err != nil {
+				logrus.Errorf("failed to remove the metadata of container %q from sandboxStore: %v", id, err)
+			}
+		}
+	}()
+
+	// applies the annotations extended.
+	if err := c.applySandboxAnnotations(sandboxMeta, config.Annotations); err != nil {
+		return nil, err
+	}
+
 	createConfig, err := makeSandboxPouchConfig(config, image)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make sandbox pouch config for pod %q: %v", config.Metadata.Name, err)
 	}
+	createConfig.SpecificID = id
 
 	sandboxName := makeSandboxName(config)
 
-	createResp, err := c.ContainerMgr.Create(ctx, sandboxName, createConfig)
+	_, err = c.ContainerMgr.Create(ctx, sandboxName, createConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a sandbox for pod %q: %v", config.Metadata.Name, err)
 	}
-	id := createResp.ID
 
 	// once sandbox container created, we are obligated to store it.
-	sandboxMeta := &SandboxMeta{
-		ID:      id,
-		Config:  config,
-		Runtime: config.Annotations[anno.KubernetesRuntime],
-	}
-
-	if _, ok := config.Annotations[anno.LxcfsEnabled]; ok {
-		enableLxcfs, err := strconv.ParseBool(config.Annotations[anno.LxcfsEnabled])
-		if err != nil {
-			return nil, err
-		}
-		sandboxMeta.LxcfsEnabled = enableLxcfs
-	}
-
+	sandboxMeta.Config = config
 	if err := c.SandboxStore.Put(sandboxMeta); err != nil {
 		return nil, err
 	}
@@ -280,13 +295,8 @@ func (c *CriManager) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	defer func() {
 		if retErr != nil {
 			if err := c.ContainerMgr.Remove(ctx, id, &apitypes.ContainerRemoveOptions{Volumes: true, Force: true}); err != nil {
+				removeContainerErr = true
 				logrus.Errorf("failed to remove container when running sandbox failed %q: %v", id, err)
-				return
-			}
-			// should not remove the sandbox container metadata from sandboxStore
-			// until it was removed by pouchd.
-			if err := c.SandboxStore.Remove(id); err != nil {
-				logrus.Errorf("failed to remove the metadata of container %q from sandboxStore: %v", id, err)
 			}
 		}
 	}()


### PR DESCRIPTION
Signed-off-by: Starnop <starnop@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

If we rely on the id which returned by pouchd, we must store the id of sandbox after sandboxContainer has been created, if the process exits between creating container completely and storing it, the container will not be controlled by sandboxstore. So we generate the id of sandbox container and use it to create the container. 

For generating the container id, I use the interface of  `ContainerMgr.Get` to determine if the id already exists.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

None.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


