### PR TITLE
refact: refact disk quota api

### DIFF
--- a/apis/opts/diskquota.go
+++ b/apis/opts/diskquota.go
@@ -17,7 +17,7 @@ func ParseDiskQuota(quotas []string) (map[string]string, error) {
 		parts := strings.Split(quota, "=")
 		switch len(parts) {
 		case 1:
-			quotaMaps["/"] = parts[0]
+			quotaMaps[".*"] = parts[0]
 		case 2:
 			quotaMaps[parts[0]] = parts[1]
 		default:
@@ -32,4 +32,33 @@ func ParseDiskQuota(quotas []string) (map[string]string, error) {
 func ValidateDiskQuota(quotaMaps map[string]string) error {
 	// TODO
 	return nil
+}
+
+// ParseQuotaID parses quota id configurations of container.
+func ParseQuotaID(id string, quotas []string) (string, error) {
+	switch len(quotas) {
+	case 0:
+		if isSetQuotaID(id) {
+			return "", fmt.Errorf("invalid to set quota id(%s) without disk-quota", id)
+		}
+	case 1:
+		if isSetQuotaID(id) {
+			return id, nil
+		}
+
+		parts := strings.Split(quotas[0], "=")
+		if len(parts) == 1 {
+			return "-1", nil
+		}
+	default:
+		if isSetQuotaID(id) {
+			return "", fmt.Errorf("invalid to set quota id(%s) for multi disk-quota", id)
+		}
+	}
+
+	return id, nil
+}
+
+func isSetQuotaID(id string) bool {
+	return id != "" && id != "0"
 }

--- a/apis/opts/diskquota_test.go
+++ b/apis/opts/diskquota_test.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -18,7 +19,7 @@ func TestParseDiskQuota(t *testing.T) {
 		// TODO: Add test cases.
 		{name: "test1", args: args{diskquota: []string{""}}, want: nil, wantErr: true},
 		{name: "test2", args: args{diskquota: []string{"foo=foo=foo"}}, want: nil, wantErr: true},
-		{name: "test3", args: args{diskquota: []string{"foo"}}, want: map[string]string{"/": "foo"}, wantErr: false},
+		{name: "test3", args: args{diskquota: []string{"foo"}}, want: map[string]string{".*": "foo"}, wantErr: false},
 		{name: "test4", args: args{diskquota: []string{"foo=foo"}}, want: map[string]string{"foo": "foo"}, wantErr: false},
 		{name: "test5", args: args{diskquota: []string{"foo=foo", "bar=bar"}}, want: map[string]string{"foo": "foo", "bar": "bar"}, wantErr: false},
 	}
@@ -33,5 +34,41 @@ func TestParseDiskQuota(t *testing.T) {
 				t.Errorf("ParseDiskQuota() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseQuotaID(t *testing.T) {
+	tests := []struct {
+		id        string
+		quota     []string
+		expectID  string
+		expectErr error
+	}{
+		{id: "", quota: []string{}, expectID: "", expectErr: nil},
+		{id: "", quota: []string{"20G"}, expectID: "-1", expectErr: nil},
+		{id: "", quota: []string{"20G", "/abc=10G"}, expectID: "", expectErr: nil},
+		{id: "0", quota: []string{}, expectID: "0", expectErr: nil},
+		{id: "0", quota: []string{"20G"}, expectID: "-1", expectErr: nil},
+		{id: "0", quota: []string{"20G", "/abc=10G"}, expectID: "0", expectErr: nil},
+		{id: "-1", quota: []string{}, expectID: "", expectErr: fmt.Errorf("invalid to set quota id(-1) without disk-quota")},
+		{id: "-1", quota: []string{"20G"}, expectID: "-1", expectErr: nil},
+		{id: "-1", quota: []string{"20G", "/abc=10G"}, expectID: "", expectErr: fmt.Errorf("invalid to set quota id(-1) for multi disk-quota")},
+		{id: "1", quota: []string{}, expectID: "", expectErr: fmt.Errorf("invalid to set quota id(1) without disk-quota")},
+		{id: "1", quota: []string{"20G"}, expectID: "1", expectErr: nil},
+		{id: "1", quota: []string{"20G", "/abc=10G"}, expectID: "", expectErr: fmt.Errorf("invalid to set quota id(1) for multi disk-quota")},
+	}
+	for _, tt := range tests {
+		got, err := ParseQuotaID(tt.id, tt.quota)
+		if (err != nil && tt.expectErr == nil) ||
+			(err == nil && tt.expectErr != nil) {
+			t.Fatalf("ParseQuotaID(%v %v) error = %v, wantErr %v", tt.id, tt.quota, err, tt.expectErr)
+		}
+		if err != nil && tt.expectErr != nil && err.Error() != tt.expectErr.Error() {
+			t.Fatalf("ParseQuotaID(%v %v) error = %v, wantErr %v", tt.id, tt.quota, err, tt.expectErr)
+		}
+		if got != tt.expectID {
+			t.Fatalf("ParseQuotaID(%v %v) = %v, want %v", tt.id, tt.quota, got, tt.expectID)
+		}
+
 	}
 }

--- a/cli/container.go
+++ b/cli/container.go
@@ -139,6 +139,11 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 		return nil, err
 	}
 
+	quotaID, err := opts.ParseQuotaID(c.quotaID, c.diskQuota)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := opts.ValidateDiskQuota(diskQuota); err != nil {
 		return nil, err
 	}
@@ -196,7 +201,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 			InitScript:          c.initScript,
 			ExposedPorts:        ports,
 			DiskQuota:           diskQuota,
-			QuotaID:             c.quotaID,
+			QuotaID:             quotaID,
 			SpecAnnotation:      specAnnotation,
 			NetPriority:         c.netPriority,
 			SpecificID:          c.specificID,

--- a/storage/quota/quota.go
+++ b/storage/quota/quota.go
@@ -193,16 +193,10 @@ func GetDefaultQuota(quotas map[string]string) string {
 		return ""
 	}
 
-	// "/" means the disk quota only takes effect on rootfs + 0 * volume
-	quota, ok := quotas["/"]
-	if ok && quota != "" {
-		return quota
-	}
-
 	// ".*" means the disk quota only takes effect on rootfs + n * volume
-	quota, ok = quotas[".*"]
-	if ok && quota != "" {
-		return quota
+	size, ok := quotas[".*"]
+	if ok && size != "" {
+		return size
 	}
 
 	return ""
@@ -268,6 +262,11 @@ func CheckRegularFile(file string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// IsSetQuotaID returns whether set quota id
+func IsSetQuotaID(id string) bool {
+	return id != "" && id != "0"
 }
 
 // getOverlayMountInfo gets overlayFS informantion from /proc/mounts.

--- a/storage/quota/quota_test.go
+++ b/storage/quota/quota_test.go
@@ -22,7 +22,7 @@ func TestGetDefaultQuota(t *testing.T) {
 					"/": "1000kb",
 				},
 			},
-			want: "1000kb",
+			want: "",
 		},
 		{
 			name: "normal case with supposed data .*",
@@ -41,7 +41,7 @@ func TestGetDefaultQuota(t *testing.T) {
 					"/":  "1000kb",
 				},
 			},
-			want: "1000kb",
+			want: "2000kb",
 		},
 		{
 			name: "normal case with no supposed data",

--- a/storage/quota/type.go
+++ b/storage/quota/type.go
@@ -7,6 +7,7 @@ type RegExp struct {
 	Pattern *regexp.Regexp
 	Path    string
 	Size    string
+	QuotaID uint32
 }
 
 // OverlayMount represents the parameters of overlay mount.


### PR DESCRIPTION



<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
for pouch cli command, support two api:
```bash
    --disk-quota []string
    --quota-id  string
```
--disk-quota can be set:
1. --disk-quota=60G
2. --disk-quota=/abc=60G
3. --disk-quota=/&/abc=60G
4. --disk-quota=.*=60G

--quota-id can be set:
1. --quota-id=0, or haven't set quota id(--quota-id="")
2. --quota-id=-1
3. --quota-id=16777216, or more than 16777216

detail rules you can see disk quota documents.

validate disk quota config when create container,
add test case for disk quota.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
run disk quota test case

### Ⅴ. Special notes for reviews


Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>