### PR TITLE
feature: add capabilities for exec process

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -27,6 +27,7 @@ type ExecCommand struct {
 	Detach      bool
 	User        string
 	Envs        []string
+	Privileged  bool
 }
 
 // Init initializes ExecCommand command.
@@ -54,6 +55,7 @@ func (e *ExecCommand) addFlags() {
 	flagSet.BoolVarP(&e.Interactive, "interactive", "i", false, "Open container's STDIN")
 	flagSet.StringVarP(&e.User, "user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
 	flagSet.StringArrayVarP(&e.Envs, "env", "e", []string{}, "Set environment variables")
+	flagSet.BoolVar(&e.Privileged, "privileged", false, "Give extended privileges to the exec process")
 }
 
 // runExec is the entry of ExecCommand command.
@@ -73,7 +75,7 @@ func (e *ExecCommand) runExec(args []string) error {
 		AttachStderr: !e.Detach,
 		AttachStdout: !e.Detach,
 		AttachStdin:  !e.Detach && e.Interactive,
-		Privileged:   false,
+		Privileged:   e.Privileged,
 		User:         e.User,
 		Env:          e.Envs,
 	}


### PR DESCRIPTION
add current container capabilities for exec process

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add current container capabilities for exec process
if container is created by docker and taken over by pouchd, no config.json can found under current path, runc exec is good even without these capabilities in exec process


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

add test for exec priviledged

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


