### PR TITLE
daemon/mgr/image: update deadline for loading images

### DIFF
--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -30,7 +30,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var deadlineLoadImagesAtBootup = time.Second * 10
+// The daemon will load all the images from containerd into memory. At
+// the beginning, we assume that it can load it in 10 secs. But if the
+// system has busy IO, it will take long time to load it, especially the
+// more-layers and huge-size images. So update it from 10 secs to 10 mins.
+var deadlineLoadImagesAtBootup = time.Minute * 10
 
 // the filter tags set allowed when pouch images -f
 var acceptedImageFilterTags = map[string]bool{


### PR DESCRIPTION


Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

PouchContainer will load all the images from containerd into memory. At
the beginning, we assume that it can load it in 10 secs. But if the
system has busy IO, it will take long time to load it, especially the
more-layers and huge-size images. So update it from 10 secs to 10 mins.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

none

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no need.

### Ⅳ. Describe how to verify it

CI

### Ⅴ. Special notes for reviews


