### PR TITLE
test: skip test cgroup parent when use cgroup ns

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,9 +1,7 @@
 package util
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -96,34 +94,4 @@ func ParseCgroupFile(text string) map[string]string {
 		}
 	}
 	return cgroups
-}
-
-// FindCgroupMountpoint find cgroup mountpoint for a specified subsystem
-func FindCgroupMountpoint(subsystem string) (string, error) {
-	f, err := os.Open("/proc/self/mountinfo")
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		txt := scanner.Text()
-		fields := strings.Fields(txt)
-		if len(fields) < 5 {
-			continue
-		}
-		if strings.Contains(txt, "cgroup") {
-			for _, opt := range strings.Split(fields[len(fields)-1], ",") {
-				if opt == subsystem {
-					return fields[4], nil
-				}
-			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return "", err
-	}
-
-	return "", fmt.Errorf("failed to find %s cgroup mountpoint", subsystem)
 }


### PR DESCRIPTION
in ##2688, I make a mistake to find container cgroup path, since when
containeruse cgroup namespace, we can not get cgroup path from container
with`exec cat proc/self/cgroups`. Skip some test if container use cgroup
namespace.

fixes: #2685

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


