### PR TITLE
test: shouldn't use string to convert int64 to string

### DIFF
--- a/test/cli_update_test.go
+++ b/test/cli_update_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/alibaba/pouch/apis/types"
@@ -417,7 +418,7 @@ func checkContainerCPUQuota(c *check.C, cName, cpuQuota string) {
 	}
 	containerID = result[0].ID
 
-	if string(result[0].HostConfig.CPUQuota) == cpuQuota {
+	if strconv.FormatInt(result[0].HostConfig.CPUQuota, 10) != cpuQuota {
 		c.Errorf("expect CPUQuota %s, but got: %v", cpuQuota, result[0].HostConfig.CPUQuota)
 	}
 


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did
I made a mistake to use `string` to convert a `int64` to string, in this PR, I would like to fix it.

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


