### PR TITLE
feature: update blkio device's read/write Bps/IOps

### DIFF
--- a/cli/update.go
+++ b/cli/update.go
@@ -40,6 +40,10 @@ func (uc *UpdateCommand) addFlags() {
 	flagSet := uc.cmd.Flags()
 	flagSet.SetInterspersed(false)
 	flagSet.Uint16Var(&uc.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable")
+	flagSet.Var(&uc.blkioDeviceReadBps, "device-read-bps", "Update read rate (bytes per second) from a device")
+	flagSet.Var(&uc.blkioDeviceReadIOps, "device-read-iops", "Update read rate (io per second) from a device")
+	flagSet.Var(&uc.blkioDeviceWriteBps, "device-write-bps", "Update write rate (bytes per second) from a device")
+	flagSet.Var(&uc.blkioDeviceWriteIOps, "device-write-iops", "Update write rate (io per second) from a device")
 	flagSet.Int64Var(&uc.cpuperiod, "cpu-period", 0, "Limit CPU CFS (Completely Fair Scheduler) period, range is in [1000(1ms),1000000(1s)]")
 	flagSet.Int64Var(&uc.cpushare, "cpu-shares", 0, "CPU shares (relative weight)")
 	flagSet.Int64Var(&uc.cpuquota, "cpu-quota", 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
@@ -69,14 +73,18 @@ func (uc *UpdateCommand) updateRun(args []string) error {
 	}
 
 	resource := types.Resources{
-		CPUPeriod:   uc.cpuperiod,
-		CPUShares:   uc.cpushare,
-		CPUQuota:    uc.cpuquota,
-		CpusetCpus:  uc.cpusetcpus,
-		CpusetMems:  uc.cpusetmems,
-		Memory:      memory,
-		MemorySwap:  memorySwap,
-		BlkioWeight: uc.blkioWeight,
+		BlkioWeight:          uc.blkioWeight,
+		BlkioDeviceReadBps:   uc.blkioDeviceReadBps.Value(),
+		BlkioDeviceReadIOps:  uc.blkioDeviceReadIOps.Value(),
+		BlkioDeviceWriteBps:  uc.blkioDeviceWriteBps.Value(),
+		BlkioDeviceWriteIOps: uc.blkioDeviceWriteIOps.Value(),
+		CPUPeriod:            uc.cpuperiod,
+		CPUShares:            uc.cpushare,
+		CPUQuota:             uc.cpuquota,
+		CpusetCpus:           uc.cpusetcpus,
+		CpusetMems:           uc.cpusetmems,
+		Memory:               memory,
+		MemorySwap:           memorySwap,
 	}
 
 	restartPolicy, err := opts.ParseRestartPolicy(uc.restartPolicy)

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1343,6 +1343,18 @@ func (mgr *ContainerManager) updateContainerResources(c *Container, resources ty
 	if resources.BlkioWeight != 0 {
 		cResources.BlkioWeight = resources.BlkioWeight
 	}
+	if len(resources.BlkioDeviceReadBps) != 0 {
+		cResources.BlkioDeviceReadBps = resources.BlkioDeviceReadBps
+	}
+	if len(resources.BlkioDeviceReadIOps) != 0 {
+		cResources.BlkioDeviceReadIOps = resources.BlkioDeviceReadIOps
+	}
+	if len(resources.BlkioDeviceWriteBps) != 0 {
+		cResources.BlkioDeviceWriteBps = resources.BlkioDeviceWriteBps
+	}
+	if len(resources.BlkioDeviceWriteIOps) != 0 {
+		cResources.BlkioDeviceWriteIOps = resources.BlkioDeviceWriteIOps
+	}
 	if resources.CPUPeriod != 0 {
 		cResources.CPUPeriod = resources.CPUPeriod
 	}


### PR DESCRIPTION
Support update limit of block device, including read/write
bps/iops.

fix #2509 

This patch is rebased from @houstar .
related: https://github.com/alibaba/pouch/pull/2563


Signed-off-by: Wang Rui <baijia.wr@antfin.com>
Signed-off-by: Leno Hou <lenohou@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


