### PR TITLE
feature: fullfill network scope field in `network ls` and `inspect` 

### DIFF
--- a/cli/network.go
+++ b/cli/network.go
@@ -371,11 +371,11 @@ func (n *NetworkListCommand) runNetworkList(args []string) error {
 
 // networkListExample shows examples in network list command, and is used in auto-generated cli docs.
 func networkListExample() string {
-	return `$ pouch network ls
-NETWORK ID   NAME   DRIVER    SCOPE
-6f7aba8a58   net2   bridge
-55f134176c   net3   bridge
-e495f50913   net1   bridge
+	return `$ pouch network list
+NETWORK ID   NAME     DRIVER   SCOPE
+058fce03b8   none     null     local
+b05a9b8844   bridge   bridge   local
+d8684bf988   host     host     local
 `
 }
 

--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -48,10 +48,12 @@ func (suite *PouchNetworkSuite) TestNetworkInspectFormat(c *check.C) {
 		c.Errorf("failed to decode inspect output: %v", err)
 	}
 	networkID := network[0].ID
+	c.Assert(network[0].Name, check.Equals, "bridge")
+	c.Assert(network[0].Scope, check.Equals, "local")
 
 	// inspect network name by ID
-	output = command.PouchRun("network", "inspect", "-f", "{{.Name}}", networkID).Stdout()
-	c.Assert(output, check.Equals, "bridge\n")
+	output = command.PouchRun("network", "inspect", "-f", "Name: {{.Name}} Scope: {{.Scope}}", networkID).Stdout()
+	c.Assert(output, check.Equals, "Name: bridge Scope: local\n")
 }
 
 // TestNetworkDefault tests the creation of default bridge/none/host network.


### PR DESCRIPTION
Signed-off-by: mathspanda <mathspanda826@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Fullfill scope value returned in pouch network list/inpsect.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
issue #2501 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Added.


### Ⅳ. Describe how to verify it
``` shell
root@lin-dev-vm2:~# pouch network list
NETWORK ID   NAME     DRIVER   SCOPE
058fce03b8   none     null     local
1bae6b8af5   bridge   bridge   local
d8684bf988   host     host     local
root@lin-dev-vm2:~# pouch network inspect 1bae6b8af5
[
    {
        "Driver": "bridge",
        "IPAM": {
            "Config": [
                {
                    "Gateway": "192.168.5.1",
                    "IPRange": "192.168.5.0/24",
                    "Subnet": "192.168.5.0/24"
                }
            ],
            "Driver": "default"
        },
        "Id": "1bae6b8af52ebd87b4f8a4a7b8b08ec6a096b0acef564f2bf27560ba4baa82da",
        "Name": "bridge",
        "Options": {
            "com.docker.network.bridge.default_bridge": "true",
            "com.docker.network.bridge.enable_icc": "true",
            "com.docker.network.bridge.enable_ip_masquerade": "true",
            "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
            "com.docker.network.bridge.name": "p0",
            "com.docker.network.driver.mtu": "1500"
        },
        "Scope": "local"
    }
]
```

### Ⅴ. Special notes for reviews
None
