### PR TITLE
feature: exposed rootfs path of the container through inspect command

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -25,6 +25,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	unknowHostRootPath = "<unknown>"
+)
+
 func (s *Server) createContainer(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	label := util_metrics.ActionCreateLabel
 	defer func(start time.Time) {
@@ -84,6 +88,12 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 		mounts = append(mounts, *mp)
 	}
 
+	hostRootPath := unknowHostRootPath
+	mergedDir, ok := c.Snapshotter.Data["MergedDir"]
+	if ok {
+		hostRootPath = mergedDir
+	}
+
 	container := types.ContainerJSON{
 		ID:           c.ID,
 		Name:         c.Name,
@@ -105,6 +115,7 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 		Args:            c.Args,
 		ResolvConfPath:  c.ResolvConfPath,
 		HostnamePath:    c.HostnamePath,
+		HostRootPath:    hostRootPath,
 		HostsPath:       c.HostsPath,
 		Driver:          c.Driver,
 		MountLabel:      c.MountLabel,

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -3484,7 +3484,9 @@ definitions:
       NetworkSettings:
         description: "NetworkSettings exposes the network settings in the API."
         $ref: "#/definitions/NetworkSettings"
-
+      HostRootPath:
+        description: "The rootfs path of the container on the host."
+        type: "string"
   ContainerState:
     type: "object"
     required: [StartedAt, FinishedAt, Pid, ExitCode, Error, OOMKilled, Dead, Paused, Restarting, Running, Status]

--- a/apis/types/container_json.go
+++ b/apis/types/container_json.go
@@ -43,6 +43,9 @@ type ContainerJSON struct {
 	// host config
 	HostConfig *HostConfig `json:"HostConfig,omitempty"`
 
+	// The rootfs path of the container on the host.
+	HostRootPath string `json:"HostRootPath,omitempty"`
+
 	// the path of container's hostname file on host.
 	HostnamePath string `json:"HostnamePath,omitempty"`
 


### PR DESCRIPTION
Signed-off-by: fengzixu <hnustphoenix@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

 Expose rootfs path of the container through inspect command

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixed https://github.com/alibaba/pouch/issues/2588

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it

I run the command as below:

```
./bin/pouch inspect -f {{.HostRootPath}} 29c7be

/var/lib/pouch/containerd/state/io.containerd.runtime.v1.linux/default/29c7be0b112bcf77332d0d71e31675fbb996ca2c3a91ed7f903dd4f7da146ce9/rootfs
```

### Ⅴ. Special notes for reviews


