### PR TITLE
blkiodev: limit blkio device's read/write Bps/IOps

### DIFF
--- a/apis/types/resources.go
+++ b/apis/types/resources.go
@@ -122,7 +122,7 @@ type Resources struct {
 	// Total memory limit (memory + swap). Set as `-1` to enable unlimited swap.
 	MemorySwap int64 `json:"MemorySwap"`
 
-	// Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
+	// Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100. -1 is also accepted, as a legacy alias of 0.
 	// Maximum: 100
 	// Minimum: -1
 	MemorySwappiness *int64 `json:"MemorySwappiness"`

--- a/cli/update.go
+++ b/cli/update.go
@@ -51,6 +51,10 @@ func (uc *UpdateCommand) addFlags() {
 	flagSet.StringSliceVarP(&uc.labels, "label", "l", nil, "Set label for container")
 	flagSet.StringVar(&uc.restartPolicy, "restart", "", "Restart policy to apply when container exits")
 	flagSet.StringSliceVar(&uc.diskQuota, "disk-quota", nil, "Update disk quota for container(/=10g)")
+	flagSet.Var(&uc.blkioDeviceReadBps, "device-read-bps", "Update read rate (bytes per second) from a device")
+	flagSet.Var(&uc.blkioDeviceWriteBps, "device-write-bps", "Update write rate (bytes per second) from a device")
+	flagSet.Var(&uc.blkioDeviceReadIOps, "device-read-iops", "Update read rate (io per second) from a device")
+	flagSet.Var(&uc.blkioDeviceWriteIOps, "device-write-iops", "Update write rate (io per second) from a device")
 }
 
 // updateRun is the entry of update command.
@@ -69,14 +73,18 @@ func (uc *UpdateCommand) updateRun(args []string) error {
 	}
 
 	resource := types.Resources{
-		CPUPeriod:   uc.cpuperiod,
-		CPUShares:   uc.cpushare,
-		CPUQuota:    uc.cpuquota,
-		CpusetCpus:  uc.cpusetcpus,
-		CpusetMems:  uc.cpusetmems,
-		Memory:      memory,
-		MemorySwap:  memorySwap,
-		BlkioWeight: uc.blkioWeight,
+		CPUPeriod:            uc.cpuperiod,
+		CPUShares:            uc.cpushare,
+		CPUQuota:             uc.cpuquota,
+		CpusetCpus:           uc.cpusetcpus,
+		CpusetMems:           uc.cpusetmems,
+		Memory:               memory,
+		MemorySwap:           memorySwap,
+		BlkioWeight:          uc.blkioWeight,
+		BlkioDeviceReadBps:   uc.blkioDeviceReadBps.Value(),
+		BlkioDeviceWriteBps:  uc.blkioDeviceWriteBps.Value(),
+		BlkioDeviceReadIOps:  uc.blkioDeviceReadIOps.Value(),
+		BlkioDeviceWriteIOps: uc.blkioDeviceWriteIOps.Value(),
 	}
 
 	restartPolicy, err := opts.ParseRestartPolicy(uc.restartPolicy)

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1284,6 +1284,18 @@ func (mgr *ContainerManager) updateContainerResources(c *Container, resources ty
 	if resources.BlkioWeight != 0 {
 		cResources.BlkioWeight = resources.BlkioWeight
 	}
+	if resources.BlkioDeviceReadBps != nil {
+		cResources.BlkioDeviceReadBps = resources.BlkioDeviceReadBps
+	}
+	if resources.BlkioDeviceReadIOps != nil {
+		cResources.BlkioDeviceReadIOps = resources.BlkioDeviceReadIOps
+	}
+	if resources.BlkioDeviceWriteBps != nil {
+		cResources.BlkioDeviceWriteBps = resources.BlkioDeviceWriteBps
+	}
+	if resources.BlkioDeviceWriteIOps != nil {
+		cResources.BlkioDeviceWriteIOps = resources.BlkioDeviceWriteIOps
+	}
 	if resources.CPUPeriod != 0 {
 		cResources.CPUPeriod = resources.CPUPeriod
 	}


### PR DESCRIPTION
Signed-off-by: Leno Hou <lenohou@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
1. blkiodev: limit blkio device's read/write Bps/IOps
2. testcase: add blkio device bps/iops testcase


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #2509 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
To be added later


### Ⅳ. Describe how to verify it
Create Container with:
1. pouch run -it --device /dev/sda:/dev/sda --device-read-bps=/dev/sda:100M busybox sh
2. Check inside Container's Cgroup filesystem
#cat /sys/fs/cgroup/blkio/blkio.throttle.read_bps_device
8:0 104857600

### Ⅴ. Special notes for reviews


