### PR TITLE
test: synchronize branch from tools-dev to release-1.12 in critest

### DIFF
--- a/hack/install/install_critest.sh
+++ b/hack/install/install_critest.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 CRITEST_BRANCH_v1alpha1=release-1.9
-CRITEST_BRANCH_DEFAULT=tools-dev
+CRITEST_BRANCH_DEFAULT=release-1.12
 
 # keep the first one only
 GOPATH="${GOPATH%%:*}"

--- a/hack/testing/run_daemon_cri_integration.sh
+++ b/hack/testing/run_daemon_cri_integration.sh
@@ -18,8 +18,7 @@ export PATH="${REPO_BASE}/bin:${PATH}"
 export PATH="${GOPATH}/bin:${PATH}"
 
 # CRI_SKIP skips the test to skip.
-DEFAULT_CRI_SKIP="seccomp localhost"
-DEFAULT_CRI_SKIP="${DEFAULT_CRI_SKIP}|should error on create with wrong options"
+DEFAULT_CRI_SKIP="should error on create with wrong options"
 CRI_SKIP="${CRI_SKIP:-"${DEFAULT_CRI_SKIP}"}"
 
 # CRI_FOCUS focuses the test to run.


### PR DESCRIPTION
Recently, there are many changes in pouch cri and k8s/cri-tools, our
cri-tools has given a synchronization and build a stable release-1.12
branch instead of old tools-dev, so need to synchronize it in pouch part.

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


