### PR TITLE
reset vendor of containerd to v1.0.3, and pass snapshot label by context

### DIFF
--- a/ctrd/image.go
+++ b/ctrd/image.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	ctrdmetaimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
-	"github.com/containerd/containerd/snapshots"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -193,7 +192,6 @@ func (c *Client) FetchImage(ctx context.Context, ref string, authConfig *types.A
 	options := []containerd.RemoteOpt{
 		containerd.WithSchema1Conversion,
 		containerd.WithResolver(resolver),
-		containerd.WithPullLabel(snapshots.TypeLabelKey, snapshots.ImageType),
 	}
 
 	handle := func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {

--- a/ctrd/image_commit.go
+++ b/ctrd/image_commit.go
@@ -270,11 +270,7 @@ func newSnapshot(ctx context.Context, name string, pImg ocispec.Image, sn snapsh
 		parent = identity.ChainID(pImg.RootFS.DiffIDs).String()
 	)
 
-	mount, err := sn.Prepare(ctx, key, parent,
-		snapshots.WithLabels(map[string]string{
-			snapshots.TypeLabelKey: snapshots.ImageType,
-		}),
-	)
+	mount, err := sn.Prepare(ctx, key, parent)
 	if err != nil {
 		return err
 	}

--- a/ctrd/snapshotter_key.go
+++ b/ctrd/snapshotter_key.go
@@ -1,6 +1,22 @@
 package ctrd
 
-import "context"
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	// TypeLabelKey is the key of label type=image in Snapshotter metadata Info.Labels, with which indicates the snapshot for image.
+	TypeLabelKey = "type"
+
+	// ImageType is the label value
+	ImageType = "image"
+
+	// SnapshotLabelContextKey is the key which is stored in context to transfer to containerd snapshotter
+	SnapshotLabelContextKey = "containerd.io.snapshot.labels"
+)
 
 type snapshotterKey struct{}
 
@@ -21,4 +37,28 @@ func CleanSnapshotter(ctx context.Context) context.Context {
 		return context.WithValue(ctx, snapshotterKey{}, "")
 	}
 	return ctx
+}
+
+// WithImageUnpack adds SnapshotLabelContextKey in context before creation of image snapshot.
+// it should be called when image snapshot is on creation, such as pullImage, loadImage and commitImage.
+func WithImageUnpack(ctx context.Context) context.Context {
+	value := fmt.Sprintf("%s=%s", TypeLabelKey, ImageType)
+	// store on the grpc headers so it gets picked up by any clients that
+	// are using this.
+	return withGRPCImageUnpackHeader(ctx, SnapshotLabelContextKey, value)
+}
+
+func withGRPCImageUnpackHeader(ctx context.Context, key string, value string) context.Context {
+	// also store on the grpc headers so it gets picked up by any clients
+	// that are using this.
+	txheader := metadata.Pairs(key, value)
+	md, ok := metadata.FromOutgoingContext(ctx) // merge with outgoing context.
+	if !ok {
+		md = txheader
+	} else {
+		// order ensures the latest is first in this list.
+		md = metadata.Join(txheader, md)
+	}
+
+	return metadata.NewOutgoingContext(ctx, md)
 }

--- a/daemon/mgr/container_commit.go
+++ b/daemon/mgr/container_commit.go
@@ -59,6 +59,9 @@ func (mgr *ContainerManager) Commit(ctx context.Context, name string, options *t
 		Image:           ociImage,
 	}
 
+	// before image commit, call WithImageUnpack
+	ctx = ctrd.WithImageUnpack(ctx)
+
 	imageDigest, err := mgr.Client.Commit(ctx, commitConfig)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to commit container (%s)", name)

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -166,6 +166,9 @@ func (mgr *ImageManager) PullImage(ctx context.Context, ref string, authConfig *
 		return err
 	}
 
