### PR TITLE
remove unused member of daemon config

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -45,9 +45,6 @@ type Config struct {
 	// Server listening address.
 	Listen []string `json:"listen,omitempty"`
 
-	// ListenCRI is the listening address which serves CRI.
-	ListenCRI string `json:"listen-cri,omitempty"`
-
 	// Debug refers to the log mode.
 	Debug bool `json:"debug,omitempty"`
 

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -100,7 +100,6 @@ func TestConfigValidate(t *testing.T) {
 	// Test cri configuration
 	cfg = &Config{
 		IsCriEnabled: true,
-		ListenCRI:    "unix:///tmp/test/pouch/pouchcri.sock",
 		CriConfig: criconfig.Config{
 			Listen:                 "unix:///var/run/pouchd.sock",
 			NetworkPluginBinDir:    "cni-bin-dir",

--- a/test/daemon/daemon.go
+++ b/test/daemon/daemon.go
@@ -22,7 +22,6 @@ const (
 	HomeDir       = "/tmp/test/pouch"
 	Listen        = "unix:///tmp/test/pouch/pouchd.sock"
 	ContainerdAdd = "/tmp/test/pouch/containerd.sock"
-	ListenCRI     = "unix:///tmp/test/pouch/pouchcri.sock"
 	Pidfile       = "/tmp/test/pouch/pouch.pid"
 )
 
@@ -42,7 +41,6 @@ type Config struct {
 	Listen         string
 	HomeDir        string
 	ContainerdAddr string
-	ListenCri      string
 	Pidfile        string
 
 	// pid of pouchd
@@ -67,7 +65,6 @@ func NewConfig() Config {
 	result.Listen = Listen
 	result.HomeDir = HomeDir
 	result.ContainerdAddr = ContainerdAdd
-	result.ListenCri = ListenCRI
 	result.Pidfile = Pidfile
 
 	result.timeout = 15
@@ -88,9 +85,6 @@ func (d *Config) NewArgs(args ...string) {
 	}
 	if len(d.ContainerdAddr) != 0 {
 		d.Args = append(d.Args, "--containerd="+d.ContainerdAddr)
-	}
-	if len(d.ListenCri) != 0 {
-		d.Args = append(d.Args, "--listen-cri="+d.ListenCri)
 	}
 	if len(d.Pidfile) != 0 {
 		d.Args = append(d.Args, "--pidfile="+d.Pidfile)


### PR DESCRIPTION
ListenCRI which is the member of daemon config, is unused.

ListenCRI was first added in commit 05e492390. Commit 05e492390
was pushed on Jan 12, and merged on Mar 6.

ListenCRI was deleted in commit 05e492390, which was merged on
Jan 16.

So, it was a mistake that the deleted ListenCRI was added back
by the merge of 05e492390.

Signed-off-by: Wang Rui <baijia.wr@antfin.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Remove unused code. 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


