### PR TITLE
bugfix: throw error when ParseLabels was passed with conflict

### DIFF
--- a/apis/opts/labels.go
+++ b/apis/opts/labels.go
@@ -14,6 +14,14 @@ func ParseLabels(labels []string) (map[string]string, error) {
 			return nil, err
 		}
 		k, v := fields[0], fields[1]
+
+		if existedV, ok := results[k]; ok && existedV != v {
+			return nil, fmt.Errorf(
+				"conflicted labels %s=%s and %s=%s",
+				k, v, k, existedV,
+			)
+		}
+
 		results[k] = v
 	}
 	return results, nil

--- a/apis/opts/labels_test.go
+++ b/apis/opts/labels_test.go
@@ -37,13 +37,10 @@ func TestParseLabels(t *testing.T) {
 			},
 		},
 		{
-			// FIXME: this case should throw error
 			input: []string{"a=b", "a=bb"},
 			expected: result{
-				labels: map[string]string{
-					"a": "bb",
-				},
-				err: nil,
+				labels: nil,
+				err:    fmt.Errorf("conflicted labels a=bb and a=b"),
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: maoyiwei <jsmyw95@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
I noticed that there is a FIXME in labels_test.go so I write this pull request
bugfix: labels.go: throw error when ParseLabels was passed with conflicted labels

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


