### PR TITLE
cleanup temporary test file

### DIFF
--- a/daemon/mgr/container_storage.go
+++ b/daemon/mgr/container_storage.go
@@ -207,6 +207,8 @@ func (mgr *ContainerManager) getMountPointFromBinds(ctx context.Context, c *Cont
 				mp.Named = false
 				mp.Driver = ""
 			}
+		} else {
+			mp.CopyData = false
 		}
 
 		c.Mounts = append(c.Mounts, mp)

--- a/test/cli_run_volume_test.go
+++ b/test/cli_run_volume_test.go
@@ -109,6 +109,7 @@ func (suite *PouchRunVolumeSuite) TestRunWithHostFileVolume(c *check.C) {
 	// first create a file on the host
 	filepath := "/tmp/TestRunWithHostFileVolume.md"
 	icmd.RunCommand("touch", filepath).Assert(c, icmd.Success)
+	defer icmd.RunCommand("rm", "-f", filepath)
 
 	cname := "TestRunWithHostFileVolume"
 	res := command.PouchRun("run", "-d", "--name", cname, "-v",


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Cleanup /tmp/TestRunWithHostFileVolume.md which is created in test case.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
Check /tmp/TestRunWithHostFileVolume.md file exists after running test case cli_run_volume_test.go:TestRunWithHostFileVolume .
After this patch, this file will be cleaned after the test

### Ⅴ. Special notes for reviews


