### PR TITLE
bugfix: can't copy data with dr mode

### DIFF
--- a/daemon/mgr/container_storage_test.go
+++ b/daemon/mgr/container_storage_test.go
@@ -1,0 +1,71 @@
+package mgr
+
+import (
+	"testing"
+
+	"github.com/alibaba/pouch/apis/types"
+)
+
+func TestSortMountPoint(t *testing.T) {
+	mounts := []*types.MountPoint{
+		{
+			Destination: "/home/admin/log",
+			Source:      "/pouch/volume1",
+		},
+		{
+			Destination: "/var/lib",
+			Source:      "/pouch/volume2",
+		},
+		{
+			Destination: "/home/admin",
+			Source:      "/pouch/volume3",
+		},
+		{
+			Destination: "/home",
+			Source:      "/pouch/volume4",
+		},
+		{
+			Destination: "/opt",
+			Source:      "/pouch/volume5",
+		},
+		{
+			Destination: "/var/log",
+			Source:      "/pouch/volume6",
+		},
+	}
+
+	expectMounts := []*types.MountPoint{
+		{
+			Destination: "/opt",
+			Source:      "/pouch/volume5",
+		},
+		{
+			Destination: "/home",
+			Source:      "/pouch/volume4",
+		},
+		{
+			Destination: "/var/lib",
+			Source:      "/pouch/volume2",
+		},
+		{
+			Destination: "/var/log",
+			Source:      "/pouch/volume6",
+		},
+		{
+			Destination: "/home/admin",
+			Source:      "/pouch/volume3",
+		},
+		{
+			Destination: "/home/admin/log",
+			Source:      "/pouch/volume1",
+		},
+	}
+
+	mounts = sortMountPoint(mounts)
+	for i := range mounts {
+		if mounts[i].Destination != expectMounts[i].Destination ||
+			mounts[i].Source != expectMounts[i].Source {
+			t.Fatalf("got unexpect sort: %v, expect: %v", *mounts[i], *expectMounts[i])
+		}
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
use volume with dr mode, can't copy image's data to parent directory
when sub-directory has copied. It causes the volume directory is not
empty, so before copy image data, it need to sort mountpoint by the
string length of destination directory.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add ut: `TestSortMountPoint`
add integration test: `TestRunCopyDataWithDR`

### Ⅳ. Describe how to verify it
run test `TestRunCopyDataWithDR` pass

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
