### PR TITLE
bugfix: should add snapshot gc label to config

### DIFF
--- a/ctrd/image_commit.go
+++ b/ctrd/image_commit.go
@@ -76,6 +76,13 @@ func (c *Client) Commit(ctx context.Context, config *CommitConfig) (_ digest.Dig
 	}
 	client := wrapperCli.client
 
+	// NOTE: make sure that gc scheduler doesn't remove content/snapshot during commmit
+	ctx, done, err := client.WithLease(ctx)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to create lease for commit")
+	}
+	defer done()
+
 	var (
 		sn     = client.SnapshotService(CurrentSnapshotterName())
 		cs     = client.ContentStore()
@@ -85,33 +92,26 @@ func (c *Client) Commit(ctx context.Context, config *CommitConfig) (_ digest.Dig
 	// export new layer
 	snapshot, err := c.GetSnapshot(ctx, config.ContainerID)
 	if err != nil {
-		return "", fmt.Errorf("failed to get snapshot: %s", err)
-	}
-	layer, diffIDStr, err := exportLayer(ctx, snapshot.Name, sn, cs, differ)
-	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "failed to get snapshot")
 	}
 
-	// create child image
-	diffIDDigest, err := digest.Parse(diffIDStr)
+	layer, diffID, err := exportLayer(ctx, snapshot.Name, sn, cs, differ)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "failed to export layer")
 	}
 
-	childImg, err := newChildImage(ctx, config, diffIDDigest)
-	if err != nil {
-		return "", err
-	}
+	childImg := newChildImage(ctx, config, diffID)
 
 	// create new snapshot for new layer
