### PR TITLE
ci: update runc version to 1.0.0-rc6-1

### DIFF
--- a/hack/install/install_runc.sh
+++ b/hack/install/install_runc.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-readonly RUNC_VERSION="1.0.0-rc4-2"
+readonly RUNC_VERSION="1.0.0-rc6-1"
 
 # runc::check_version checks the command and the version.
 runc::check_version() {
@@ -53,6 +53,9 @@ main() {
   command -v runc > /dev/null
 
   echo
+
+  # test version runc
+  runc -v
 }
 
 main


### PR DESCRIPTION
update runc version used by integration test

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Now we still use a very old runc base on version `v1.0.0-rc4`, since `v1.0.0-rc6` have been released, and bring lots of feature and bufixs, so let's update runc version

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


