### PR TITLE
bugfix: cleanup containerd container before do restart policy

### DIFF
--- a/ctrd/client.go
+++ b/ctrd/client.go
@@ -119,7 +119,7 @@ func (c *Client) Get(ctx context.Context) (*WrapperClient, error) {
 }
 
 // SetExitHooks specified the handlers of container exit.
-func (c *Client) SetExitHooks(hooks ...func(string, *Message) error) {
+func (c *Client) SetExitHooks(hooks ...func(string, *Message, func() error) error) {
 	c.watch.hooks = hooks
 }
 

--- a/ctrd/interface.go
+++ b/ctrd/interface.go
@@ -61,7 +61,7 @@ type ContainerAPIClient interface {
 	// UpdateResources updates the configurations of a container.
 	UpdateResources(ctx context.Context, id string, resources types.Resources) error
 	// SetExitHooks specified the handlers of container exit.
-	SetExitHooks(hooks ...func(string, *Message) error)
+	SetExitHooks(hooks ...func(string, *Message, func() error) error)
 	// SetExecExitHooks specified the handlers of exec process exit.
 	SetExecExitHooks(hooks ...func(string, *Message) error)
 	// Events subscribe containerd events through an event subscribe client.

--- a/ctrd/watch.go
+++ b/ctrd/watch.go
@@ -36,7 +36,7 @@ func (m *Message) ExitTime() time.Time {
 type watch struct {
 	sync.Mutex
 	containers map[string]*containerPack
-	hooks      []func(string, *Message) error
+	hooks      []func(string, *Message, func() error) error
 
 	// containerdDead to specify whether containerd process is dead
 	containerdDead bool
@@ -98,23 +98,31 @@ func (w *watch) add(pack *containerPack) {
 			exitTime: status.ExitTime(),
 		}
 
+		// NOTE: cleanup action should be taken only once!
+		var cleanupOnce sync.Once
+		cleanupFunc := func() error {
+			cleanupOnce.Do(func() {
+				if _, err := pack.task.Delete(context.Background()); err != nil {
+					logrus.Errorf("failed to delete task, container id: %s: %v", pack.id, err)
+				}
+
+				if err := pack.container.Delete(context.Background()); err != nil {
+					logrus.Errorf("failed to delete container, container id: %s: %v", pack.id, err)
+				}
+			})
+			return nil
+		}
+
 		if !pack.skipStopHooks {
 			for _, hook := range w.hooks {
-				if err := hook(pack.id, msg); err != nil {
+				if err := hook(pack.id, msg, cleanupFunc); err != nil {
 					logrus.Errorf("failed to execute the exit hooks: %v", err)
 					break
 				}
 			}
 		}
+		cleanupFunc()
 
-		// NOTE: we should delete task/container after update the status, for example, status code.
-		if _, err := pack.task.Delete(context.Background()); err != nil {
-			logrus.Errorf("failed to delete task, container id: %s: %v", pack.id, err)
-		}
-
-		if err := pack.container.Delete(context.Background()); err != nil {
-			logrus.Errorf("failed to delete container, container id: %s: %v", pack.id, err)
-		}
 		pack.ch <- msg
 
 	}(w, pack)

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1698,13 +1698,18 @@ func (mgr *ContainerManager) markExitedAndRelease(c *Container, m *ctrd.Message)
 
 // exitedAndRelease be register into ctrd as a callback function, when the running container suddenly
 // exited, "ctrd" will call it to set the container's state and release resouce and so on.
-func (mgr *ContainerManager) exitedAndRelease(id string, m *ctrd.Message) error {
+func (mgr *ContainerManager) exitedAndRelease(id string, m *ctrd.Message, cleanup func() error) error {
 	c, err := mgr.container(id)
 	if err != nil {
 		return err
 	}
 
 	if err := mgr.markExitedAndRelease(c, m); err != nil {
+		return err
+	}
+
+	// for example, delete containerd container/task.
+	if err := cleanup(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION

Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

If the cleanup action is taken before restart policy, the restart action
will be failed because new container keeps the same name with the old
one. We should cleanup the old one before the restart policy.

In order to make it happen, we add the cleanup function in the hooks.

> NOTE: the cleanup should be done after update status because we should make sure that all the status has been updated in the pouch container store.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no need

### Ⅳ. Describe how to verify it

Use the following command and the container should be restarted after exit.

```
sudo pouch run --restart=always -it busybox sh -c "exit 1"
```

And don't break existing case 

### Ⅴ. Special notes for reviews


