### PR TITLE
test: optimize the time of run test cases

### DIFF
--- a/test/cli_events_test.go
+++ b/test/cli_events_test.go
@@ -109,7 +109,7 @@ func (suite *PouchEventsSuite) TestDieEventWorks(c *check.C) {
 	// only works when test case run on the same machine with pouchd
 	time.Sleep(1100 * time.Millisecond)
 	start := time.Now()
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 	time.Sleep(1100 * time.Millisecond)
 	end := time.Now()
 

--- a/test/cli_exec_test.go
+++ b/test/cli_exec_test.go
@@ -145,7 +145,7 @@ func (suite *PouchExecSuite) TestExecStoppedContainer(c *check.C) {
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 
 	out := command.PouchRun("exec", name, "echo", "test").Stderr()
 	if !strings.Contains(out, "failed") {
@@ -188,7 +188,7 @@ func (suite *PouchExecSuite) TestExecAfterContainerRestart(c *check.C) {
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 

--- a/test/cli_inspect_test.go
+++ b/test/cli_inspect_test.go
@@ -192,7 +192,7 @@ func (suite *PouchInspectSuite) TestContainerInspectState(c *check.C) {
 	defer DelContainerForceMultyTime(c, name)
 	res.Assert(c, icmd.Success)
 	// stop container
-	res = command.PouchRun("stop", "-t", "0", name)
+	res = command.PouchRun("stop", "-t", "1", name)
 	res.Assert(c, icmd.Success)
 
 	output = command.PouchRun("inspect", "-f", "{{.State.Pid}}", name).Stdout()

--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -182,7 +182,7 @@ func (suite *PouchNetworkSuite) TestNetworkBridgeWorks(c *check.C) {
 	{
 		// running container is stopped, then the veth device should also been removed
 		command.PouchRun("run", "-d", "--name", funcname, "--net", funcname, busyboxImage, "top").Assert(c, icmd.Success)
-		command.PouchRun("stop", funcname).Assert(c, icmd.Success)
+		command.PouchRun("stop", "-t", "1", funcname).Assert(c, icmd.Success)
 
 		// get the ID of bridge to construct the bridge name.
 		cmd := "pouch network list |grep " + funcname + "|awk '{print $1}'"

--- a/test/cli_pause_test.go
+++ b/test/cli_pause_test.go
@@ -55,7 +55,7 @@ func (suite *PouchPauseSuite) TestPauseInWrongWay(c *check.C) {
 	defer DelContainerForceMultyTime(c, stoppedContainerName)
 	res.Assert(c, icmd.Success)
 	command.PouchRun("start", stoppedContainerName).Assert(c, icmd.Success)
-	command.PouchRun("stop", stoppedContainerName).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", stoppedContainerName).Assert(c, icmd.Success)
 
 	for _, tc := range []struct {
 		name          string

--- a/test/cli_ps_test.go
+++ b/test/cli_ps_test.go
@@ -60,7 +60,7 @@ func (suite *PouchPsSuite) TestPsWorks(c *check.C) {
 
 	// stop
 	{
-		command.PouchRun("stop", name).Assert(c, icmd.Success)
+		command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 
 		res := command.PouchRun("ps", "-a").Assert(c, icmd.Success)
 		kv := psToKV(res.Combined())

--- a/test/cli_restart_test.go
+++ b/test/cli_restart_test.go
@@ -85,7 +85,7 @@ func (suite *PouchRestartSuite) TestPouchRestartStoppedContainer(c *check.C) {
 
 	res.Assert(c, icmd.Success)
 
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 
 	command.PouchRun("restart", "-t", "1", name).Assert(c, icmd.Success)
 }

--- a/test/cli_rich_container_test.go
+++ b/test/cli_rich_container_test.go
@@ -123,7 +123,7 @@ func (suite *PouchRichContainerSuite) TestRichContainerDumbInitWorks(c *check.C)
 	c.Assert(checkPidofProcessIsOne(funcname, "dumb-init"), check.Equals, true)
 
 	// stop and start could work well.
-	command.PouchRun("stop", funcname).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", funcname).Assert(c, icmd.Success)
 	command.PouchRun("start", funcname).Assert(c, icmd.Success)
 	c.Assert(checkPidofProcessIsOne(funcname, "dumb-init"), check.Equals, true)
 
@@ -215,7 +215,7 @@ func (suite *PouchRichContainerSuite) TestRichContainerSystemdWorks(c *check.C) 
 	c.Assert(checkPPid(funcname, "sleep", "1"), check.Equals, true)
 
 	// stop and start could work well.
-	command.PouchRun("stop", funcname).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", funcname).Assert(c, icmd.Success)
 	command.PouchRun("start", funcname).Assert(c, icmd.Success)
 	c.Assert(checkPidofProcessIsOne(funcname, "/usr/lib/systemd/systemd"), check.Equals, true)
 	c.Assert(checkPPid(funcname, "sleep", "1"), check.Equals, true)

--- a/test/cli_run_volume_test.go
+++ b/test/cli_run_volume_test.go
@@ -162,7 +162,7 @@ func (suite *PouchRunVolumeSuite) TestRunWithVolumesFrom(c *check.C) {
 	res.Assert(c, icmd.Success)
 
 	// stop container1
-	command.PouchRun("stop", containerName1).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", containerName1).Assert(c, icmd.Success)
 
 	// run container2
 	res = command.PouchRun("run", "-d",
@@ -227,7 +227,7 @@ func (suite *PouchRunVolumeSuite) TestRunWithVolumesFromWithDupclicate(c *check.
 	res.Assert(c, icmd.Success)
 
 	// stop container1
-	command.PouchRun("stop", containerName1).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", containerName1).Assert(c, icmd.Success)
 
 	// run container2
 	res = command.PouchRun("run", "-d",
@@ -446,7 +446,7 @@ func (suite *PouchRunVolumeSuite) TestRunVolumesFromWithDR(c *check.C) {
 	}()
 
 	// stop bak container
-	command.PouchRun("stop", cNameBak).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", cNameBak).Assert(c, icmd.Success)
 
 	// run new container with volumes-from
 	command.PouchRun("run", "-d", "--name", cName,

--- a/test/cli_start_test.go
+++ b/test/cli_start_test.go
@@ -46,7 +46,7 @@ func (suite *PouchStartSuite) TestStartCommand(c *check.C) {
 
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 }
 
 // TestStartInTTY tests "pouch start -i" work.
@@ -74,7 +74,7 @@ func (suite *PouchStartSuite) TestStartInTTY(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(strings.TrimSpace(echo), check.Equals, msg)
 
-	command.PouchRun("stop", name)
+	command.PouchRun("stop", "-t", "1", name)
 }
 
 // TestStartInWrongWay runs start command in wrong way.
@@ -106,7 +106,7 @@ func (suite *PouchStartSuite) TestStartWithEnv(c *check.C) {
 		c.Errorf("failed to set env: %s, %s", env, output)
 	}
 
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 }
 
 // TestStartWithEntrypoint starts a container with  entrypoint.
@@ -172,7 +172,7 @@ func (suite *PouchStartSuite) TestStartWithHostname(c *check.C) {
 		c.Errorf("failed to set hostname: %s, %s", hostname, output)
 	}
 
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 }
 
 // TestStartWithSysctls starts a container with sysctls.
@@ -189,7 +189,7 @@ func (suite *PouchStartSuite) TestStartWithSysctls(c *check.C) {
 		c.Errorf("failed to start a container with sysctls: %s", output)
 	}
 
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 }
 
 // TestStartWithAppArmor starts a container with security option AppArmor.
@@ -204,7 +204,7 @@ func (suite *PouchStartSuite) TestStartWithAppArmor(c *check.C) {
 
 	// TODO: do the test more strictly with effective AppArmor profile.
 
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 }
 
 // TestStartWithSeccomp starts a container with security option seccomp.
@@ -219,7 +219,7 @@ func (suite *PouchStartSuite) TestStartWithSeccomp(c *check.C) {
 
 	// TODO: do the test more strictly with effective seccomp profile.
 
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 }
 
 // TestStartWithCapability starts a container with capability.
@@ -323,7 +323,7 @@ func (suite *PouchStartSuite) TestStartFromCheckpoint(c *check.C) {
 	// image busybox not have /proc directory, we need to start busybox image and stop it
 	// make /proc exist, then we can restore successful
 	command.PouchRun("run", "-d", "--name", restoredContainer, busyboxImage).Assert(c, icmd.Success)
-	command.PouchRun("stop", restoredContainer).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", restoredContainer).Assert(c, icmd.Success)
 
 	command.PouchRun("start", "--checkpoint-dir", tmpDir, "--checkpoint", checkpoint, restoredContainer).Assert(c, icmd.Success)
 
@@ -357,7 +357,7 @@ func (suite *PouchStartSuite) TestStartMultiContainers(c *check.C) {
 	res := command.PouchRun("start", containernames[0], containernames[1])
 	res.Assert(c, icmd.Success)
 
-	res = command.PouchRun("stop", containernames[0], containernames[1])
+	res = command.PouchRun("stop", "-t", "1", containernames[0], containernames[1])
 	res.Assert(c, icmd.Success)
 }
 

--- a/test/cli_stop_test.go
+++ b/test/cli_stop_test.go
@@ -36,13 +36,13 @@ func (suite *PouchStopSuite) TestStopWorks(c *check.C) {
 	defer DelContainerForceMultyTime(c, name)
 
 	// test stop a created container
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 
 	// start the created container
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 
 	// test stop a running container
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 	// test stop a stopped container
 	command.PouchRun("stop", name).Assert(c, icmd.Success)
 
@@ -52,7 +52,7 @@ func (suite *PouchStopSuite) TestStopWorks(c *check.C) {
 
 	// test stop container with timeout(*seconds)
 	command.PouchRun("start", name).Assert(c, icmd.Success)
-	command.PouchRun("stop", "-t", "3", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 
 	status, err = inspectFilter(name, ".State.Status")
 	c.Assert(err, check.IsNil)
@@ -61,7 +61,7 @@ func (suite *PouchStopSuite) TestStopWorks(c *check.C) {
 	// test stop a paused container
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 	command.PouchRun("pause", name).Assert(c, icmd.Success)
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 
 	status, err = inspectFilter(name, ".State.Status")
 	c.Assert(err, check.IsNil)
@@ -78,7 +78,7 @@ func (suite *PouchStopSuite) TestStopInWrongWay(c *check.C) {
 		{name: "unknown flag", args: "-a"},
 		{name: "Error: requires at least 1 arg(s), only received 0", args: ""},
 	} {
-		res := command.PouchRun("stop", tc.args)
+		res := command.PouchRun("stop", "-t", "1", tc.args)
 		c.Assert(res.Stderr(), check.NotNil, check.Commentf(tc.name))
 	}
 }
@@ -93,7 +93,7 @@ func (suite *PouchStopSuite) TestStopMultiContainers(c *check.C) {
 	defer DelContainerForceMultyTime(c, name1)
 	defer DelContainerForceMultyTime(c, name2)
 
-	command.PouchRun("stop", "-t", "3", name1, name2).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name1, name2).Assert(c, icmd.Success)
 
 	// test if the container is already stopped
 	status, err := inspectFilter(name1, ".State.Status")
@@ -113,7 +113,7 @@ func (suite *PouchStopSuite) TestStopPidValue(c *check.C) {
 	defer DelContainerForceMultyTime(c, name)
 
 	// test stop a created container
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 
 	pid, err := inspectFilter(name, ".State.Pid")
 	c.Assert(err, check.IsNil)

--- a/test/cli_upgrade_test.go
+++ b/test/cli_upgrade_test.go
@@ -81,7 +81,7 @@ func (suite *PouchUpgradeSuite) TestPouchUpgradeStoppedContainer(c *check.C) {
 	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
-	command.PouchRun("stop", name).Assert(c, icmd.Success)
+	command.PouchRun("stop", "-t", "1", name).Assert(c, icmd.Success)
 
 	res := command.PouchRun("upgrade", "--image", busyboxImage125, name)
 	res.Assert(c, icmd.Success)

--- a/test/util_api.go
+++ b/test/util_api.go
@@ -92,7 +92,11 @@ func StartContainerOk(c *check.C, cname string) {
 
 // StopContainerOk stops the container and asserts success..
 func StopContainerOk(c *check.C, cname string) {
-	resp, err := request.Post("/containers/" + cname + "/stop")
+	q := url.Values{}
+	q.Add("t", "1")
+	query := request.WithQuery(q)
+
+	resp, err := request.Post("/containers/"+cname+"/stop", query)
 	c.Assert(err, check.IsNil)
 
 	defer resp.Body.Close()
@@ -125,7 +129,13 @@ func CheckContainerRunning(c *check.C, cname string, isRunning bool) {
 }
 
 func delContainerForce(cname string) (*http.Response, error) {
+	// first stop the container, then delete it
 	q := url.Values{}
+	q.Add("t", "1")
+	resp, _ := request.Post("/containers/"+cname+"/stop", request.WithQuery(q))
+	defer resp.Body.Close()
+
+	q = url.Values{}
 	q.Add("force", "true")
 	q.Add("v", "true")
 
@@ -152,7 +162,6 @@ func UnpauseContainerOk(c *check.C, cname string) {
 // DelContainerForceMultyTime forcely deletes the container multy times.
 func DelContainerForceMultyTime(c *check.C, cname string) {
 	timeout := 1 * time.Minute
-
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 


### PR DESCRIPTION
Signed-off-by: ziren.wzr <ziren.wzr@alibaba-inc.com>


### Ⅰ. Describe what this PR did
Since our integration test cases run about 30mins,  the more test cases, the longer the running time.

So, we can optimize some test cases to decrease the running time, like:
  * first stop the container with timeout 1 then delete it
  * add timeout to 1 when stop a container

Let's see if we can decrease the running time of the integration test cases :)


### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


