### PR TITLE
Revert "test: increate the memory limit to TestRunWithMemoryswap2x"

### DIFF
--- a/test/cli_run_memory_test.go
+++ b/test/cli_run_memory_test.go
@@ -75,8 +75,8 @@ func (suite *PouchRunMemorySuite) TestRunWithMemoryswap(c *check.C) {
 
 	// test memory swap should be 2x memory if not specify it.
 	cname = "TestRunWithMemoryswap2x"
-	memory = "20m"
-	expected = 2 * 20 * m
+	memory = "10m"
+	expected = 2 * 10 * m
 
 	res = command.PouchRun("run", "-d", "-m", memory,
 		"--name", cname, busyboxImage, "sleep", sleep)


### PR DESCRIPTION
This reverts commit 69e6356fabc6019276a6a0dca994439d6bd69768.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

Thank for the wonderful work in https://github.com/opencontainers/runc/pull/1984 slove this problem with bind way, by the way, it also sloved the kernel limit problem in https://github.com/opencontainers/runc/issues/1979

After https://github.com/alibaba/runc/pull/20 merged, we can revert the change in `TestRunWithMemoryswap2x`.

/cc @fuweid 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


