### PR TITLE
test: increate the memory limit to TestRunWithMemoryswap2x

### DIFF
--- a/test/cli_run_memory_test.go
+++ b/test/cli_run_memory_test.go
@@ -75,8 +75,8 @@ func (suite *PouchRunMemorySuite) TestRunWithMemoryswap(c *check.C) {
 
 	// test memory swap should be 2x memory if not specify it.
 	cname = "TestRunWithMemoryswap2x"
-	memory = "10m"
-	expected = 2 * 10 * m
+	memory = "20m"
+	expected = 2 * 20 * m
 
 	res = command.PouchRun("run", "-d", "-m", memory,
 		"--name", cname, busyboxImage, "sleep", sleep)


### PR DESCRIPTION
Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

For the CVE-2019-5736, the runC will copy the binary during initializing
process in container. The binary is about 11M so that it will make the
case fail. Based on this, we should increate to 20m.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

none

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no need

### Ⅳ. Describe how to verify it

CI

### Ⅴ. Special notes for reviews


