### PR TITLE
test: simpler test in cli_run_with_privileged_test.go

### DIFF
--- a/test/cli_run_with_privileged_test.go
+++ b/test/cli_run_with_privileged_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"strings"
-
 	"github.com/alibaba/pouch/test/command"
 	"github.com/alibaba/pouch/test/environment"
 	"github.com/alibaba/pouch/test/util"
@@ -40,14 +38,8 @@ func (suite *PouchRunPrivilegedSuite) TestRunWithAndWithoutPrivileged(c *check.C
 	name1 := "TestRunWithoutPrivileged"
 	res := command.PouchRun("run", "--name", name1, busyboxImage, "brctl", "addbr", "foobar")
 	defer DelContainerForceMultyTime(c, name1)
-	if res.ExitCode == 0 {
-		c.Errorf("non-privileged container executes brctl should failed, but succeeded: %v", res.Combined())
-	}
 
-	expected := "Operation not permitted"
-	if out := res.Combined(); !strings.Contains(out, expected) {
-		c.Errorf("expected %s, but got %s", expected, out)
-	}
+	c.Assert(util.PartialEqual(res.Combined(), "Operation not permitted"), check.IsNil)
 }
 
 func (suite *PouchRunPrivilegedSuite) TestRunCheckProcWritableWithAndWithoutPrivileged(c *check.C) {
@@ -59,14 +51,7 @@ func (suite *PouchRunPrivilegedSuite) TestRunCheckProcWritableWithAndWithoutPriv
 	res := command.PouchRun("run", "--name", name1, busyboxImage, "sh", "-c", "touch /proc/sysrq-trigger")
 	defer DelContainerForceMultyTime(c, name1)
 
-	if res.ExitCode == 0 {
-		c.Errorf("non-privileged container executes touch /proc/sysrq-trigger should failed, but succeeded: %v", res.Combined())
-	}
-
-	expected := "Read-only file system"
-	if out := res.Combined(); !strings.Contains(out, expected) {
-		c.Errorf("expected %s, but got %s", expected, out)
-	}
+	c.Assert(util.PartialEqual(res.Combined(), "Read-only file system"), check.IsNil)
 }
 
 func (suite *PouchRunPrivilegedSuite) TestRunCheckSysWritableWithAndWithoutPrivileged(c *check.C) {
@@ -78,14 +63,7 @@ func (suite *PouchRunPrivilegedSuite) TestRunCheckSysWritableWithAndWithoutPrivi
 	res := command.PouchRun("run", "--name", name1, busyboxImage, "sh", "-c", "touch /sys/kernel/profiling")
 	defer DelContainerForceMultyTime(c, name1)
 
-	if res.ExitCode == 0 {
-		c.Errorf("non-privileged container executes touch /sys/kernel/profiling should failed, but succeeded: %v", res.Combined())
-	}
-
-	expected := "Read-only file system"
-	if out := res.Combined(); !strings.Contains(out, expected) {
-		c.Errorf("expected %s, but got %s", expected, out)
-	}
+	c.Assert(util.PartialEqual(res.Combined(), "Read-only file system"), check.IsNil)
 }
 
 // TestCgroupWritableWithAndWithoutPrivileged tests cgroup can be writable with privileged,
@@ -98,10 +76,6 @@ func (suite *PouchRunPrivilegedSuite) TestCgroupWritableWithAndWithoutPrivileged
 	name1 := "TestRunCheckCgroupCannotWritable"
 	res := command.PouchRun("run", "--name", name1, busyboxImage, "sh", "-c", "mkdir /sys/fs/cgroup/cpu/test")
 	defer DelContainerForceMultyTime(c, name1)
-
-	if res.ExitCode == 0 {
-		c.Errorf("non-privileged container executes mkdir /sys/fs/cgroup/cpu/test should failed, but succeeded: %v", res.Combined())
-	}
 
 	c.Assert(util.PartialEqual(res.Combined(), "Read-only file system"), check.IsNil)
 }


### PR DESCRIPTION
remove check exitcode, check output error is enough

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

remove check exitcode, check output error is enough in cli_run_with_privileged_test.go

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

has test


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


