### PR TITLE
ctrd: fix not set mediaType in manifest when commit image

### DIFF
--- a/ctrd/image_commit.go
+++ b/ctrd/image_commit.go
@@ -143,12 +143,18 @@ func (c *Client) Commit(ctx context.Context, config *CommitConfig) (_ digest.Dig
 	}
 
 	// new manifest descriptor
-	mfst := ocispec.Manifest{
-		Versioned: specs.Versioned{
-			SchemaVersion: 2,
+	mfst := struct {
+		MediaType string `json:"mediaType,omitempty"`
+		ocispec.Manifest
+	}{
+		MediaType: manifestType,
+		Manifest: ocispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: configDesc,
+			Layers: layers,
 		},
-		Config: configDesc,
-		Layers: layers,
 	}
 
 	mfstJSON, err := json.MarshalIndent(mfst, "", "   ")


### PR DESCRIPTION
set mediaType when commit image from container

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


