### PR TITLE
bugfix: delete upperDir and workDir when deleting container taken over by pouch

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1165,6 +1165,14 @@ func (mgr *ContainerManager) Remove(ctx context.Context, name string, options *t
 		if err := mount.Unmount(c.BaseFS, 0); err != nil {
 			logrus.Errorf("failed to umount rootfs when remove the container %s: %v", c.ID, err)
 		}
+
+		// Note(ziren): when deleting a container whose rootfs was provided, we also should
+		// remove the upperDir and workDir of container. because the directories cost disk
+		// space and the disk space counted into the new container that using the same
+		// disk quota id.
+		if err := c.CleanRootfsSnapshotDirs(); err != nil {
+			logrus.Errorf("failed to clean rootfs: %v", err)
+		}
 	} else if err := mgr.Client.RemoveSnapshot(ctx, c.SnapshotKey()); err != nil {
 		// if the container is created by normal method, remove the
 		// snapshot when delete it.

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -439,10 +439,11 @@ func (c *Container) FormatStatus() (string, error) {
 }
 
 // UnsetMergedDir unsets Snapshot MergedDir. Stop a container will
-// delete the containerd container, the merged dir
-// will also be deleted, so we should unset the
-// container's MergedDir.
+// delete the containerd container, the merged dir  will also be
+// deleted, so we should unset the container's MergedDir.
 func (c *Container) UnsetMergedDir() {
+	c.Lock()
+	defer c.Unlock()
 	if c.Snapshotter == nil || c.Snapshotter.Data == nil {
 		return
 	}
@@ -489,6 +490,41 @@ func (c *Container) GetSpecificBasePath(path string) string {
 	}
 
 	return ""
+}
+
+// CleanRootfsSnapshotDirs deletes container's rootfs snapshot MergedDir, UpperDir and
+// WorkDir. Since the snapshot of container created by containerd will be cleaned by
+// containerd, so we only clean rootfs that is RootFSProvided.
+func (c *Container) CleanRootfsSnapshotDirs() error {
+	// if RootFSProvided is not set or Snapshotter data empty , we no need clean the rootfs
+	if !c.RootFSProvided || c.Snapshotter == nil || c.Snapshotter.Data == nil {
+		return nil
+	}
+
+	var (
+		removeDirs []string
+	)
+
+	c.Lock()
+	for _, dir := range []string{"MergedDir", "UpperDir", "WorkDir"} {
+		if v, ok := c.Snapshotter.Data[dir]; ok {
+			removeDirs = append(removeDirs, v)
+		}
+	}
+	c.Unlock()
+
+	var errMsgs []string
+	for _, dir := range removeDirs {
+		if err := os.RemoveAll(dir); err != nil {
+			errMsgs = append(errMsgs, err.Error())
+		}
+	}
+
+	if len(errMsgs) != 0 {
+		return fmt.Errorf(strings.Join(errMsgs, "\n"))
+	}
+
+	return nil
 }
 
 // ContainerRestartPolicy represents the policy is used to manage container.


### PR DESCRIPTION
Signed-off-by: ziren.wzr <ziren.wzr@alibaba-inc.com>

### Ⅰ. Describe what this PR did

When using [d2p-migrator](https://github.com/pouchcontainer/d2p-migrator) to upgrade docker to PouchContainer, we take over the old container's network, volumes, but the snapshot of an old container is not charged by pouchd.

So when we delete the old containers, the `UpperDir` and `WorkDir` still stay on the host, they will cost many disk space.  Moreover, if the directories have disk quota id, it will make the new containers used the same disk quota id cannot use the total storage that they should.  we can make it more clear:

The old `UpperDir` that has disk quota id 1111 costs 20G disk space, if we create a new container with the same disk quota id 1111 and intend to assign 100G disk space. Since the old `UpperDir` has occupied 20G, so the new container actually just can use 80G disk space.


### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