+	// before image unpack, call WithImageUnpack
+	ctx = ctrd.WithImageUnpack(ctx)
+
 	// unpack image
 	if err = img.Unpack(ctx, ctrd.CurrentSnapshotterName(ctx)); err != nil {
 		writeStream(err)

--- a/daemon/mgr/image_load.go
+++ b/daemon/mgr/image_load.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/alibaba/pouch/ctrd"
 	"github.com/alibaba/pouch/pkg/multierror"
 	"github.com/alibaba/pouch/pkg/reference"
 
@@ -34,6 +35,9 @@ func (mgr *ImageManager) LoadImage(ctx context.Context, imageName string, tarstr
 	importer := &ociimage.V1Importer{
 		ImageName: imageName,
 	}
+
+	// before image is unpacked, call WithImageUnpack
+	ctx = ctrd.WithImageUnpack(ctx)
 
 	imgs, err := mgr.client.ImportImage(ctx, importer, tarstream)
 	if err != nil {

--- a/vendor/github.com/containerd/containerd/client.go
+++ b/vendor/github.com/containerd/containerd/client.go
@@ -253,13 +253,6 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (Image
 		}
 	}
 
-	if pullCtx.Labels == nil {
-		pullCtx.Labels = make(map[string]string)
-	}
-
-	// add label type=image to image labels
-	pullCtx.Labels[snapshots.TypeLabelKey] = snapshots.ImageType
-
 	imgrec := images.Image{
 		Name:   name,
 		Target: desc,
@@ -563,12 +556,6 @@ func (c *Client) Import(ctx context.Context, importer images.Importer, reader io
 		} else {
 			imgrec = updated
 		}
-
-		if imgrec.Labels == nil {
-			imgrec.Labels = make(map[string]string)
-		}
-		// add label type=image to pass to snapshot
-		imgrec.Labels[snapshots.TypeLabelKey] = snapshots.ImageType
 
 		images = append(images, &image{
 			client: c,

--- a/vendor/github.com/containerd/containerd/image.go
+++ b/vendor/github.com/containerd/containerd/image.go
@@ -9,8 +9,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/rootfs"
-	"github.com/containerd/containerd/snapshots"
-
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -101,16 +99,15 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 	}
 
 	var (
-		sn  = i.client.SnapshotService(snapshotterName)
-		a   = i.client.DiffService()
-		cs  = i.client.ContentStore()
-		opt = snapshots.WithLabels(i.i.Labels)
+		sn = i.client.SnapshotService(snapshotterName)
+		a  = i.client.DiffService()
+		cs = i.client.ContentStore()
 
 		chain    []digest.Digest
 		unpacked bool
 	)
 	for _, layer := range layers {
-		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a, opt)
+		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/containerd/containerd/snapshots/snapshotter.go
+++ b/vendor/github.com/containerd/containerd/snapshots/snapshotter.go
@@ -9,12 +9,6 @@ import (
 	"github.com/containerd/containerd/mount"
 )
 
-//add label type=image in Snapshotter metadata Info.Labels to indicate the snapshot for image.
-const (
-	TypeLabelKey = "type"
-	ImageType    = "image"
-)
-
 // Kind identifies the kind of snapshot.
 type Kind uint8
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -141,12 +141,12 @@
 			"revisionTime": "2017-09-25T15:48:32Z"
 		},
 		{
-			"checksumSHA1": "FWVcLZHVLh1DFPx4vdgdXZSPICY=",
+			"checksumSHA1": "1ny6UV3Oq4kaqpQtM8bs9W9e3vw=",
 			"path": "github.com/containerd/containerd",
-			"revision": "8d8f780274f3fcf2efb5d21c25569b6fc3bb08fb",
-			"revisionTime": "2018-12-05T03:53:22Z",
-			"version": "v1.0.3-dev-alibaba",
-			"versionExact": "v1.0.3-dev-alibaba"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "5pKxGJe3gsS/LjW8ZklKJvSXBMs=",
@@ -515,12 +515,12 @@
 			"versionExact": "v1.0.3"
 		},
 		{
-			"checksumSHA1": "/C8Wbf5VxH2wJkQTcZ+rsgG0BKY=",
+			"checksumSHA1": "DzMZUrndYzzDT7nqwcxHq2oC8Kc=",
 			"path": "github.com/containerd/containerd/snapshots",
-			"revision": "8d8f780274f3fcf2efb5d21c25569b6fc3bb08fb",
-			"revisionTime": "2018-12-05T03:53:22Z",
-			"version": "v1.0.3-dev-alibaba",
-			"versionExact": "v1.0.3-dev-alibaba"
+			"revision": "773c489c9c1b21a6d78b5c538cd395416ec50f88",
+			"revisionTime": "2018-04-02T20:34:37Z",
+			"version": "v1.0.3",
+			"versionExact": "v1.0.3"
 		},
 		{
 			"checksumSHA1": "8u2ZojhEDaoA4Co6usLof+TKj78=",


### PR DESCRIPTION
Signed-off-by: allen.wang <allen.wq@alipay.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
reset vendor of containerd to v1.0.3, related to PR https://github.com/alibaba/pouch/pull/2525。
pass snapshot label by grpc context to containerd.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no need.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


