### PR TITLE
test: skip the flay case

### DIFF
--- a/test/z_cli_daemon_test.go
+++ b/test/z_cli_daemon_test.go
@@ -476,6 +476,8 @@ func (suite *PouchDaemonSuite) TestDaemonWithMultiRuntimes(c *check.C) {
 // when container is stopped and then pouchd restarts, the restore logic should
 // initialize the existing container IO settings even though they are not alive.
 func (suite *PouchDaemonSuite) TestRestartStoppedContainerAfterDaemonRestart(c *check.C) {
+	c.Skip("The wait command can't guarantee container cleanup job can be done before api return")
+
 	cfgFile := filepath.Join("/tmp", c.TestName())
 	c.Assert(CreateConfigFile(cfgFile, nil), check.IsNil)
 	defer os.RemoveAll(cfgFile)


### PR DESCRIPTION
Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

When the init process in a container exits, the pouchcontainer daemon
will handle the cleanup job, such as update status code, delete the
containerd's task/container record. The action is handled in the
goroutine. Since pouchcontainer doesn't lock the whole container, when
the status has been updated from `running` into `stopped`, the
containerd's task/container records are not removed by the cleanup job.
if the user wants to use `wait` command to make sure that cleanup job
has been done, it will fail because the status is updated first.

The flaky case is running on this case. We can run it until we have
better solutions to make the status notification more stable.



### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

none

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no need

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


