### PR TITLE
test: add override default mount config test

### DIFF
--- a/test/cli_run_volume_test.go
+++ b/test/cli_run_volume_test.go
@@ -541,3 +541,18 @@ func (suite *PouchRunVolumeSuite) TestRunWithQuotaID(c *check.C) {
 	}
 	c.Assert(found, check.Equals, true)
 }
+
+// TestRunOverrideVolume tests bind volume should override default config
+func (suite *PouchRunVolumeSuite) TestRunOverrideVolume(c *check.C) {
+	cname := "TestRunOverrideVolume"
+	ret := command.PouchRun("run", "-d", "-v", "/sys/fs/cgroup:/sys/fs/cgroup",
+		"--name", cname, busyboxImage, "top")
+
+	defer DelContainerForceMultyTime(c, cname)
+	ret.Assert(c, icmd.Success)
+
+	output := command.PouchRun("inspect", "-f", "{{.ID}}", cname).Stdout()
+	containerID := strings.TrimSpace(output)
+
+	command.PouchRun("exec", cname, "ls", "/sys/fs/cgroup/memory/default/"+containerID).Assert(c, icmd.Success)
+}


### PR DESCRIPTION
tests user defined bind should override default mount config

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


