### PR TITLE
delete omitempty from Privileged in api

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -2273,9 +2273,9 @@ definitions:
 
   HostConfig:
     description: "Container configuration that depends on the host we are running on"
-    type: "object"
     allOf:
-      - properties:
+      - type: "object"
+        properties:
           # Applicable to all platforms
           Binds:
             type: "array"
@@ -2389,6 +2389,7 @@ definitions:
               - `"host"`: use the host's PID namespace inside the container
           Privileged:
             type: "boolean"
+            x-omitempty: false
             description: "Gives the container full access to the host."
           PublishAllPorts:
             type: "boolean"

--- a/apis/types/host_config.go
+++ b/apis/types/host_config.go
@@ -111,7 +111,7 @@ type HostConfig struct {
 	PortBindings PortMap `json:"PortBindings,omitempty"`
 
 	// Gives the container full access to the host.
-	Privileged bool `json:"Privileged,omitempty"`
+	Privileged bool `json:"Privileged"`
 
 	// Allocates a random host port for all of a container's exposed ports.
 	PublishAllPorts bool `json:"PublishAllPorts,omitempty"`
@@ -214,7 +214,7 @@ func (m *HostConfig) UnmarshalJSON(raw []byte) error {
 
 		PortBindings PortMap `json:"PortBindings,omitempty"`
 
-		Privileged bool `json:"Privileged,omitempty"`
+		Privileged bool `json:"Privileged"`
 
 		PublishAllPorts bool `json:"PublishAllPorts,omitempty"`
 
@@ -385,7 +385,7 @@ func (m HostConfig) MarshalJSON() ([]byte, error) {
 
 		PortBindings PortMap `json:"PortBindings,omitempty"`
 
-		Privileged bool `json:"Privileged,omitempty"`
+		Privileged bool `json:"Privileged"`
 
 		PublishAllPorts bool `json:"PublishAllPorts,omitempty"`
 

--- a/test/cli_inspect_test.go
+++ b/test/cli_inspect_test.go
@@ -70,7 +70,7 @@ func (suite *PouchInspectSuite) TestInspectCreateAndStartedFormat(c *check.C) {
 	res = command.PouchRun("start", name)
 	res.Assert(c, icmd.Success)
 
-	// Inspect LogPath, HostnamePath, HostsPath, ResolvConfPath
+	// Inspect LogPath, HostnamePath, HostsPath, ResolvConfPath, Privileged
 	output = command.PouchRun("inspect", "-f", "{{.LogPath}}", name).Stdout()
 	expectedLogPath := fmt.Sprintf(rootDir+"/containers/%s/json.log", containerID)
 	c.Assert(strings.TrimSpace(output), check.Equals, expectedLogPath)
@@ -86,6 +86,9 @@ func (suite *PouchInspectSuite) TestInspectCreateAndStartedFormat(c *check.C) {
 	output = command.PouchRun("inspect", "-f", "{{.HostsPath}}", name).Stdout()
 	expectedLogPath = fmt.Sprintf(rootDir+"/containers/%s/hosts", containerID)
 	c.Assert(strings.TrimSpace(output), check.Equals, expectedLogPath)
+
+	output = command.PouchRun("inspect", "-f", "{{.HostConfig.Privileged}}", name).Stdout()
+	c.Assert(strings.TrimSpace(output), check.Equals, "false")
 }
 
 // TestInspectWrongFormat is to verify using wrong format flag of inspect command.


### PR DESCRIPTION
Signed-off-by: ziren.wzr <ziren.wzr@alibaba-inc.com>

### Ⅰ. Describe what this PR did

We have some situations need to check the `Privileged` value in a container meta. So we must make sure the json data of `inspect` api contains the `Privileged` parameter.

I delete the `omitempty` from `Privileged` parameter in `HostConfig` struct 


### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add the test code in PouchInspectSuite.TestInspectCreateAndStartedFormat


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


