### PR TITLE
bugfix: make pouchd support top a paused container

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1342,8 +1342,8 @@ func (mgr *ContainerManager) Top(ctx context.Context, name string, psArgs string
 		return nil, err
 	}
 
-	if !c.IsRunning() {
-		return nil, fmt.Errorf("container %s is not running, cannot execute top command", c.ID)
+	if !c.IsRunningOrPaused() {
+		return nil, fmt.Errorf("container %s is not running or paused, cannot execute top command", c.ID)
 	}
 
 	pids, err := mgr.Client.ContainerPIDs(ctx, c.ID)


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Currently in pouchd, it does not support top a paused container, this pull request tries to make it.

Update the container status checking and test cases.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes https://github.com/alibaba/pouch/issues/2598


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
 
cc @drpmma