-	snapshotKey := identity.ChainID(childImg.RootFS.DiffIDs).String()
-	if err = newSnapshot(ctx, config.Image, sn, differ, layer, snapshotKey, diffIDStr); err != nil {
+	rootfsID := identity.ChainID(childImg.RootFS.DiffIDs).String()
+	if err = newSnapshot(ctx, rootfsID, config.Image, sn, differ, layer); err != nil {
 		return "", err
 	}
+
 	defer func() {
 		if err0 != nil {
-			logrus.Warnf("remove snapshot %s cause commit image failed", snapshotKey)
-			client.SnapshotService(CurrentSnapshotterName()).Remove(ctx, snapshotKey)
+			logrus.Warnf("remove snapshot %s cause commit image failed", rootfsID)
+			client.SnapshotService(CurrentSnapshotterName()).Remove(ctx, rootfsID)
 		}
 	}()
 
@@ -180,18 +180,24 @@ func (c *Client) Commit(ctx context.Context, config *CommitConfig) (_ digest.Dig
 		if !errdefs.IsNotFound(err) {
 			return "", fmt.Errorf("failed to cover exist image %s", err)
 		}
+
 		if _, err := client.ImageService().Create(ctx, img); err != nil {
 			return "", fmt.Errorf("failed to create new image %s", err)
 		}
 	}
 
 	// write manifest content
-	if err := content.WriteBlob(ctx, cs, mfstDigest.String(), bytes.NewReader(mfstJSON), mfstDesc.Size, mfstDesc.Digest, content.WithLabels(labels)); err != nil {
+	ref := mfstDigest.String()
+	if err := content.WriteBlob(ctx, cs, ref, bytes.NewReader(mfstJSON), mfstDesc.Size, mfstDesc.Digest, content.WithLabels(labels)); err != nil {
 		return "", errors.Wrapf(err, "error writing manifest blob %s", mfstDigest)
 	}
 
 	// write config content
-	if err := content.WriteBlob(ctx, cs, configDesc.Digest.String(), bytes.NewReader(imgJSON), configDesc.Size, configDesc.Digest); err != nil {
+	ref = configDesc.Digest.String()
+	labelOpt := content.WithLabels(map[string]string{
+		fmt.Sprintf("containerd.io/gc.ref.snapshot.%s", CurrentSnapshotterName()): rootfsID,
+	})
+	if err := content.WriteBlob(ctx, cs, ref, bytes.NewReader(imgJSON), configDesc.Size, configDesc.Digest, labelOpt); err != nil {
 		return "", errors.Wrap(err, "error writing config blob")
 	}
 
@@ -200,22 +206,25 @@ func (c *Client) Commit(ctx context.Context, config *CommitConfig) (_ digest.Dig
 }
 
 // export a new layer from a container
-func exportLayer(ctx context.Context, name string, sn snapshots.Snapshotter, cs content.Store, differ diff.Differ) (ocispec.Descriptor, string, error) {
-	// export new layer
-	rwDesc, err := rootfs.Diff(ctx, name, sn, differ, diff.WithLabels(map[string]string{
-		"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339Nano),
-	}))
+func exportLayer(ctx context.Context, name string, sn snapshots.Snapshotter, cs content.Store, differ diff.Differ) (ocispec.Descriptor, digest.Digest, error) {
+	rwDesc, err := rootfs.Diff(ctx, name, sn, differ)
 	if err != nil {
-		return ocispec.Descriptor{}, "", fmt.Errorf("failed to diff: %s", err)
+		return ocispec.Descriptor{}, digest.Digest(""), fmt.Errorf("failed to diff: %s", err)
 	}
 
 	info, err := cs.Info(ctx, rwDesc.Digest)
 	if err != nil {
-		return ocispec.Descriptor{}, "", fmt.Errorf("failed to get exported layer info: %s", err)
+		return ocispec.Descriptor{}, digest.Digest(""), fmt.Errorf("failed to get exported layer info: %s", err)
 	}
+
 	diffIDStr, ok := info.Labels[containerdUncompressed]
 	if !ok {
-		return ocispec.Descriptor{}, "", fmt.Errorf("invalid differ response with no diffID")
+		return ocispec.Descriptor{}, digest.Digest(""), fmt.Errorf("invalid differ response with no diffID")
+	}
+
+	diffID, err := digest.Parse(diffIDStr)
+	if err != nil {
+		return ocispec.Descriptor{}, digest.Digest(""), err
 	}
 
 	layer := ocispec.Descriptor{
@@ -223,14 +232,13 @@ func exportLayer(ctx context.Context, name string, sn snapshots.Snapshotter, cs 
 		Digest:    rwDesc.Digest,
 		Size:      info.Size,
 	}
-
-	return layer, diffIDStr, nil
+	return layer, diffID, nil
 }
 
 // create a new child image descriptor
-func newChildImage(ctx context.Context, config *CommitConfig, diffIDDigest digest.Digest) (ocispec.Image, error) {
+func newChildImage(ctx context.Context, config *CommitConfig, diffID digest.Digest) ocispec.Image {
 	createdTime := time.Now()
-	emptyLayer := (diffIDDigest == emptyGZLayer)
+	emptyLayer := (diffID == emptyGZLayer)
 	history := ocispec.History{
 		Created:    &createdTime,
 		CreatedBy:  strings.Join(config.ContainerConfig.Cmd, " "),
@@ -241,7 +249,7 @@ func newChildImage(ctx context.Context, config *CommitConfig, diffIDDigest diges
 
 	// new child image
 	pImg := config.Image
-	image := ocispec.Image{
+	return ocispec.Image{
 		Architecture: runtime.GOARCH,
 		OS:           runtime.GOOS,
 		Created:      &createdTime,
@@ -249,26 +257,24 @@ func newChildImage(ctx context.Context, config *CommitConfig, diffIDDigest diges
 		Config:       newImageConfig(config.ContainerConfig),
 		RootFS: ocispec.RootFS{
 			Type:    "layers",
-			DiffIDs: append(pImg.RootFS.DiffIDs, diffIDDigest),
+			DiffIDs: append(pImg.RootFS.DiffIDs, diffID),
 		},
 		History: append(pImg.History, history),
 	}
-
-	return image, nil
 }
 
 // create a new snapshot for exported layer
-func newSnapshot(ctx context.Context, pImg ocispec.Image, sn snapshots.Snapshotter, differ diff.Differ, layer ocispec.Descriptor, name, diffIDStr string) error {
-	diffIDs := pImg.RootFS.DiffIDs
-	parent := identity.ChainID(diffIDs).String()
+func newSnapshot(ctx context.Context, name string, pImg ocispec.Image, sn snapshots.Snapshotter, differ diff.Differ, layer ocispec.Descriptor) error {
+	var (
+		key    = randomid.Generate()
+		parent = identity.ChainID(pImg.RootFS.DiffIDs).String()
+	)
 
-	key := randomid.Generate()
-	// avoid active snapshots cleaned by containerd 1.0.3 gc
-	opt := snapshots.WithLabels(map[string]string{
-		"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
-		snapshots.TypeLabelKey:  snapshots.ImageType,
-	})
-	mount, err := sn.Prepare(ctx, key, parent, opt)
+	mount, err := sn.Prepare(ctx, key, parent,
+		snapshots.WithLabels(map[string]string{
+			snapshots.TypeLabelKey: snapshots.ImageType,
+		}),
+	)
 	if err != nil {
 		return err
 	}
@@ -278,15 +284,7 @@ func newSnapshot(ctx context.Context, pImg ocispec.Image, sn snapshots.Snapshott
 		return fmt.Errorf("failed to apply layer: %s", err)
 	}
 
-	withLabels := func(info *snapshots.Info) error {
-		info.Labels = map[string]string{
-			containerdUncompressed:  diffIDStr,
-			"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339Nano),
-		}
-		return nil
-	}
-
-	if err = sn.Commit(ctx, name, key, withLabels); err != nil {
+	if err = sn.Commit(ctx, name, key); err != nil {
 		if !errdefs.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to commit snapshot %s: %s", key, err)
 		}
@@ -296,7 +294,6 @@ func newSnapshot(ctx context.Context, pImg ocispec.Image, sn snapshots.Snapshott
 			return fmt.Errorf("failed to cleanup aborted apply %s: %s", key, err)
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


```
# containerd content/snapshot gc reference overview
+----------+        +-------------+     +-----------------+
| manifest +------> | config blob +---> | rootfs snapshot |
+-----+----+        +-------------+     +-----------------+
      |             +-------------+
      +-----------> | layer blob  |
                    +-------------+
```

For `containerd.io/gc.root` label means the content/snapshot cannot be
removed during gc. If we use it for snapshot, the snapshot cannot be
removed during removing image.

By default, we should add
`containerd.io/gc.ref.snapshot.{snapshot-name}` gc label to the image
config so that gc can remove the snapshot if user tries to remove the
image.

Signed-off-by: Wei Fu <fuweid89@gmail.com>

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

close #2556

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no need 


### Ⅳ. Describe how to verify it

```
# create container
$ sudo pouch run -d --name test1 busybox sh -c "echo 1 > /tmp/1 && sleep 1000"
be0d930081334dfc409e96aa1ec7184c89de3357be82ec28febba09921ee64a8

# commit it
$ sudo pouch commit test1 hello:1
b57ae9798515

# run it make sure that it is correct.
$ sudo pouch run --rm hello:1 sh -c "cat /tmp/1"
1

# check content gc label use by image id(= config digest)
$ sudo ctr -a /var/run/containerd.sock content ls | grep b57ae9798515 | grep snapshot
sha256:b57ae9798515d642a7b9c9ec5beea9dac5870d1cf770b76e70b76d134afb06eb 822 B           2 minutes       containerd.io/gc.ref.snapshot.overlayfs=sha256:964c0a9b08d55c0b51b044c0affe021fdd9fd366deffd1df3abe82baaf95d6ac

# check the snapshot (id is in the gc label)
$ sudo ctr -a /var/run/containerd.sock snapshot info sha256:964c0a9b08d55c0b51b044c0affe021fdd9fd366deffd1df3abe82baaf95d6ac
{
    "Kind": "Committed",
    "Name": "sha256:964c0a9b08d55c0b51b044c0affe021fdd9fd366deffd1df3abe82baaf95d6ac",
    "Parent": "sha256:23bc2b70b2014dec0ac22f27bb93e9babd08cdd6f1115d0c955b9ff22b382f5a",
    "Created": "2018-12-29T05:24:14.337401258Z",
    "Updated": "2018-12-29T05:24:14.337401258Z"
}

# time to remove the image
$ sudo pouch rmi hello:1

# check the snapshot
$ sudo ctr -a /var/run/containerd.sock snapshot info sha256:964c0a9b08d55c0b51b044c0affe021fdd9fd366deffd1df3abe82baaf95d6ac
ctr: snapshot sha256:964c0a9b08d55c0b51b044c0affe021fdd9fd366deffd1df3abe82baaf95d6ac does not exist: not found
```

### Ⅴ. Special notes for reviews


