### PR TITLE
feature: Add log for cri request

### DIFF
--- a/cri/middleware/debug.go
+++ b/cri/middleware/debug.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+const (
+	// defaultRecordTimeOut defines a certain period of time, if a cri request spent
+	// more than it, a log will be recorded to reminder it. the unit of measurement is millisecond.
+	defaultRecordTimeOut = 500
+)
+
+// DebugRequestMiddleWare add log for cri request
+func DebugRequestMiddleWare(handler UnaryMiddleWareHandler) UnaryMiddleWareHandler {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo) (resp interface{}, err error) {
+		logrus.WithField("method", info.FullMethod).Debugf("Cri request: %v", req)
+
+		start := time.Now()
+		defer func() {
+			d := time.Since(start) / (time.Millisecond)
+			if d > defaultRecordTimeOut {
+				logrus.WithField("method", info.FullMethod).Infof("End of Calling Cri request: %v, costs %d ms", req, d)
+			}
+		}()
+
+		return handler(ctx, req, info)
+	}
+}

--- a/cri/middleware/middleware.go
+++ b/cri/middleware/middleware.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// UnaryMiddleWareHandler is an adapter to allow user to intercept the execution of a unary RPC on the server.
+// parameters are defined as grpc.UnaryServerInterceptor.
+type UnaryMiddleWareHandler func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo) (resp interface{}, err error)
+
+// MiddleWare is an adapter to allow user to filter the execution of a unary RPC on the server
+type MiddleWare func(handler UnaryMiddleWareHandler) UnaryMiddleWareHandler
+
+// HandleWithGlobalMiddlewares provides a hook to intercept the execution of a unary RPC on the server
+func HandleWithGlobalMiddlewares(interceptor grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		// a transition from grpc.UnaryServerInterceptor to UnaryMiddleWareHandler
+		next := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo) (resp interface{}, err error) {
+			if interceptor != nil {
+				return interceptor(ctx, req, info, handler)
+			}
+
+			return handler(ctx, req)
+		}
+
+		next = DebugRequestMiddleWare(next)
+		return next(ctx, req, info)
+	}
+}

--- a/cri/v1alpha1/service/cri.go
+++ b/cri/v1alpha1/service/cri.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/alibaba/pouch/cri/middleware"
 	cri "github.com/alibaba/pouch/cri/v1alpha1"
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/pkg/netutils"
@@ -20,7 +21,9 @@ type Service struct {
 func NewService(cfg *config.Config, criMgr cri.CriMgr) (*Service, error) {
 	s := &Service{
 		config: cfg,
-		server: grpc.NewServer(),
+		server: grpc.NewServer(
+			grpc.UnaryInterceptor(middleware.HandleWithGlobalMiddlewares(nil)),
+		),
 		criMgr: criMgr,
 	}
 

--- a/cri/v1alpha2/service/cri.go
+++ b/cri/v1alpha2/service/cri.go
@@ -3,6 +3,7 @@ package service
 import (
 	runtime "github.com/alibaba/pouch/cri/apis/v1alpha2"
 	"github.com/alibaba/pouch/cri/metrics"
+	"github.com/alibaba/pouch/cri/middleware"
 	cri "github.com/alibaba/pouch/cri/v1alpha2"
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/pkg/netutils"
@@ -19,11 +20,12 @@ type Service struct {
 
 // NewService creates a brand new cri service.
 func NewService(cfg *config.Config, criMgr cri.CriMgr) (*Service, error) {
+	unaryInterceptor := middleware.HandleWithGlobalMiddlewares(metrics.GRPCMetrics.UnaryServerInterceptor())
 	s := &Service{
 		config: cfg,
 		server: grpc.NewServer(
 			grpc.StreamInterceptor(metrics.GRPCMetrics.StreamServerInterceptor()),
-			grpc.UnaryInterceptor(metrics.GRPCMetrics.UnaryServerInterceptor()),
+			grpc.UnaryInterceptor(unaryInterceptor),
 		),
 		criMgr: criMgr,
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Design an interface  to provides a hook to intercept the execution of a unary RPC on the server for cri request. 
Add an implementation to add debug log for cri request. If a cri request is spent more than a certain period of time, it will be recorded as a log.  

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fix https://github.com/alibaba/pouch/issues/2633.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
No needed.  Only make sure cri tests and metric tests are passed.


### Ⅳ. Describe how to verify it
If set debug mode, we can see cri debug log like this:
```
time="2018-12-29T17:49:13.066497641+08:00" level=debug msg="Cri request: &ListContainersRequest{Filter:&ContainerFilter{Id:,State:&ContainerStateValue{State:CONTAINER_RUNNING,},PodSandboxId:,LabelSelector:map[string]string{},},}" method="/runtime.v1alpha2.RuntimeService/ListContainers"
```


### Ⅴ. Special notes for reviews


