### PR TITLE
docs: add two maintainers and component owner/backup policy for project

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,7 @@
 # Maintainers
 
+## Maintainers List
+
 |GitHub ID| Name | Email|Company|
 |:---:| :----:| :---:|:--: |
 |[allencloud](https://github.com/allencloud)|Allen Sun|shlallen1990@gmail.com|Alibaba Group|
@@ -11,3 +13,26 @@
 |[sunyuan3](https://github.com/sunyuan3)|Yuan Sun|yile.sy@alibaba-inc.com |Alibaba Group|
 |[HusterWan](https://github.com/HusterWan)|Michael Wan|zirenwan@gmail.com|Alibaba Group|
 |[ZYecho](https://github.com/ZYecho)|Yue Zhang|zy675793960@yeah.net|ISCAS|
+|[fuweid](https://github.com/fuweid)|Wei Fu|yuge.fw@alibaba-inc.com|Alibaba Group|
+|[zhuangqh](https://github.com/zhuangqh)|Jerry Zhuang|zhijin.zqh@alibaba-inc.com| Alibaba Group|
+
+## Component Owner/Backup
+
+In order to make all components in PouchContainer well-maintained, an owner/backup responsibility policy is set for all maintainers. No matter the owner or the backup, they have responsibilities to make/review design and programme code for the corresponding component. They work for success of the decoupled component, and efforts all maintainers do guarantee PouchContainer's success.
+
+We encourage all community participants to communicate with component owner/backup to get more information or guidance via all kinds of channels, such as @him in GitHub issue or pull request, email him via listed email address and so on. And component owner/backups are obligated to provide kind and patient help to the community.
+
+The component owner and backup are listed as below:
+
+|Component|Owner|Backup|Notes|
+|:---:|:----:|:---:|:--:|
+|CRI/Kubernetes|zhuangqh|Starnop|CRI stablibity/improvement, collaborate with upstream|
+|API/CLI|allencloud|fuweid|API/CLI definitions/change reviews|
+|runtime/OCI|Ace-Tang| zhuangqh|multiple runtime support, runc/kata/gvisor|
+|storage|rudyfly|fuweid|volumes, diskquota, volume plugin protocols|
+|network|rudyfly|HusterWan|libnetwork, cni plugins|
+|image|fuweid|ZYecho|image storage/distribution/management |
+|ctrd|fuweid|Ace-Tang|component used in pouchd to communicated with containerd|
+|ContainerMgr|HusterWan|Ace-Tang|container lifecycle management in pouchd|
+|Test|sunyuan3|chuanchang|test framework and software quality|
+|Document|allencloud|rufyfly|Document Roadmap and quality improvement|


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This PR added two parts of things:

1. add @zhuangqh and @fuweid in the maintainers list, since both of them has invested lots of energy in making PouchContainer much better. @zhuangqh is doing great work on standardizing CRI implementation in pouchd and some other meaningful work. For @fuweid, he is almost involved in all kinds of part in pouchd, no only the software component, but also the organization effort for the maintainers meetings. In addition, he did a lot to spread PouchContainer in the ecosystem. I think both of them are qualified maintainers which have ability to lead the project to success. I propose to add them into the maintainer's list.

2. add component owner/backup policy for projects. In order to make all components in PouchContainer well-maintained, an owner/backup responsibility policy is set for all maintainers. No matter the owner or the backup, they have responsibilities to make/review design and programme code for the corresponding component. They work for success of the decoupled component, and efforts all maintainers do guarantee PouchContainer's success.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none



### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no need


### Ⅳ. Describe how to verify it
no need

### Ⅴ. Special notes for reviews
cc @alibaba/pouch 

