### PR TITLE
ctrd: try to fix fail to destroy container

### DIFF
--- a/ctrd/container.go
+++ b/ctrd/container.go
@@ -394,6 +394,12 @@ func (c *Client) destroyContainer(ctx context.Context, id string, timeout int64)
 	}
 
 clean:
+	// for normal destroy process, task.Delete() and container.Delete()
+	// is done in ctrd/watch.go, after task exit. clean is task effect only
+	// when unexcepted error happened in task exit process.
+	if _, err := pack.task.Delete(ctx); err != nil {
+		logrus.Errorf("failed to delete task %s again: %v", pack.id, err)
+	}
 	if err := pack.container.Delete(ctx); err != nil {
 		if !errdefs.IsNotFound(err) {
 			return msg, errors.Wrap(err, "failed to delete container")


### PR DESCRIPTION
we got error in stop pouch container
```
the task has quit, id: 6a8dd031f5c87b4c67813908bbe7d3b3d96239e0054dd2516b411c88f7aa681f, err: <nil>, exitcode: 137, time: 2019-01-02 14:18:19.201110172 +0000 UTC"
failed to delete task, container id: 6a8dd031f5c87b4c67813908bbe7d3b3d96239e0054dd2516b411c88f7aa681f: task must be stopped before deletion: running: failed precondition
failed to delete container, container id: 6a8dd031f5c87b4c67813908bbe7d3b3d96239e0054dd2516b411c88f7aa681f: cannot delete running task 6a8dd031f5c87b4c67813908bbe7d3b3d96239e0054dd2516b411c88f7aa681f: failed precondition"
```

For checking containerd code, the problem probably happend maybe:
when called delete task, first get task status, taskService().Get()
-> processFromContainerd -> shim.State() -> init.Status() -> p.runtime.State()
containerd-shim not use init proc status as container status, they
should always keep same, but obviously, here is not.

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


