### PR TITLE
[RFC]refactor: refact the container lock

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -3524,6 +3524,20 @@ definitions:
         description: "Whether this container is dead."
         type: "boolean"
         x-nullable: false
+      Exited:
+        description: |
+          Whether this container is abnormal stopped. So that we can distinguish whether
+          a container stoppped by API or abnormal.
+
+          This flag can be used on the circumstances that when the host restart and try to pull up
+          the containers that are running before host down. If we have a container with `RestartPolicy`
+          is `always` but the `Status` is `Stopped`, should we start it or not?
+
+          So with the `Exited` flag being set, we can make sure that this container is exited by abnormal,
+          we should pull it up. But with status is `Stopped`, we should not pull it up because it is stopped
+          by API.
+        type: "boolean"
+        x-nullable: false
       Pid:
         x-nullable: false
         description: "The process ID of this container"

--- a/apis/types/container_state.go
+++ b/apis/types/container_state.go
@@ -28,6 +28,19 @@ type ContainerState struct {
 	// Required: true
 	ExitCode int64 `json:"ExitCode"`
 
+	// Whether this container is abnormal stopped. So that we can distinguish whether
+	// a container stoppped by API or abnormal.
+	//
+	// This flag can be used on the circumstances that when the host restart and try to pull up
+	// the containers that are running before host down. If we have a container with `RestartPolicy`
+	// is `always` but the `Status` is `Stopped`, should we start it or not?
+	//
+	// So with the `Exited` flag being set, we can make sure that this container is exited by abnormal,
+	// we should pull it up. But with status is `Stopped`, we should not pull it up because it is stopped
+	// by API.
+	//
+	Exited bool `json:"Exited,omitempty"`
+
 	// The time when this container last exited.
 	// Required: true
 	FinishedAt string `json:"FinishedAt"`

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -556,7 +556,7 @@ func (mgr *ContainerManager) Get(ctx context.Context, name string) (*Container, 
 	if err != nil {
 		return nil, err
 	}
-	cID := c.Key()
+	cID := c.ID
 
 	// get all execids belongs to this container
 	fn := func(v interface{}) bool {
@@ -589,16 +589,6 @@ func (mgr *ContainerManager) Start(ctx context.Context, id string, options *type
 		return err
 	}
 
-	// check if container's status is paused
-	if c.IsPaused() {
-		return fmt.Errorf("cannot start a paused container, try unpause instead")
-	}
-
-	// check if container's status is running
-	if c.IsRunning() {
-		return errors.Wrapf(errtypes.ErrNotModified, "container already started")
-	}
-
 	// NOTE: choose snapshotter, snapshotter can only be set
 	// through containerPlugin in Create function
 	ctx = ctrd.WithSnapshotter(ctx, c.Config.Snapshotter)
@@ -612,8 +602,22 @@ func (mgr *ContainerManager) Start(ctx context.Context, id string, options *type
 }
 
 func (mgr *ContainerManager) start(ctx context.Context, c *Container, options *types.ContainerStartOptions) error {
+	// NOTE: add a big lock when start a container
+	c.Lock()
+	defer c.Unlock()
+
 	var err error
 	c.DetachKeys = options.DetachKeys
+
+	// check if container's status is paused
+	if c.State.Paused {
+		return fmt.Errorf("cannot start a paused container, try unpause instead")
+	}
+
+	// check if container's status is running
+	if c.State.Running {
+		return errors.Wrapf(errtypes.ErrNotModified, "container already started")
+	}
 
 	attachedVolumes := map[string]struct{}{}
 	defer func() {
@@ -657,9 +661,6 @@ func (mgr *ContainerManager) start(ctx context.Context, c *Container, options *t
 }
 
 func (mgr *ContainerManager) prepareContainerNetwork(ctx context.Context, c *Container) error {
-	c.Lock()
-	defer c.Unlock()
-
 	networkMode := c.HostConfig.NetworkMode
 
 	if IsContainer(networkMode) {
@@ -736,11 +737,9 @@ func (mgr *ContainerManager) buildNetworkRelatedPath(c *Container) error {
 func (mgr *ContainerManager) createContainerdContainer(ctx context.Context, c *Container, checkpointDir, checkpointID string) error {
 	// CgroupParent from HostConfig will be first priority to use,
 	// then will be value from mgr.Config.CgroupParent
-	c.Lock()
 	if c.HostConfig.CgroupParent == "" {
 		c.HostConfig.CgroupParent = mgr.Config.CgroupParent
 	}
-	c.Unlock()
 
 	var (
 		err     error
@@ -790,7 +789,6 @@ func (mgr *ContainerManager) createContainerdContainer(ctx context.Context, c *C
 		return err
 	}
 
-	c.Lock()
 	ctrdContainer := &ctrd.Container{
 		ID:             c.ID,
 		Image:          c.Config.Image,
@@ -802,7 +800,6 @@ func (mgr *ContainerManager) createContainerdContainer(ctx context.Context, c *C
 		BaseFS:         c.BaseFS,
 		UseSystemd:     mgr.Config.UseSystemd(),
 	}
-	c.Unlock()
 	// make sure the SnapshotID got a proper value
 	ctrdContainer.SnapshotID = c.SnapshotKey()
 
@@ -831,9 +828,7 @@ func (mgr *ContainerManager) createContainerdContainer(ctx context.Context, c *C
 	c.SetStatusRunning(int64(pid))
 
 	// set Snapshot MergedDir
-	c.Lock()
 	c.Snapshotter.Data["MergedDir"] = c.BaseFS
-	c.Unlock()
 
 	return c.Write(mgr.Store)
 }
@@ -892,15 +887,6 @@ func (mgr *ContainerManager) Stop(ctx context.Context, name string, timeout int6
 		return err
 	}
 
-	if !c.IsRunningOrPaused() {
-		// stopping a non-running container is valid.
-		return nil
-	}
-
-	if timeout == 0 {
-		timeout = c.StopTimeout()
-	}
-
 	// NOTE: choose snapshotter, snapshotter can only be set
 	// through containerPlugin in Create function
 	ctx = ctrd.WithSnapshotter(ctx, c.Config.Snapshotter)
@@ -915,6 +901,18 @@ func (mgr *ContainerManager) Stop(ctx context.Context, name string, timeout int6
 }
 
 func (mgr *ContainerManager) stop(ctx context.Context, c *Container, timeout int64) error {
+	c.Lock()
+	defer c.Unlock()
+
+	if !c.IsRunningOrPaused() {
+		// stopping a non-running container is valid.
+		return nil
+	}
+
+	if timeout == 0 {
+		timeout = c.StopTimeout()
+	}
+
 	id := c.ID
 	msg, err := mgr.Client.DestroyContainer(ctx, id, timeout)
 	if err != nil {
@@ -929,10 +927,6 @@ func (mgr *ContainerManager) Restart(ctx context.Context, name string, timeout i
 	c, err := mgr.container(name)
 	if err != nil {
 		return err
-	}
-
-	if timeout == 0 {
-		timeout = c.StopTimeout()
 	}
 
 	// NOTE: choose snapshotter, snapshotter can only be set
@@ -950,16 +944,14 @@ func (mgr *ContainerManager) Restart(ctx context.Context, name string, timeout i
 
 	logrus.Debugf("start container %s when restarting", c.ID)
 
-	//let restartCount++
-	restartCount := c.RestartCount + 1
-
 	// start container
 	err = mgr.start(ctx, c, &types.ContainerStartOptions{})
 	if err != nil {
 		return err
 	}
 
-	c.RestartCount = restartCount
+	// count start times
+	c.RestartCount++
 
 	logrus.Debugf("container %s restartCount is %d", c.ID, c.RestartCount)
 	return c.Write(mgr.Store)
@@ -972,7 +964,10 @@ func (mgr *ContainerManager) Pause(ctx context.Context, name string) error {
 		return err
 	}
 
-	if !c.IsRunning() {
+	c.Lock()
+	defer c.Unlock()
+
+	if !c.State.Running {
 		return fmt.Errorf("container's status is not running: %s", c.State.Status)
 	}
 
@@ -998,7 +993,10 @@ func (mgr *ContainerManager) Unpause(ctx context.Context, name string) error {
 		return err
 	}
 
-	if !c.IsPaused() {
+	c.Lock()
+	defer c.Unlock()
+
+	if !c.State.Paused {
 		return fmt.Errorf("status(%s) of container %s is not paused", c.State.Status, c.ID)
 	}
 
@@ -1071,14 +1069,15 @@ func (mgr *ContainerManager) Rename(ctx context.Context, oldName, newName string
 		return errors.Wrapf(err, "failed to rename container %s", oldName)
 	}
 
+	c.Lock()
+	defer c.Unlock()
+
 	attributes := map[string]string{
 		"oldName": oldName,
 	}
 
-	c.Lock()
 	name := c.Name
 	c.Name = newName
-	c.Unlock()
 
 	mgr.NameToID.Remove(name)
 	mgr.NameToID.Put(newName, c.ID)
@@ -1099,6 +1098,9 @@ func (mgr *ContainerManager) Update(ctx context.Context, name string, config *ty
 		return err
 	}
 
+	c.Lock()
+	defer c.Unlock()
+
 	warnings, err := validateResource(&config.Resources, true)
 	if err != nil {
 		return err
@@ -1112,14 +1114,12 @@ func (mgr *ContainerManager) Update(ctx context.Context, name string, config *ty
 	oldHostconfig := *c.HostConfig
 	defer func() {
 		if restore {
-			c.Lock()
 			c.Config = &oldConfig
 			c.HostConfig = &oldHostconfig
-			c.Unlock()
 		}
 	}()
 
-	if c.IsRunning() && config.Resources.KernelMemory != 0 {
+	if c.State.Running && config.Resources.KernelMemory != 0 {
 		return fmt.Errorf("failed to update container %s: can not update kernel memory to a running container, please stop it first", c.ID)
 	}
 
@@ -1127,8 +1127,6 @@ func (mgr *ContainerManager) Update(ctx context.Context, name string, config *ty
 	if err := mgr.updateContainerDiskQuota(ctx, c, config.DiskQuota); err != nil {
 		return errors.Wrapf(err, "failed to update diskquota of container %s", c.ID)
 	}
-
-	c.Lock()
 
 	// init Container Labels
 	if c.Config.Labels == nil {
@@ -1152,7 +1150,6 @@ func (mgr *ContainerManager) Update(ctx context.Context, name string, config *ty
 			}
 		}
 	}
-	c.Unlock()
 
 	// update Resources of a container.
 	if err := mgr.updateContainerResources(c, config.Resources); err != nil {
@@ -1160,12 +1157,10 @@ func (mgr *ContainerManager) Update(ctx context.Context, name string, config *ty
 		return errors.Wrapf(err, "failed to update resource of container %s", c.ID)
 	}
 
-	c.Lock()
 	// TODO update restartpolicy when container is running.
 	if config.RestartPolicy != nil && config.RestartPolicy.Name != "" {
 		c.HostConfig.RestartPolicy = config.RestartPolicy
 	}
-	c.Unlock()
 
 	// Update Env
 	newEnvSlice, err := mergeEnvSlice(config.Env, c.Config.Env)
@@ -1184,11 +1179,9 @@ func (mgr *ContainerManager) Update(ctx context.Context, name string, config *ty
 		}
 	}
 
-	c.Lock()
 	if len(config.SpecAnnotation) > 0 {
 		c.Config.SpecAnnotation = mergeAnnotation(config.SpecAnnotation, c.Config.SpecAnnotation)
 	}
-	c.Unlock()
 
 	if mgr.containerPlugin != nil && len(config.Env) > 0 {
 		if err = mgr.containerPlugin.PostUpdate(c.BaseFS, c.Config.Env); err != nil {
@@ -1199,7 +1192,7 @@ func (mgr *ContainerManager) Update(ctx context.Context, name string, config *ty
 	// If container is not running, update container metadata struct is enough,
 	// resources will be updated when the container is started again,
 	// If container is running, we need to update configs to the real world.
-	if c.IsRunning() {
+	if c.State.Running {
 		if err := mgr.Client.UpdateResources(ctx, c.ID, c.HostConfig.Resources); err != nil {
 			restore = true
 			return fmt.Errorf("failed to update resource: %s", err)
@@ -1227,12 +1220,15 @@ func (mgr *ContainerManager) Remove(ctx context.Context, name string, options *t
 	// through containerPlugin in Create function
 	ctx = ctrd.WithSnapshotter(ctx, c.Config.Snapshotter)
 
-	if !c.IsStopped() && !c.IsExited() && !c.IsCreated() && !options.Force {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.IsRunningOrPaused() && !options.Force {
 		return fmt.Errorf("container %s is not stopped, cannot remove it without flag force", c.ID)
 	}
 
 	// if the container is running, force to stop it.
-	if c.IsRunning() && options.Force {
+	if c.IsRunningOrPaused() && options.Force {
 		_, err := mgr.Client.DestroyContainer(ctx, c.ID, c.StopTimeout())
 		if err != nil && !errtypes.IsNotfound(err) {
 			return errors.Wrapf(err, "failed to destroy container %s when removing", c.ID)
@@ -1298,20 +1294,16 @@ func (mgr *ContainerManager) updateContainerDiskQuota(ctx context.Context, c *Co
 	origDiskQuota := c.Config.DiskQuota
 	defer func() {
 		if err != nil {
-			c.Lock()
 			c.Config.DiskQuota = origDiskQuota
-			c.Unlock()
 		}
 	}()
 
-	c.Lock()
 	if c.Config.DiskQuota == nil {
 		c.Config.DiskQuota = make(map[string]string)
 	}
 	for dir, quota := range diskQuota {
 		c.Config.DiskQuota[dir] = quota
 	}
-	c.Unlock()
 
 	// set mount point disk quota
 	if err = mgr.setDiskQuota(ctx, c, false); err != nil {
@@ -1323,8 +1315,6 @@ func (mgr *ContainerManager) updateContainerDiskQuota(ctx context.Context, c *Co
 
 // updateContainerResources update container's resources parameters.
 func (mgr *ContainerManager) updateContainerResources(c *Container, resources types.Resources) error {
-	c.Lock()
-	defer c.Unlock()
 	// update resources of container.
 	cResources := &c.HostConfig.Resources
 	if resources.BlkioWeight != 0 {
@@ -1389,6 +1379,9 @@ func (mgr *ContainerManager) Top(ctx context.Context, name string, psArgs string
 		return nil, err
 	}
 
+	c.Lock()
+	defer c.Unlock()
+
 	if !c.IsRunningOrPaused() {
 		return nil, fmt.Errorf("container %s is not running or paused, cannot execute top command", c.ID)
 	}
@@ -1418,6 +1411,9 @@ func (mgr *ContainerManager) Resize(ctx context.Context, name string, opts types
 		return err
 	}
 
+	c.Lock()
+	defer c.Unlock()
+
 	if !c.IsRunningOrPaused() {
 		return fmt.Errorf("failed to resize container %s: container is not running", c.ID)
 	}
@@ -1435,16 +1431,10 @@ func (mgr *ContainerManager) Wait(ctx context.Context, name string) (types.Conta
 	// We should notice that container's meta data shouldn't be locked in wait process, otherwise waiting for
 	// a running container to stop would make other client commands which manage this container are blocked.
 	// If a container status is exited or stopped, return exit code immediately.
-	if c.IsExited() || c.IsStopped() {
+	if !c.IsRunningOrPaused() {
 		return types.ContainerWaitOKBody{
 			Error:      c.State.Error,
 			StatusCode: c.ExitCode(),
-		}, nil
-	}
-	// If a container status is created, return 0 as status code.
-	if c.IsCreated() {
-		return types.ContainerWaitOKBody{
-			StatusCode: 0,
 		}, nil
 	}
 
@@ -1470,8 +1460,11 @@ func (mgr *ContainerManager) Connect(ctx context.Context, name string, networkID
 		epConfig = &types.EndpointSettings{}
 	}
 
-	if !c.IsRunning() {
-		if c.IsDead() {
+	c.Lock()
+	defer c.Unlock()
+
+	if !c.State.Running {
+		if c.State.Dead {
 			return fmt.Errorf("container %s is marked for removal and cannot be connected or disconnected to the network %s", c.ID, n.Name)
 		}
 
@@ -1502,32 +1495,26 @@ func (mgr *ContainerManager) Disconnect(ctx context.Context, containerName, netw
 		return fmt.Errorf("failed to get network %s when disconnecting container %s: %v", networkName, c.Name, err)
 	}
 
-	// container cannot be disconnected from host network
 	c.Lock()
-	networkMode := c.HostConfig.NetworkMode
-	c.Unlock()
+	defer c.Unlock()
 
+	// container cannot be disconnected from host network
+	networkMode := c.HostConfig.NetworkMode
 	if IsHost(networkMode) && IsHost(network.Mode) {
 		return fmt.Errorf("container cannot be disconnected from host network or connected to hostnetwork ")
 	}
 
-	c.Lock()
-	networkSettings := c.NetworkSettings
-	c.Unlock()
-
-	if networkSettings == nil {
+	if c.NetworkSettings == nil {
 		return nil
 	}
 
-	epConfig, ok := networkSettings.Networks[network.Name]
+	epConfig, ok := c.NetworkSettings.Networks[network.Name]
 	if !ok {
 		// container not attached to the given network
 		return fmt.Errorf("failed to disconnect container from network: container %s not attach to %s", c.Name, networkName)
 	}
 
-	c.Lock()
 	endpoint := mgr.buildContainerEndpoint(c, network.Name)
-	c.Unlock()
 	endpoint.EndpointConfig = epConfig
 	if err := mgr.NetworkMgr.EndpointRemove(ctx, endpoint); err != nil {
 		// TODO(ziren): it is a trick, we should wrapper sandbox
@@ -1539,18 +1526,16 @@ func (mgr *ContainerManager) Disconnect(ctx context.Context, containerName, netw
 	}
 
 	// disconnect an endpoint success, delete endpoint info from container json
-	delete(networkSettings.Networks, network.Name)
+	delete(c.NetworkSettings.Networks, network.Name)
 
 	// if container has no network attached any more, set NetworkDisabled to true
 	// so that not setup Network Namespace when restart the container
-	c.Lock()
-	if len(networkSettings.Networks) == 0 {
+	if len(c.NetworkSettings.Networks) == 0 {
 		c.Config.NetworkDisabled = true
 	}
 
 	// container meta changed, refresh the cache
 	mgr.cache.Put(c.ID, c)
-	c.Unlock()
 
 	mgr.LogNetworkEventWithAttributes(ctx, network.Network, "disconnect", map[string]string{"container": c.ID})
 
@@ -1617,9 +1602,7 @@ func (mgr *ContainerManager) connectToNetwork(ctx context.Context, container *Co
 		return errors.Wrap(err, "failed to get network")
 	}
 
-	container.Lock()
 	endpoint := mgr.buildContainerEndpoint(container, network.Name)
-	container.Unlock()
 	endpoint.EndpointConfig = epConfig
 	if _, err := mgr.NetworkMgr.EndpointCreate(ctx, endpoint); err != nil {
 		logrus.Errorf("failed to create endpoint: %v", err)
@@ -1773,6 +1756,9 @@ func (mgr *ContainerManager) exitedAndRelease(id string, m *ctrd.Message, cleanu
 		return err
 	}
 
+	c.Lock()
+	defer c.Unlock()
+
 	if err := mgr.markExitedAndRelease(c, m); err != nil {
 		return err
 	}
@@ -1797,14 +1783,12 @@ func (mgr *ContainerManager) exitedAndRelease(id string, m *ctrd.Message, cleanu
 	// send exit event to monitor
 	mgr.monitor.PostEvent(ContainerExitEvent(c).WithHandle(func(c *Container) error {
 		// check status and restart policy
-		if !c.IsExited() {
+		if !c.State.Exited {
 			return nil
 		}
 
-		c.Lock()
 		policy := (*ContainerRestartPolicy)(c.HostConfig.RestartPolicy)
 		keys := c.DetachKeys
-		c.Unlock()
 
 		if policy == nil || policy.IsNone() {
 			return nil
@@ -1850,18 +1834,11 @@ func (mgr *ContainerManager) releaseContainerResources(c *Container) error {
 
 // releaseContainerNetwork release container network when container exits or is stopped.
 func (mgr *ContainerManager) releaseContainerNetwork(c *Container) error {
-	c.Lock()
-	defer c.Unlock()
-
 	// NetworkMgr is nil, which means the pouch daemon is initializing.
 	// And the libnetwork will also initialize, which will release all
 	// staled network resources(endpoint, network and namespace). So we
 	// don't need release the network resources.
-	if mgr.NetworkMgr == nil {
-		return nil
-	}
-
-	if c.NetworkSettings == nil {
+	if mgr.NetworkMgr == nil || c.NetworkSettings == nil {
 		return nil
 	}
 
@@ -1923,9 +1900,7 @@ func (mgr *ContainerManager) setBaseFS(ctx context.Context, c *Container) {
 	}
 
 	// io.containerd.runtime.v1.linux as a const used by runc
-	c.Lock()
 	c.BaseFS = filepath.Join(mgr.Config.HomeDir, "containerd/state", "io.containerd.runtime.v1.linux", mgr.Config.DefaultNamespace, c.ID, "rootfs")
-	c.Unlock()
 }
 
 // execProcessGC cleans unused exec processes config every 5 minutes.

--- a/daemon/mgr/container_checkpoint.go
+++ b/daemon/mgr/container_checkpoint.go
@@ -59,7 +59,7 @@ func (mgr *ContainerManager) CreateCheckpoint(ctx context.Context, name string, 
 		return err
 	}
 
-	if c.State.Status != types.StatusRunning {
+	if !c.IsRunningOrPaused() {
 		return fmt.Errorf("can not checkpoint from a %s container", c.State.Status)
 	}
 

--- a/daemon/mgr/container_exec.go
+++ b/daemon/mgr/container_exec.go
@@ -24,7 +24,7 @@ func (mgr *ContainerManager) CreateExec(ctx context.Context, name string, config
 		return "", err
 	}
 
-	if !c.IsRunning() {
+	if !c.State.Running {
 		return "", fmt.Errorf("container %s is not running", c.ID)
 	}
 

--- a/daemon/mgr/container_logs.go
+++ b/daemon/mgr/container_logs.go
@@ -57,7 +57,7 @@ func (mgr *ContainerManager) Logs(ctx context.Context, name string, logOpt *type
 	}
 
 	// NOTE: unset the follow if the container is not running
-	cfg.Follow = cfg.Follow && c.IsRunning()
+	cfg.Follow = cfg.Follow && c.State.Running
 
 	msgCh := make(chan *logger.LogMessage, 1)
 	watcher := jf.ReadLogMessages(cfg)
@@ -103,7 +103,7 @@ func (mgr *ContainerManager) Logs(ctx context.Context, name string, logOpt *type
 				// This case will be convered by the followFile
 				// in daemon/logger/jsonfile package.
 				if c, ok := mgr.cache.Get(c.ID).Result(); ok {
-					if !c.(*Container).IsRunning() {
+					if !c.(*Container).State.Running {
 						return
 					}
 				}

--- a/daemon/mgr/container_stats.go
+++ b/daemon/mgr/container_stats.go
@@ -112,8 +112,7 @@ func (mgr *ContainerManager) Stats(ctx context.Context, name string) (*container
 	}
 
 	c.Lock()
-	ID := c.ID
-	c.Unlock()
+	defer c.Unlock()
 
 	// only get metrics when the container is running
 	// return error to help client quick fail
@@ -121,7 +120,7 @@ func (mgr *ContainerManager) Stats(ctx context.Context, name string) (*container
 		return nil, nil, errors.New("can only stats running or paused container")
 	}
 
-	metric, err := mgr.Client.ContainerStats(ctx, ID)
+	metric, err := mgr.Client.ContainerStats(ctx, c.ID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/daemon/mgr/container_storage.go
+++ b/daemon/mgr/container_storage.go
@@ -670,9 +670,6 @@ func (mgr *ContainerManager) detachVolumes(ctx context.Context, c *Container, re
 
 // setMountFS is used to set mountfs directory.
 func (mgr *ContainerManager) setMountFS(ctx context.Context, c *Container) {
-	c.Lock()
-	defer c.Unlock()
-
 	c.MountFS = path.Join(mgr.Store.Path(c.ID), "rootfs")
 }
 

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -273,28 +273,17 @@ type Container struct {
 
 // Key returns container's id.
 func (c *Container) Key() string {
-	c.Lock()
-	defer c.Unlock()
 	return c.ID
 }
 
 // SnapshotKey returns id of container's snapshot
 func (c *Container) SnapshotKey() string {
-	c.Lock()
-	defer c.Unlock()
 	// for old container, SnapshotKey equals to Container ID
 	if c.SnapshotID == "" {
 		return c.ID
 	}
 
 	return c.SnapshotID
-}
-
-// SetSnapshotID sets the snapshot id of container
-func (c *Container) SetSnapshotID(snapID string) {
-	c.Lock()
-	defer c.Unlock()
-	c.SnapshotID = snapID
 }
 
 // Write writes container's meta data into meta store.
@@ -304,8 +293,6 @@ func (c *Container) Write(store *meta.Store) error {
 
 // StopTimeout returns the timeout (in seconds) used to stop the container.
 func (c *Container) StopTimeout() int64 {
-	c.Lock()
-	defer c.Unlock()
 	if c.Config.StopTimeout != nil {
 		return *c.Config.StopTimeout
 	}
@@ -313,8 +300,6 @@ func (c *Container) StopTimeout() int64 {
 }
 
 func (c *Container) merge(getconfig func() (v1.ImageConfig, error)) error {
-	c.Lock()
-	defer c.Unlock()
 	imageConf, err := getconfig()
 	if err != nil {
 		return err
@@ -391,8 +376,6 @@ func (c *Container) merge(getconfig func() (v1.ImageConfig, error)) error {
 
 // FormatStatus format container status
 func (c *Container) FormatStatus() (string, error) {
-	c.Lock()
-	defer c.Unlock()
 	var status string
 
 	switch c.State.Status {
@@ -444,8 +427,6 @@ func (c *Container) FormatStatus() (string, error) {
 // delete the containerd container, the merged dir  will also be
 // deleted, so we should unset the container's MergedDir.
 func (c *Container) UnsetMergedDir() {
-	c.Lock()
-	defer c.Unlock()
 	if c.Snapshotter == nil || c.Snapshotter.Data == nil {
 		return
 	}
@@ -507,13 +488,11 @@ func (c *Container) CleanRootfsSnapshotDirs() error {
 		removeDirs []string
 	)
 
-	c.Lock()
 	for _, dir := range []string{"MergedDir", "UpperDir", "WorkDir"} {
 		if v, ok := c.Snapshotter.Data[dir]; ok {
 			removeDirs = append(removeDirs, v)
 		}
 	}
-	c.Unlock()
 
 	var errMsgs []string
 	for _, dir := range removeDirs {

--- a/daemon/mgr/container_upgrade.go
+++ b/daemon/mgr/container_upgrade.go
@@ -65,7 +65,7 @@ func (mgr *ContainerManager) Upgrade(ctx context.Context, name string, config *t
 	}
 
 	// if the container is running, we need first stop it.
-	if c.IsRunning() {
+	if c.State.Running {
 		IsRunning = true
 		err = mgr.stop(ctx, c, 10)
 		if err != nil {
@@ -79,7 +79,7 @@ func (mgr *ContainerManager) Upgrade(ctx context.Context, name string, config *t
 	if err != nil {
 		return err
 	}
-	c.SetSnapshotID(newSnapID)
+	c.SnapshotID = newSnapID
 
 	// initialize container storage config before container started
 	err = mgr.initContainerStorage(ctx, c)

--- a/daemon/mgr/spec.go
+++ b/daemon/mgr/spec.go
@@ -26,9 +26,6 @@ type SpecWrapper struct {
 
 // createSpec create a runtime-spec.
 func createSpec(ctx context.Context, c *Container, specWrapper *SpecWrapper) error {
-	c.Lock()
-	defer c.Unlock()
-
 	// new a default spec from containerd.
 	s := oci.NewDefaultSpec()
 	specWrapper.s = s


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

### Ⅰ. Describe what this PR did

Since the single container APIs have not occurred performance problem and the Fine-grained locking mechanism has occurred many concurrency problems, so we decide to change to Coarse-grained locking mechanism that will lock all operations in one API function. 

Of course, we should make sure this change has no influence on the legacy containers and the CRI interfaces, so we will first make all test cases happy, then consider to merge this pr.

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


