### PR TITLE
[RFC] CRI: Add daemon configuration to StatusResponse as extra information

### DIFF
--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -130,6 +130,9 @@ type CriManager struct {
 
 	// imageFSPath is the path to image filesystem.
 	imageFSPath string
+
+	// DaemonConfig is the config of daemon
+	DaemonConfig *config.Config
 }
 
 // NewCriManager creates a brand new cri manager.
@@ -160,6 +163,7 @@ func NewCriManager(config *config.Config, ctrMgr mgr.ContainerMgr, imgMgr mgr.Im
 		SandboxBaseDir: path.Join(config.HomeDir, "sandboxes"),
 		SandboxImage:   config.CriConfig.SandboxImage,
 		SnapshotStore:  mgr.NewSnapshotStore(),
+		DaemonConfig:   config,
 	}
 	c.CniMgr, err = cni.NewCniManager(&config.CriConfig)
 	if err != nil {
@@ -1254,7 +1258,12 @@ func (c *CriManager) Status(ctx context.Context, r *runtime.StatusRequest) (*run
 		if err != nil {
 			return nil, err
 		}
+		configByt, err := json.Marshal(c.DaemonConfig)
+		if err != nil {
+			return nil, err
+		}
 		resp.Info["golang"] = string(versionByt)
+		resp.Info["daemon-config"] = string(configByt)
 
 		// TODO return more info
 	}


### PR DESCRIPTION
StatusResponse in CRI returns runtime extra information which is in
the map of Info. Now there is only one key in this map. This patch
add "daemon-config" as another key and its value is the daemon
configuration in json format. With this patch, for example, we can
get pouch root dir from StatusResponse.

Signed-off-by: Wang Rui <baijia.wr@antfin.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
User could get pouch root dir by StatusResponse in CRI with this patch.
This patch add a new key "daemon-config" to StatusResponse.Info . A lot of extra information can be found in info["daemon-config"].
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
It fix the proposal #2568 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


