### PR TITLE
bugfix: do not use string to convert int64

### DIFF
--- a/cli/image_list.go
+++ b/cli/image_list.go
@@ -108,9 +108,9 @@ func (i *ImagesCommand) runImages(args []string) error {
 
 	for _, dimg := range dimgs {
 		if i.flagDigest {
-			display.AddRow([]string{dimg.id, dimg.name, dimg.digest, string(dimg.size)})
+			display.AddRow([]string{dimg.id, dimg.name, dimg.digest, dimg.size.String()})
 		} else {
-			display.AddRow([]string{dimg.id, dimg.name, string(dimg.size)})
+			display.AddRow([]string{dimg.id, dimg.name, dimg.size.String()})
 		}
 	}
 


### PR DESCRIPTION


Signed-off-by: Wei Fu <fhfuwei@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

We should use imageSize.String() instead of string(imageSize).
Otherwise, we will get messy display.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

No need.

### Ⅳ. Describe how to verify it

before fix:

```
➜  pouch git:(bugfix_image_list_display_issue) sudo pouch images
IMAGE ID       IMAGE NAME                                       SIZE
59788edf1f3e   registry.hub.docker.com/library/busybox:latest   򲸜
```
after fix:

```
➜  pouch git:(bugfix_image_list_display_issue) sudo pouch images
IMAGE ID       IMAGE NAME                                       SIZE
59788edf1f3e   registry.hub.docker.com/library/busybox:latest   715.53 KB
```

### Ⅴ. Special notes for reviews


