### PR TITLE
fix: volume test fails in custom version pouch

### DIFF
--- a/test/cli_run_volume_test.go
+++ b/test/cli_run_volume_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/alibaba/pouch/apis/types"
+	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
 
@@ -93,8 +94,12 @@ func (suite *PouchRunVolumeSuite) TestRunWithVolumeCopyData(c *check.C) {
 	defer DelContainerForceMultyTime(c, containerName1)
 	output1 := icmd.RunCommand("ls", DefaultVolumeMountPath+"/"+volumeName).Stdout()
 	lines := strings.Split(output1, "\n")
-	c.Assert(lines[0], check.Equals, "spool")
-	c.Assert(lines[1], check.Equals, "www")
+	if !utils.StringInSlice(lines, "spool") {
+		c.Fatalf("expected \"spool\" directory under /var directory, but got %s", output1)
+	}
+	if !utils.StringInSlice(lines, "www") {
+		c.Fatalf("expected \"www\" directory under /var directory, but got %s", output1)
+	}
 
 	command.PouchRun("run", "-t", "-v", hostdir+":/var", "--name", containerName2, busyboxImage, "ls", "/var").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, containerName2)


### PR DESCRIPTION
Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
test `TestRunWithVolumeCopyData` may fails with some custom version busybox image.

This PR make TestRunWithVolumeCopyData compatible with different situation

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


