### PR TITLE
daemon: replace error with warning message when synchronize snapshot update

### DIFF
--- a/daemon/mgr/snapshot.go
+++ b/daemon/mgr/snapshot.go
@@ -137,7 +137,7 @@ func (s *SnapshotsSyncer) Sync() error {
 		}
 		usage, err := s.client.GetSnapshotUsage(context.Background(), info.Name)
 		if err != nil {
-			logrus.Errorf("failed to get usage for snapshot %q: %v", info.Name, err)
+			logrus.Warnf("failed to get usage for snapshot %q: %v", info.Name, err)
 			continue
 		}
 		sn.Size = uint64(usage.Size)


### PR DESCRIPTION
The Sync() is an loop function, which will collect usage of snapshot util
success, it means there are many error message will be written into log
if it's failed to get usage for snapshot, these error will be easy to
trigger a monitor tool, so replace writing error with warning into log.

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
e.g.

```shell
time="2018-12-28T06:14:25.311286459+08:00" level=error msg="failed to get usage for snapshot "0781c8f0ccb03a1341fb715a7ba6e615308bcf584ccd37e47efef4a73da03034":lstat /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6904/fs/usr/local/ilogtail/snapshot/ilogtail_status.LOG.44: no such file or directory: not found"
time="2018-12-28T07:07:31.03424663+08:00" level=error msg="failed to get usage for snapshot "fb280451f04f57d476838b718c520f68f1d834669eb91cb9b8f6c53fa6384455": lstat /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/8181/fs/usr/local/ilogtail/snapshot/ilogtail_status.LOG.12: no such file ordirectory: not found"
time="2018-12-28T08:12:55.321965671+08:00" level=error msg="failed to get usage for snapshot "2340109eab02355a7738a761284af455b00db33813fbe635e1b1e6b212a3025a":lstat /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/7962/fs/usr/local/ilogtail/snapshot/ilogtail_status.LOG.39: no such file or directory: not found"
time="2018-12-28T08:59:20.510390419+08:00" level=error msg="failed to get usage for snapshot "7de2a771e56621b6904d38cd99359bf9972e25c5e824e44921e1c03932cc1faf":lstat /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/7938/fs/usr/local/ilogtail/snapshot/ilogtail_status.LOG.43: no such file or directory: not found"
time="2018-12-28T09:29:30.133803579+08:00" level=error msg="failed to get usage for snapshot "947431cc154292676ebaeb003070d0ea9656a25ec846bd5deb5fb81642d03910":lstat /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/4922/fs/tmp/logtail_check_point.bak: no such file or directory: not found"
time="2018-12-28T10:10:55.484146651+08:00" level=error msg="failed to get usage for snapshot "2340109eab02355a7738a761284af455b00db33813fbe635e1b1e6b212a3025a":lstat /home/t4/pouch/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/7962/fs/usr/local/ilogtail/snapshot/ilogtail_status.LOG.41: no such file or directory: not found"
```