### PR TITLE
bugfix: support rich mode container

### DIFF
--- a/daemon/mgr/container_rich_mode.go
+++ b/daemon/mgr/container_rich_mode.go
@@ -9,45 +9,16 @@ import (
 const (
 	richModeEnv       = "rich_mode=true"
 	richModeLaunchEnv = "rich_mode_launch_manner"
-
-	//for ali internal
-	interRichModeEnv = "ali_run_mode=common_vm"
 )
 
 func richContainerModeEnv(c *Container) []string {
-	var (
-		ret         = []string{}
-		setRichMode = false
-		richMode    = ""
-	)
-
-	envs := c.Config.Env
-
-	//if set inter_rich_mode_env, you can also run in rich container mode
-	for _, e := range envs {
-		if e == interRichModeEnv {
-			setRichMode = true
-			richMode = types.ContainerConfigRichModeSystemd
-			break
-		}
+	if !c.Config.Rich {
+		return nil
 	}
 
-	if c.Config.Rich {
-		setRichMode = true
+	if c.Config.RichMode == "" {
+		c.Config.RichMode = types.ContainerConfigRichModeDumbInit
 	}
 
-	if c.Config.RichMode != "" {
-		richMode = c.Config.RichMode
-	}
-
-	//if not set rich mode manner, default set dumb-init
-	if richMode == "" {
-		richMode = types.ContainerConfigRichModeDumbInit
-	}
-
-	if setRichMode {
-		ret = append(ret, richModeEnv, fmt.Sprintf("%s=%s", richModeLaunchEnv, richMode))
-	}
-
-	return ret
+	return []string{richModeEnv, fmt.Sprintf("%s=%s", richModeLaunchEnv, c.Config.RichMode)}
 }

--- a/daemon/mgr/container_rich_mode_test.go
+++ b/daemon/mgr/container_rich_mode_test.go
@@ -64,17 +64,4 @@ func TestRichModeSet(t *testing.T) {
 	mEnvs4 := convertEnvArrayToMap(envs4)
 	assert.Equal(t, "true", mEnvs4["rich_mode"])
 	assert.Equal(t, types.ContainerConfigRichModeSystemd, mEnvs4[richModeLaunchEnv])
-
-	//test set rich mode by env
-	c = &Container{
-		Config: &types.ContainerConfig{
-			Env: []string{
-				interRichModeEnv,
-			},
-		},
-	}
-	envs5 := richContainerModeEnv(c)
-	mEnvs5 := convertEnvArrayToMap(envs5)
-	assert.Equal(t, "true", mEnvs5["rich_mode"])
-	assert.Equal(t, types.ContainerConfigRichModeSystemd, mEnvs5[richModeLaunchEnv])
 }

--- a/docs/features/pouch_with_rich_container.md
+++ b/docs/features/pouch_with_rich_container.md
@@ -65,19 +65,19 @@ PID   USER     TIME  COMMAND
 
 ### Using systemd or sbin-init
 
-In order to use systemd or /sbin/init to init container, please make sure install them on image.
+In order to use systemd or /sbin/init to init container, please make sure to install them in image. Please use pouch version not lower than 1.1.0 if you want to use systemd rich mode.
 As shown below, centos image has both of them.
 Also `--privileged` is required in this situation. An example of systemd and sbin-init is as following:
 
 ```
-#cat /tmp/1.sh
-#! /bin/sh
+# cat /tmp/1.sh
+! /bin/sh
 echo $(cat) >/tmp/xxx
 
 #pouch run -d -v /tmp:/tmp --privileged --rich --rich-mode systemd --initscript /tmp/1.sh registry.hub.docker.com/library/centos:latest /usr/bin/sleep 10000
 3054125e44443fd5ee9190ee49bbca0a842724f5305cb05df49f84fd7c901d63
 
-#pouch exec 3054125e44443fd5ee9190ee49bbca0a842724f5305cb05df49f84fd7c901d63 ps aux
+# pouch exec 3054125e44443fd5ee9190ee49bbca0a842724f5305cb05df49f84fd7c901d63 ps aux
 USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root          1  7.4  0.0  42968  3264 ?        Ss   05:29   0:00 /usr/lib/systemd/systemd
 root         17  0.0  0.0  10752   756 ?        Ss   05:29   0:00 /usr/lib/systemd/systemd-readahead collect
@@ -87,13 +87,13 @@ root         36  0.0  0.0   7724   608 ?        Ss   05:29   0:00 /usr/bin/sleep
 dbus         37  0.0  0.0  24288  1604 ?        Ss   05:29   0:00 /bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
 root         45  0.0  0.0  47452  1676 ?        Rs   05:29   0:00 ps aux
 
-#cat /tmp/xxx
+# cat /tmp/xxx
 {"ociVersion":"1.0.0","id":"3054125e44443fd5ee9190ee49bbca0a842724f5305cb05df49f84fd7c901d63","status":"","pid":125745,"bundle":"/var/lib/pouch/containerd/state/io.containerd.runtime.v1.linux/default/3054125e44443fd5ee9190ee49bbca0a842724f5305cb05df49f84fd7c901d63"}
 
-#pouch run -d -v /tmp:/tmp --privileged --rich --rich-mode sbin-init --initscript /tmp/1.sh registry.hub.docker.com/library/centos:latest /usr/bin/sleep 10000
+# pouch run -d -v /tmp:/tmp --privileged --rich --rich-mode sbin-init --initscript /tmp/1.sh registry.hub.docker.com/library/centos:latest /usr/bin/sleep 10000
 c5b5eef81749ce00fb68a59ee623777bfecc8e07c617c0601cc56e4ae8b1e69f
 
-#pouch exec c5b5eef81749ce00fb68a59ee623777bfecc8e07c617c0601cc56e4ae8b1e69f ps aux
+# pouch exec c5b5eef81749ce00fb68a59ee623777bfecc8e07c617c0601cc56e4ae8b1e69f ps aux
 USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root          1  7.4  0.0  42968  3260 ?        Ss   05:30   0:00 /sbin/init
 root         17  0.0  0.0  10752   752 ?        Ss   05:30   0:00 /usr/lib/systemd/systemd-readahead collect
@@ -103,7 +103,7 @@ root         35  0.0  0.0   7724   612 ?        Ss   05:30   0:00 /usr/bin/sleep
 dbus         36  0.0  0.0  24288  1608 ?        Ss   05:30   0:00 /bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
 root         45  0.0  0.0  47452  1676 ?        Rs   05:30   0:00 ps aux
 
-#cat /tmp/xxx
+# cat /tmp/xxx
 {"ociVersion":"1.0.0","id":"c5b5eef81749ce00fb68a59ee623777bfecc8e07c617c0601cc56e4ae8b1e69f","status":"","pid":127183,"bundle":"/var/lib/pouch/containerd/state/io.containerd.runtime.v1.linux/default/c5b5eef81749ce00fb68a59ee623777bfecc8e07c617c0601cc56e4ae8b1e69f"}
 ```
 


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
systemd rich mode container need use cgroup on hosts, and should have write access. As describe in #2537 , even using privileged mode,  we still have no write access to cgroup of hosts.

Since the bug has been fixed in pouch 1.1.0, So I refactor the rich mode containers code logic and add some test cases for creating rich containers.

### Ⅱ. Does this pull request fix one issue?
fixes #2537 


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
already add test cases

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


