### PR TITLE
bugfix: container can not write cgroup with privileged

### DIFF
--- a/daemon/mgr/spec_mount.go
+++ b/daemon/mgr/spec_mount.go
@@ -129,12 +129,15 @@ func setupMounts(ctx context.Context, c *Container, s *specs.Spec) error {
 	s.Mounts = sortMounts(mounts)
 
 	if c.HostConfig.Privileged {
-		if !s.Root.Readonly {
+		for i := range s.Mounts {
 			// Clear readonly for /sys.
-			for i := range s.Mounts {
-				if s.Mounts[i].Destination == "/sys" {
-					clearReadonly(&s.Mounts[i])
-				}
+			if s.Mounts[i].Destination == "/sys" && !s.Root.Readonly {
+				clearReadonly(&s.Mounts[i])
+			}
+
+			// Clear readonly for cgroup
+			if s.Mounts[i].Type == "cgroup" {
+				clearReadonly(&s.Mounts[i])
 			}
 		}
 	}


### PR DESCRIPTION
clear ro in mount option when container get privileged, make cgroup
writable, add test for it.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #2553 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

add test.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


