### PR TITLE
cri: diable snapshotter usage collector by default

### DIFF
--- a/cri/config/config.go
+++ b/cri/config/config.go
@@ -23,6 +23,6 @@ type Config struct {
 	StreamServerReusePort bool `json:"stream-server-reuse-port,omitempty"`
 	// CriStatsCollectPeriod specify the time duration (in time.Second) cri collect stats from containerd.
 	CriStatsCollectPeriod int `json:"cri-stats-collect-period,omitempty"`
-	// DisableCriStatsCollect specify whether cri collect stats from containerd.
-	DisableCriStatsCollect bool `json:"disable-cri-stats-collect,omitempty"`
+	// EnableCriStatsCollect specify whether cri collect stats from containerd.
+	EnableCriStatsCollect bool `json:"enable-cri-stats-collect,omitempty"`
 }

--- a/cri/v1alpha1/cri.go
+++ b/cri/v1alpha1/cri.go
@@ -166,7 +166,7 @@ func NewCriManager(config *config.Config, ctrMgr mgr.ContainerMgr, imgMgr mgr.Im
 		return nil, fmt.Errorf("failed to get imagefs uuid of %q: %v", imageFSPath, err)
 	}
 
-	if !config.CriConfig.DisableCriStatsCollect {
+	if config.CriConfig.EnableCriStatsCollect {
 		period := config.CriConfig.CriStatsCollectPeriod
 		if period <= 0 {
 			return nil, fmt.Errorf("cri stats collect period should > 0")

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -178,7 +178,7 @@ func NewCriManager(config *config.Config, ctrMgr mgr.ContainerMgr, imgMgr mgr.Im
 	c.imageFSPath = imageFSPath(path.Join(config.HomeDir, "containerd/root"), ctrd.CurrentSnapshotterName(context.TODO()))
 	logrus.Infof("Get image filesystem path %q", c.imageFSPath)
 
-	if !config.CriConfig.DisableCriStatsCollect {
+	if config.CriConfig.EnableCriStatsCollect {
 		period := config.CriConfig.CriStatsCollectPeriod
 		if period <= 0 {
 			return nil, fmt.Errorf("cri stats collect period should > 0")

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -101,15 +101,15 @@ func TestConfigValidate(t *testing.T) {
 	cfg = &Config{
 		IsCriEnabled: true,
 		CriConfig: criconfig.Config{
-			Listen:                 "unix:///var/run/pouchd.sock",
-			NetworkPluginBinDir:    "cni-bin-dir",
-			NetworkPluginConfDir:   "cni-conf-dir",
-			SandboxImage:           "registry.hub.docker.com/library/busybox",
-			CriVersion:             "v1alpha2",
-			StreamServerPort:       "10010",
-			StreamServerReusePort:  true,
-			CriStatsCollectPeriod:  10,
-			DisableCriStatsCollect: false,
+			Listen:                "unix:///var/run/pouchd.sock",
+			NetworkPluginBinDir:   "cni-bin-dir",
+			NetworkPluginConfDir:  "cni-conf-dir",
+			SandboxImage:          "registry.hub.docker.com/library/busybox",
+			CriVersion:            "v1alpha2",
+			StreamServerPort:      "10010",
+			StreamServerReusePort: true,
+			CriStatsCollectPeriod: 10,
+			EnableCriStatsCollect: false,
 		},
 	}
 	assert.Equal(nil, cfg.Validate())

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func setupFlags(cmd *cobra.Command) {
 	flagSet.StringVar(&cfg.CriConfig.StreamServerPort, "stream-server-port", "10010", "The port stream server of cri is listening on.")
 	flagSet.BoolVar(&cfg.CriConfig.StreamServerReusePort, "stream-server-reuse-port", false, "Specify whether cri stream server share port with pouchd. If this is true, the listen option of pouchd should specify a tcp socket and its port should be same with stream-server-port.")
 	flagSet.IntVar(&cfg.CriConfig.CriStatsCollectPeriod, "cri-stats-collect-period", 10, "The time duration (in time.Second) cri collect stats from containerd.")
-	flagSet.BoolVar(&cfg.CriConfig.DisableCriStatsCollect, "disable-cri-stats-collect", true, "Specify whether cri collect stats from containerd.If this is true, option CriStatsCollectPeriod will take no effect.")
+	flagSet.BoolVar(&cfg.CriConfig.EnableCriStatsCollect, "enable-cri-stats-collect", false, "Specify whether cri collect stats from containerd. If this is true, option CriStatsCollectPeriod will take effect.")
 	flagSet.BoolVarP(&cfg.Debug, "debug", "D", false, "Switch daemon log level to DEBUG mode")
 	flagSet.StringVarP(&cfg.ContainerdAddr, "containerd", "c", "/var/run/containerd.sock", "Specify listening address of containerd")
 	flagSet.StringVar(&cfg.ContainerdPath, "containerd-path", "", "Specify the path of containerd binary")


### PR DESCRIPTION


Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

If there is config for pouchd, the default value for command flag won't
work. For this case, we should change Disable to Enable.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

none

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no need


### Ⅳ. Describe how to verify it

manually check.

### Ⅴ. Special notes for reviews


