### PR TITLE
enhance: use bit operation to get device major/minor

### DIFF
--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -168,8 +168,8 @@ func getWeightDevice(devs []*types.WeightDevice) ([]specs.LinuxWeightDevice, err
 		d := specs.LinuxWeightDevice{
 			Weight: &dev.Weight,
 		}
-		d.Major = int64(stat.Rdev / 256)
-		d.Minor = int64(stat.Rdev % 256)
+		d.Major = int64(stat.Rdev >> 8)
+		d.Minor = int64(stat.Rdev & 255)
 		weightDevice = append(weightDevice, d)
 	}
 
@@ -188,8 +188,8 @@ func getThrottleDevice(devs []*types.ThrottleDevice) ([]specs.LinuxThrottleDevic
 		d := specs.LinuxThrottleDevice{
 			Rate: dev.Rate,
 		}
-		d.Major = int64(stat.Rdev / 256)
-		d.Minor = int64(stat.Rdev % 256)
+		d.Major = int64(stat.Rdev >> 8)
+		d.Minor = int64(stat.Rdev & 255)
 		ThrottleDevice = append(ThrottleDevice, d)
 	}
 


### PR DESCRIPTION
Signed-off-by: Leno Hou <lenohou@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
In computer architecture, bit operation use less CPU cycle than Div and Mod
```
Formula:
Val / 2^n   =  Val >> n                (right shift n bit)
Val % 2^n  = Val & (2^n -1)            (only get the low bit)
```
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NO

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
NO


### Ⅳ. Describe how to verify it
NO

### Ⅴ. Special notes for reviews


