### PR TITLE
bugfix: do not return stop container time out error

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -366,6 +366,7 @@ func (c *Client) destroyContainer(ctx context.Context, id string, timeout int64)
 
 	var msg *Message
 
+	// TODO: set task request timeout by context timeout
 	if err := pack.task.Kill(ctx, syscall.SIGTERM, containerd.WithKillAll); err != nil {
 		if !errdefs.IsNotFound(err) {
 			return nil, errors.Wrap(err, "failed to kill task")
@@ -385,7 +386,10 @@ func (c *Client) destroyContainer(ctx context.Context, id string, timeout int64)
 		}
 		msg = waitExit()
 	}
-	if err := msg.RawError(); err != nil && errtypes.IsTimeout(err) {
+
+	// ignore the error is stop time out
+	// TODO: how to design the stop error is time out?
+	if err := msg.RawError(); err != nil && !errtypes.IsTimeout(err) {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Add timeout into context when call kill rpc request.
do not return stop container time out error.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
I don't know how to setup the `timeout` error when stopping container


### Ⅳ. Describe how to verify it
1. make entrypoint script
```
cat << EOF > /tmp/start.sh
dd if=/dev/zero of=/mnt/test/ddfile bs=1k count=1000000
EOF

```
2. prepare a disk partition that different from the disk of rootfs,
such as `/dev/sdb`
```
mkfs.ext4 /dev/sdb
mount /dev/sdb /mnt/data
```

3. prepare the loop disk
```
mkdir -p /mnt/data/test
dd if=/dev/zero of=/mnt/data/test/test.raw bs=1M count=128
mkfs.ext4 /mnt/data/test/test.raw
mount /mnt/data/test/test.raw /mnt/test
```

4. start container with bind `/mnt/test`, and freeze file system to make
io hang
```
(pouch run -d --name stop-test -v /mnt/test:/mnt/test -v /tmp/start.sh:/home/start.sh reg.docker.alibaba-inc.com/pouch/busybox:1.28 sh /home/start.sh) ; fsfreeze -f /mnt/data/test
```

5. stop container, check it whether stop hang...
```
pouch stop stop-test
```

### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>
