### PR TITLE
feature: add kernel-memory support in cli and ctrd

### DIFF
--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -54,10 +54,10 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringArrayVar(&c.logOpts, "log-opt", nil, "Log driver options")
 
 	// memory
-
 	flagSet.StringVarP(&c.memory, "memory", "m", "", "Memory limit")
 	flagSet.StringVar(&c.memorySwap, "memory-swap", "", "Swap limit equal to memory + swap, '-1' to enable unlimited swap")
 	flagSet.Int64Var(&c.memorySwappiness, "memory-swappiness", 0, "Container memory swappiness [0, 100]")
+	flagSet.StringVar(&c.kernelMemory, "kernel-memory", "", "Kernel memory limit (in bytes)")
 	// for alikernel isolation options
 	flagSet.Int64Var(&c.memoryWmarkRatio, "memory-wmark-ratio", 0, "Represent this container's memory low water mark percentage, range in [0, 100]. The value of memory low water mark is memory.limit_in_bytes * MemoryWmarkRatio")
 	flagSet.Int64Var(&c.memoryExtra, "memory-extra", 0, "Represent container's memory high water mark percentage, range in [0, 100]")

--- a/cli/container.go
+++ b/cli/container.go
@@ -43,6 +43,7 @@ type container struct {
 	memory           string
 	memorySwap       string
 	memorySwappiness int64
+	kernelMemory     string
 
 	memoryWmarkRatio    int64
 	memoryExtra         int64
@@ -106,6 +107,11 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 	}
 
 	memorySwap, err := opts.ParseMemorySwap(c.memorySwap)
+	if err != nil {
+		return nil, err
+	}
+
+	kmemory, err := opts.ParseMemory(c.kernelMemory)
 	if err != nil {
 		return nil, err
 	}
@@ -223,6 +229,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 				Memory:           memory,
 				MemorySwap:       memorySwap,
 				MemorySwappiness: &c.memorySwappiness,
+				KernelMemory:     kmemory,
 				// FIXME: validate in client side
 				MemoryWmarkRatio:    &c.memoryWmarkRatio,
 				MemoryExtra:         &c.memoryExtra,

--- a/ctrd/utils.go
+++ b/ctrd/utils.go
@@ -153,6 +153,8 @@ func toLinuxResources(resources types.Resources) (*specs.LinuxResources, error) 
 		Limit:       &resources.Memory,
 		Swap:        &resources.MemorySwap,
 		Reservation: &resources.MemoryReservation,
+		Kernel:      &resources.KernelMemory,
+		// TODO: add other fields of specs.LinuxMemory
 	}
 
 	// TODO: add more fields.

--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -207,6 +207,11 @@ func setupMemory(ctx context.Context, r types.Resources, s *specs.Spec) {
 		memory.DisableOOMKiller = &v
 	}
 
+	if r.KernelMemory > 0 {
+		v := r.KernelMemory
+		memory.Kernel = &v
+	}
+
 	s.Linux.Resources.Memory = memory
 }
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

This feature add kernel-memory support in cli part and containerd part.

Actually we have add KernelMemory in swagger.yml in https://github.com/alibaba/pouch/blob/master/apis/swagger.yml#L2676. Then in the API side, this field has been supported in the struct definition of `Resource`.

However in the daemon side, we have not set it in the LinuxResource of runc. Then there is no way to set kernel memory for PouchContainer.

This PR tries to fix that, and this pr did:

* add kernel-memory flag in cli side;
* deal kernel-memory in daemon side to insert it for containerd;
* add kernel-memory checking in test case and refactor memory test case to add memory checking.


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix https://github.com/alibaba/pouch/issues/2716


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

