### PR TITLE
feature: support push image in daemon side

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -207,3 +207,26 @@ func (s *Server) getImageHistory(ctx context.Context, rw http.ResponseWriter, re
 
 	return EncodeResponse(rw, http.StatusOK, history)
 }
+
+// pushImage will push an image to a specified registry.
+func (s *Server) pushImage(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+	name := mux.Vars(req)["name"]
+	tag := req.FormValue("tag")
+
+	// get registry auth from Request header
+	authStr := req.Header.Get("X-Registry-Auth")
+	authConfig := types.AuthConfig{}
+	if authStr != "" {
+		data := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authStr))
+		if err := json.NewDecoder(data).Decode(&authConfig); err != nil {
+			return err
+		}
+	}
+
+	if err := s.ImageMgr.PushImage(ctx, name, tag, &authConfig, newWriteFlusher(rw)); err != nil {
+		logrus.Errorf("failed to push image %s with tag %s: %v", name, tag, err)
+		return err
+	}
+
+	return nil
+}

--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -74,6 +74,7 @@ func initRoute(s *Server) *mux.Router {
 		{Method: http.MethodPost, Path: "/images/load", HandlerFunc: withCancelHandler(s.loadImage)},
 		{Method: http.MethodGet, Path: "/images/save", HandlerFunc: withCancelHandler(s.saveImage)},
 		{Method: http.MethodGet, Path: "/images/{name:.*}/history", HandlerFunc: s.getImageHistory},
+		{Method: http.MethodPost, Path: "/images/{name:.*}/push", HandlerFunc: s.pushImage},
 
 		// volume
 		{Method: http.MethodGet, Path: "/volumes", HandlerFunc: s.listVolume},

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -423,6 +423,33 @@ paths:
         500:
           $ref: "#/responses/500ErrorResponse"
 
+  /images/{imageid}/push:
+    post:
+      summary: "push an image"
+      description: "push an image on the registry"
+      operationId: "ImagePush"
+      consumes:
+        - "application/octet-stream"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/imageid"
+        - name: "tag"
+          in: "query"
+          description: "the tag to associate with the image on the registry. This is optional."
+          type: "string"
+        - name: "X-Registry-Auth"
+          in: "header"
+          description: "A base64-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
+          type: "string"
+      responses:
+        200:
+          description: "no error"
+        404:
+          $ref: "#/responses/404ErrorResponse"
+        500:
+          $ref: "#/responses/500ErrorResponse"
+
   /containers/create:
     post:
       summary: "Create a container"

--- a/cli/pull.go
+++ b/cli/pull.go
@@ -157,7 +157,7 @@ func displayImageReferenceProgress(output io.Writer, isTerminal bool, msgs []jso
 			current += msg.Detail.Current
 		}
 
-		status := jsonstream.PullReferenceStatus(!isTerminal, msg)
+		status := jsonstream.ProcessStatus(!isTerminal, msg)
 		if _, err := fmt.Fprint(tw, status); err != nil {
 			return err
 		}

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -1,0 +1,42 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+
+	"github.com/alibaba/pouch/pkg/reference"
+)
+
+// ImagePush requests daemon to push an image to registry.
+func (client *APIClient) ImagePush(ctx context.Context, ref, encodedAuth string) (io.ReadCloser, error) {
+	namedRef, err := reference.Parse(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	if reference.IsCanonicalDigested(namedRef) {
+		return nil, errors.New("cannot push a digest reference format image")
+	}
+
+	tag := ""
+	if v, ok := namedRef.(reference.Tagged); ok {
+		tag = v.Tag()
+	}
+
+	q := url.Values{}
+	if tag != "" {
+		q.Set("tag", tag)
+	}
+
+	headers := map[string][]string{}
+	if encodedAuth != "" {
+		headers["X-Registry-Auth"] = []string{encodedAuth}
+	}
+	resp, err := client.post(ctx, "/images/"+namedRef.Name()+"/push", q, nil, headers)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestImagePushServerError(t *testing.T) {
+	client := &APIClient{
+		HTTPCli: newMockClient(errorMockResponse(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ImagePush(context.Background(), "image", "auth")
+	if err == nil || !strings.Contains(err.Error(), "Server error") {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestImagePush(t *testing.T) {
+	name := "test_image"
+	expectedURL := "/images/" + name + "/push"
+
+	httpClient := newMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+
+		if req.Method != "POST" {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	})
+
+	client := &APIClient{
+		HTTPCli: httpClient,
+	}
+
+	_, err := client.ImagePush(context.Background(), name, "auth")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -58,6 +58,7 @@ type ImageAPIClient interface {
 	ImageLoad(ctx context.Context, name string, r io.Reader) error
 	ImageSave(ctx context.Context, imageName string) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, name string) ([]types.HistoryResultItem, error)
+	ImagePush(ctx context.Context, ref, encodedAuth string) (io.ReadCloser, error)
 }
 
 // VolumeAPIClient defines methods of Volume client.

--- a/ctrd/interface.go
+++ b/ctrd/interface.go
@@ -90,6 +90,8 @@ type ImageAPIClient interface {
 	SaveImage(ctx context.Context, exporter ctrdmetaimages.Exporter, ref string) (io.ReadCloser, error)
 	// Commit commits an image from a container.
 	Commit(ctx context.Context, config *CommitConfig) (digest.Digest, error)
+	// PushImage pushes a image to registry
+	PushImage(ctx context.Context, ref string, authConfig *types.AuthConfig, out io.Writer) error
 }
 
 // SnapshotAPIClient provides access to containerd snapshot features

--- a/ctrd/utils.go
+++ b/ctrd/utils.go
@@ -16,14 +16,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-func resolver(authConfig *types.AuthConfig) (remotes.Resolver, error) {
+func resolver(authConfig *types.AuthConfig, resolverOpt docker.ResolverOptions) (remotes.Resolver, error) {
 	var (
 		// TODO
-		username  = ""
-		secret    = ""
-		plainHTTP = false
-		refresh   = ""
-		insecure  = false
+		username = ""
+		secret   = ""
+		refresh  = ""
+		insecure = false
 	)
 
 	if authConfig != nil {
@@ -35,8 +34,8 @@ func resolver(authConfig *types.AuthConfig) (remotes.Resolver, error) {
 	_ = refresh
 
 	options := docker.ResolverOptions{
-		PlainHTTP: plainHTTP,
-		Tracker:   docker.NewInMemoryTracker(),
+		PlainHTTP: resolverOpt.PlainHTTP,
+		Tracker:   resolverOpt.Tracker,
 	}
 	options.Credentials = func(host string) (string, string, error) {
 		// Only one host

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -44,6 +44,9 @@ type ImageMgr interface {
 	// PullImage pulls images from specified registry.
 	PullImage(ctx context.Context, ref string, authConfig *types.AuthConfig, out io.Writer) error
 
+	// PushImage pushes image to specified registry.
+	PushImage(ctx context.Context, name, tag string, authConfig *types.AuthConfig, out io.Writer) error
+
 	// GetImage returns imageInfo by reference or id.
 	GetImage(ctx context.Context, idOrRef string) (*types.ImageInfo, error)
 
@@ -192,6 +195,22 @@ func (mgr *ImageManager) PullImage(ctx context.Context, ref string, authConfig *
 	mgr.LogImageEvent(ctx, img.Name(), namedRef.String(), "pull")
 
 	return mgr.StoreImageReference(ctx, img)
+}
+
+// PushImage pushes image to specified registry.
+func (mgr *ImageManager) PushImage(ctx context.Context, name, tag string, authConfig *types.AuthConfig, out io.Writer) error {
+	ref, err := reference.Parse(name)
+	if err != nil {
+		return err
+	}
+
+	if tag == "" {
+		ref = reference.WithDefaultTagIfMissing(ref)
+	} else {
+		ref = reference.WithTag(ref, tag)
+	}
+
+	return mgr.client.PushImage(ctx, ref.String(), authConfig, out)
 }
 
 // GetImage returns imageInfo by reference.

--- a/pkg/jsonstream/image_progress.go
+++ b/pkg/jsonstream/image_progress.go
@@ -19,13 +19,16 @@ const (
 	PullStatusExists = "exists"
 	// PullStatusDone represents done status.
 	PullStatusDone = "done"
+
+	// PushStatusUploading represents uploading status.
+	PushStatusUploading = "uploading"
 )
 
-// PullReferenceStatus returns the status of pulling the image reference.
+// ProcessStatus returns the status of download or upload image
 //
 // NOTE: if the stdout is not terminal, it should only show the reference and
 // status without progress bar.
-func PullReferenceStatus(short bool, msg JSONMessage) string {
+func ProcessStatus(short bool, msg JSONMessage) string {
 	if short || msg.Detail == nil {
 		return fmt.Sprintf("%s:\t%s\n", msg.ID, msg.Status)
 	}
@@ -33,7 +36,7 @@ func PullReferenceStatus(short bool, msg JSONMessage) string {
 	switch msg.Status {
 	case PullStatusResolving, PullStatusWaiting:
 		return fmt.Sprintf("%s:\t%s\t%40r\t\n", msg.ID, msg.Status, progress.Bar(0.0))
-	case PullStatusDownloading:
+	case PullStatusDownloading, PushStatusUploading:
 		bar := progress.Bar(0)
 		current, total := progress.Bytes(msg.Detail.Current), progress.Bytes(msg.Detail.Total)
 

--- a/pkg/jsonstream/image_push.go
+++ b/pkg/jsonstream/image_push.go
@@ -1,0 +1,98 @@
+package jsonstream
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/remotes/docker"
+)
+
+// PushJobs defines a job in upload progress
+type PushJobs struct {
+	jobs    map[string]struct{}
+	ordered []string
+	tracker docker.StatusTracker
+	mu      sync.Mutex
+}
+
+// NewPushJobs news a PushJobs
+func NewPushJobs(tracker docker.StatusTracker) *PushJobs {
+	return &PushJobs{
+		jobs:    make(map[string]struct{}),
+		tracker: tracker,
+	}
+}
+
+// Add adds a ref in upload job
+func (j *PushJobs) Add(ref string) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if _, ok := j.jobs[ref]; ok {
+		return
+	}
+	j.ordered = append(j.ordered, ref)
+	j.jobs[ref] = struct{}{}
+}
+
+// Status gets PushJobs statuses
+func (j *PushJobs) Status() []JSONMessage {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	statuses := make([]JSONMessage, 0, len(j.jobs))
+	for _, name := range j.ordered {
+		si := JSONMessage{
+			ID: name,
+		}
+
+		status, err := j.tracker.GetStatus(name)
+		if err != nil {
+			si.Status = "waiting"
+		} else {
+			si.Detail = &ProgressDetail{
+				Current: status.Offset,
+				Total:   status.Total,
+			}
+			si.StartedAt = status.StartedAt
+			si.UpdatedAt = status.UpdatedAt
+			if status.Offset >= status.Total {
+				if status.UploadUUID == "" {
+					si.Status = "done"
+				} else {
+					si.Status = "committing"
+				}
+			} else {
+				si.Status = "uploading"
+			}
+		}
+		statuses = append(statuses, si)
+	}
+
+	return statuses
+}
+
+// PushProcess translates upload progress to json stream
+func PushProcess(ctx context.Context, ongoing *PushJobs, stream *JSONStream) {
+	var (
+		ticker = time.NewTicker(100 * time.Millisecond)
+		done   bool
+	)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			for _, si := range ongoing.Status() {
+				stream.WriteObject(si)
+			}
+
+			if done {
+				return
+			}
+		case <-ctx.Done():
+			done = true // allow ui to update once more
+		}
+	}
+}

--- a/test/api_image_push_test.go
+++ b/test/api_image_push_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/test/request"
+
+	"github.com/go-check/check"
+)
+
+// APIImagePushSuite is the test suite for image create API.
+type APIImagePushSuite struct{}
+
+func init() {
+	check.Suite(&APIImagePushSuite{})
+}
+
+// SetUpTest does common setup in the beginning of each test.
+func (suite *APIImagePushSuite) SetUpTest(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+}
+
+// TestPushImageFail tests push a non-exist image should fail.
+func (suite *APIImagePushSuite) TestPushImageFail(c *check.C) {
+	name := "not_exist_image"
+	resp, err := request.Post("/images/" + name + "/push")
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 404)
+}


### PR DESCRIPTION
implement push command in daemon side, since containerd v1.0.3
version push get some problem when push image with index.json which
have multiple platforms. But it works good with only one platform,
this feature is our need.

fixes: #2099 

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes: #2099

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

not easy to add ci test, since it need a registry

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


