### PR TITLE
fix: should not start a paused container

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -589,6 +589,11 @@ func (mgr *ContainerManager) Start(ctx context.Context, id string, options *type
 		return err
 	}
 
+	// check if container's status is paused
+	if c.IsPaused() {
+		return fmt.Errorf("cannot start a paused container, try unpause instead")
+	}
+
 	// check if container's status is running
 	if c.IsRunning() {
 		return errors.Wrapf(errtypes.ErrNotModified, "container already started")

--- a/test/api_container_start_test.go
+++ b/test/api_container_start_test.go
@@ -64,7 +64,7 @@ func (suite *APIContainerStartSuite) TestStartPausedContainer(c *check.C) {
 
 	resp, err := request.Post("/containers/" + cname + "/start")
 	c.Assert(err, check.IsNil)
-	CheckRespStatus(c, resp, 409)
+	CheckRespStatus(c, resp, 500)
 }
 
 // TestStartDetachKeyWork test detatch-keys works.
@@ -105,5 +105,4 @@ func (suite *APIContainerStartSuite) TestStartAlreadyRunningContainer(c *check.C
 	resp, err := request.Post("/containers/" + cname + "/start")
 	c.Assert(err, check.IsNil)
 	CheckRespStatus(c, resp, 304)
-
 }


### PR DESCRIPTION
pouch should not start a paused container, or when create container
fail, pouch will do a clean to remove all container data in meta data.

```
func (mgr *ContainerManager) start(ctx context.Context, c *Container, options *types.ContainerStartOptions) error {
    var err error
    c.DetachKeys = options.DetachKeys

    attachedVolumes := map[string]struct{}{}
    defer func() {
        if err == nil {
            return
        }

        // release the container resources(network and containerio)
        err = mgr.releaseContainerResources(c)
        if err != nil {
            logrus.Errorf("failed to release container(%s) resources: %v", c.ID, err)
        }

        // detach the volumes
        for name := range attachedVolumes {
            if _, err = mgr.VolumeMgr.Detach(ctx, name, map[string]string{volumetypes.OptionRef: c.ID}); err != nil {
                logrus.Errorf("failed to detach volume(%s) when start container(%s) rollback: %v", name, c.ID, err)
            }
        }
    }()
```

reproduce:

pouch pause $cid
pouch start $cid
then container was removed by pouchd

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


