### PR TITLE
bugfix: we should get a container's execids from inspect

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -120,6 +120,7 @@ func (s *Server) getContainer(ctx context.Context, rw http.ResponseWriter, req *
 		Driver:          c.Driver,
 		MountLabel:      c.MountLabel,
 		ProcessLabel:    c.ProcessLabel,
+		ExecIds:         c.ExecIds,
 	}
 
 	return EncodeResponse(rw, http.StatusOK, container)

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -192,7 +192,7 @@ type Container struct {
 	Driver string `json:"Driver,omitempty"`
 
 	// exec ids
-	ExecIds string `json:"ExecIDs,omitempty"`
+	ExecIds []string `json:"ExecIDs,omitempty"`
 
 	// Snapshotter, GraphDriver is same, keep both
 	// just for compatibility

--- a/pkg/collect/safe_map.go
+++ b/pkg/collect/safe_map.go
@@ -8,6 +8,9 @@ type SafeMap struct {
 	inner map[string]interface{}
 }
 
+// ValueFilter defines a function to filter values in map
+type ValueFilter func(interface{}) bool
+
 // NewSafeMap generates a instance of SafeMap type.
 func NewSafeMap() *SafeMap {
 	return &SafeMap{
@@ -26,13 +29,15 @@ func (m *SafeMap) Get(k string) *Value {
 }
 
 // Values returns all key-values stored in map
-func (m *SafeMap) Values() map[string]interface{} {
+func (m *SafeMap) Values(filter ValueFilter) map[string]interface{} {
 	m.RLock()
 	defer m.RUnlock()
 
 	nmap := make(map[string]interface{})
 	for k, v := range m.inner {
-		nmap[k] = v
+		if filter == nil || filter(v) {
+			nmap[k] = v
+		}
 	}
 
 	return nmap

--- a/pkg/collect/safe_map_test.go
+++ b/pkg/collect/safe_map_test.go
@@ -3,8 +3,61 @@ package collect
 import (
 	"testing"
 
+	"github.com/alibaba/pouch/pkg/utils"
+
 	"github.com/stretchr/testify/assert"
 )
+
+// TestSafeMapValues is to valid the Values function
+func TestSafeMapValues(t *testing.T) {
+	safeMap := NewSafeMap()
+	assert.Equal(t, len(safeMap.inner), 0)
+
+	safeMap.Put("key", "value")
+	assert.Equal(t, len(safeMap.inner), 1)
+
+	safeMap.Put("key1", "value1")
+	assert.Equal(t, len(safeMap.inner), 2)
+
+	// first not specify filter
+	values := safeMap.Values(nil)
+	assert.Equal(t, len(values), 2)
+	for k, v := range values {
+		if !utils.StringInSlice([]string{"key", "key1"}, k) {
+			t.Errorf("got unexpected key: %v", k)
+		}
+
+		if k == "key" && v != "value" {
+			t.Errorf("expected 'value', but got %v", v)
+		}
+
+		if k == "key1" && v != "value1" {
+			t.Errorf("expected 'value1', but got %v", v)
+		}
+	}
+
+	// test filter function
+	fn := func(obj interface{}) bool {
+		v, ok := obj.(string)
+		if !ok || v != "value" {
+			return false
+		}
+
+		return true
+	}
+
+	values = safeMap.Values(fn)
+	assert.Equal(t, len(values), 1)
+	v, ok := values["key"]
+	if !ok {
+		t.Errorf("expected 'key' in map, but got: %v", values)
+	}
+
+	stringVar, ok := v.(string)
+	if !ok || stringVar != "value" {
+		t.Errorf("expected map's value is 'value', but got: %v", stringVar)
+	}
+}
 
 func TestSafeMapPutAndGet(t *testing.T) {
 	safeMap := NewSafeMap()
@@ -67,7 +120,7 @@ func TestSafeMapDirectNew(t *testing.T) {
 	sm.Remove("k")
 
 	// test Values not panic
-	values := sm.Values()
+	values := sm.Values(nil)
 	assert.Equal(values, map[string]interface{}{})
 }
 


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>


### Ⅰ. Describe what this PR did
Now we cannot get a container's execids from inspect interface, So I opened this pull request tries to fix this problem. Now we can get the execids:
```
#  pouch inspect -f {{.ExecIds}} b63f88
[27573dc84a363456df62ac26a6258536c8c989a87bf9cbbe95c0adf9619f1c36]
```

But this solution has a problem, the execids  of container's memory data or `meta.json` file may be incorrect, because we only update a container's execids when we call `Get` Container API.

So we can ensure the API's data is correct, but the data in memory or file may incorrect, this solution may not be best, we can discuss it. How about extend the interface:
```golang
// before
Get(ctx context.Context, name string) (*Container, error)

// after changed, execids not stored in ContainerJSON, but by api interface
Get(ctx context.Context, name string) (*Container, []string, error)
``` 

### Ⅱ. Does this pull request fix one issue?
fixes: #2697 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add unit test TestSafeMapValues
add an integration test  TestContainerInspectExecIds

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


