### PR TITLE
fix: dont set status to exit for oom condition

### DIFF
--- a/daemon/mgr/container_state.go
+++ b/daemon/mgr/container_state.go
@@ -145,11 +145,7 @@ func (c *Container) SetStatusOOM() {
 	c.Lock()
 	defer c.Unlock()
 	c.State.OOMKilled = true
-	c.State.Status = types.StatusExited
-	c.State.Pid = 0
-	c.State.ExitCode = 137
 	c.State.Error = "OOMKilled"
-	c.setStatusFlags(types.StatusExited)
 }
 
 // Notes(ziren): i still feel uncomfortable for a function hasing no return


### PR DESCRIPTION

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

fix: dont set status to exit for oom condition

pouch would fail to stop or remove a oom container if it was set
to exited status

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

```bash
$ CID=$(pouch run -d busybox sh)
$ pouch exec -it $CID sh
$ run a oom program

// another terminal
$ pouch ps -a | grep $CID
// container is up
$ pouch inspect $CID | grep -i oom
// oomkilled is set to true
```

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

CRI part using state.Error info string to identify oom status

