### PR TITLE
test: increase waiting time for daemon related test

### DIFF
--- a/test/cli_rich_container_test.go
+++ b/test/cli_rich_container_test.go
@@ -236,7 +236,9 @@ func waitSystemdPullProcess(c *check.C, cname, processName string) {
 
 	select {
 	case <-check:
-	case <-time.After(10 * time.Second):
+	case <-time.After(60 * time.Second):
+		// increasing the time just in case that the systemd won't
+		// start the process in time
 		c.Fatalf("failed to wait systemd pull process %s", processName)
 	}
 


### PR DESCRIPTION


Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

The rich-mode container depends on the systemd to start the stopped
process automatically. But it might take more time to starting. 60s
might be too long but just in case that the system environment might
impact the process.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no need

### Ⅳ. Describe how to verify it

CI

### Ⅴ. Special notes for reviews


