### PR TITLE
bugfix: fix wrongly update cpu-quota to 0 

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1328,7 +1328,7 @@ func (mgr *ContainerManager) updateContainerResources(c *Container, resources ty
 	if resources.CPUPeriod != 0 {
 		cResources.CPUPeriod = resources.CPUPeriod
 	}
-	if resources.CPUQuota > -1 {
+	if resources.CPUQuota == -1 || resources.CPUQuota >= 1000 {
 		cResources.CPUQuota = resources.CPUQuota
 	}
 	if resources.CPUShares != 0 {

--- a/test/cli_run_cgroup_test.go
+++ b/test/cli_run_cgroup_test.go
@@ -62,7 +62,7 @@ func testRunWithCgroupParent(c *check.C, cgroupParent, name string) {
 
 	file := filepath.Join(cgroupMount, cgroupPaths["memory"], "memory.limit_in_bytes")
 	if _, err := os.Stat(file); err != nil {
-		c.Fatalf("container %s cgroup mountpoint not exists", name)
+		c.Fatalf("failed to Stat container %s cgroup mountpoint %s: %v", name, file, err)
 	}
 
 	out, err := exec.Command("cat", file).Output()


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

On kernel, `cpu.cfs_quota_us` only support:
  * -1: not limit container's cpu-quota
  * [1000, ∞) : correct values for cpu-quota

So `0` is not a valid value for cpu-quota, we can use `0` to distinct not set from other values in api. In PouchContainer API:
  * 0: don't set cpu-quota
  * -1: not limit containers'cpu-quota
  *  [1000, ∞) : correct values for cpu-quota

### Ⅱ. Does this pull request fix one issue?

fix: https://github.com/alibaba/pouch/issues/2538

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

add test case: PouchUpdateSuite.TestUpdateContainerCPUQuota


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


