### PR TITLE
bugfix: /etc/mtab will miss quota id

### DIFF
--- a/daemon/mgr/container_storage.go
+++ b/daemon/mgr/container_storage.go
@@ -113,12 +113,6 @@ func (mgr *ContainerManager) generateMountPoints(ctx context.Context, c *Contain
 		return errors.Wrap(err, "failed to populate volumes")
 	}
 
-	// set volumes into /etc/mtab in container
-	err = mgr.setMountTab(ctx, c)
-	if err != nil {
-		return errors.Wrap(err, "failed to set mount tab")
-	}
-
 	return nil
 }
 
@@ -701,6 +695,11 @@ func (mgr *ContainerManager) initContainerStorage(ctx context.Context, c *Contai
 	// set rootfs disk quota
 	if err = mgr.setRootfsQuota(ctx, c); err != nil {
 		logrus.Warnf("failed to set rootfs disk quota, err(%v)", err)
+	}
+
+	// set volumes into /etc/mtab in container
+	if err = mgr.setMountTab(ctx, c); err != nil {
+		return errors.Wrap(err, "failed to set mount tab")
 	}
 
 	return nil

--- a/storage/quota/quota.go
+++ b/storage/quota/quota.go
@@ -231,6 +231,10 @@ func SetRootfsDiskQuota(basefs, size string, quotaID uint32) (uint32, error) {
 		if err := SetDiskQuota(dir, size, quotaID); err != nil {
 			return 0, errors.Wrapf(err, "failed to set dir(%s) disk quota", dir)
 		}
+
+		if err := SetQuotaForDir(dir, quotaID); err != nil {
+			return 0, errors.Wrapf(err, "failed to set dir(%s) quota recursively", dir)
+		}
 	}
 
 	return quotaID, nil


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
if set `/etc/mtab` before set rootfs quota, it will make /etc/mtab miss
quota id of rootfs quota, so it need be moved after set rootfs quota.

with overlay work dir, it disappear `work/work`, when only set the dir
`work`'s quota id, if we remove set dir quota id by recursively, the
quota id for overlay is invalid.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
I have no good idea

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>

