### PR TITLE
bugfix: make sure SnapshotID not empty when start container

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -761,10 +761,11 @@ func (mgr *ContainerManager) createContainerdContainer(ctx context.Context, c *C
 		IO:             mgr.IOs.Get(c.ID),
 		RootFSProvided: c.RootFSProvided,
 		BaseFS:         c.BaseFS,
-		SnapshotID:     c.SnapshotID,
 		UseSystemd:     mgr.Config.UseSystemd(),
 	}
 	c.Unlock()
+	// make sure the SnapshotID got a proper value
+	ctrdContainer.SnapshotID = c.SnapshotKey()
 
 	if checkpointID != "" {
 		checkpointDir, err = mgr.getCheckpointDir(c.ID, checkpointDir, checkpointID, false)


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
Found a problem on production environment:
```
time="2019-01-21T16:56:13.761316917+08:00" level=error msg="failed to create new containerd container: failed to create container 1edc1d9a416f3ed03d91fd941f040ae16c7a7376c24bf0b5370147c4cc9350e3: snapshot  does not exist: not found: not found"
```

I checked the container's meta.json file and found the `SnapshotID` is empty, though i cannot figure out why this field was empty, but we should make sure the `SnapshotID` should be assigned to proper value.

### Ⅱ. Does this pull request fix one issue?



### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


