### PR TITLE
bugfix: Fix CopyData in Bind Mount

### DIFF
--- a/daemon/mgr/container_storage.go
+++ b/daemon/mgr/container_storage.go
@@ -207,6 +207,8 @@ func (mgr *ContainerManager) getMountPointFromBinds(ctx context.Context, c *Cont
 				mp.Named = false
 				mp.Driver = ""
 			}
+		} else {
+			mp.CopyData = false
 		}
 
 		c.Mounts = append(c.Mounts, mp)


### PR DESCRIPTION
CopyData is an action which should be enabled only in mount volumes and images.

For example:
 [root@hostname]# pouch run  -it --name test2 -v /home/baijia.wr/volume/:/var/ docker.io/library/busybox:latest ls /var/
 spool  www
 [root@hostname]# ls /home/baijia.wr/volume/
 spool  www

Without this patch, data is copied form container's dir "/var/" to host's dir "/home/baijia.wr/volume/",
that is unexpected. So CopyData should be disabled in bind mount.

Signed-off-by: Wang Rui <baijia.wr@antfin.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Data will be copied from container to host when bind mount is used, that is unexpected.
For example:
 
> [root@hostname]# pouch run  -it --name test2 -v /home/baijia.wr/volume/:/var/ docker.io/library/busybox:latest ls /var/
>  spool  www
>  [root@hostname]# ls /home/baijia.wr/volume/
>  spool  www

Data is copied form container's dir "/var/" to host's dir "/home/baijia.wr/volume/".
This patch will fix that.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
With this patch, DataCopy is disabled in bind mount.

> [root@hostname]# pouch run  -it --name test2 -v /home/baijia.wr/volume/:/var/ docker.io/library/busybox:latest ls /var/
>  [root@hostname]# ls /home/baijia.wr/volume/
>  [root@hostname]#


### Ⅴ. Special notes for reviews


