### PR TITLE
fix: make command flag not interspersed

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -51,7 +51,8 @@ func NewCli() *Cli {
 
 // SetFlags sets all global options.
 func (c *Cli) SetFlags() *Cli {
-	flags := c.rootCmd.PersistentFlags()
+	flags := c.rootCmd.Flags()
+	flags.SetInterspersed(false)
 	flags.StringVarP(&c.Option.host, "host", "H", "unix:///var/run/pouchd.sock", "Specify connecting address of Pouch CLI")
 	flags.BoolVarP(&c.Option.Debug, "debug", "D", false, "Switch client log level to DEBUG mode")
 	flags.StringVar(&c.Option.TLS.Key, "tlskey", "", "Specify key file of TLS")

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// PouchSuite is the test suite for pouch cli.
+type PouchSuite struct{}
+
+func init() {
+	check.Suite(&PouchSuite{})
+}
+
+// SetUpTest does common setup in the beginning of each test.
+func (suite *PouchSuite) SetUpTest(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+}
+
+// TestImageTagOKWithSourceImageName tests OK.
+func (suite *PouchSuite) TestInterspersedFlags(c *check.C) {
+	// set flags directly to pouch cli
+	command.PouchRun("-D", "ps").Assert(c, icmd.Success)
+
+	// set pouch cli flags to subcommand is forbidden
+	command.PouchRun("pull",
+		"--tlscacert",
+		"/data/cert/ca.crt",
+		"--tlscert", "/data/cert/20.26.38.138.cert",
+		"--tlskey", "/data/cert/20.26.38.138.key",
+		busyboxImage,
+	).Assert(c, icmd.Expected{
+		ExitCode: 1, // non-zero exit code
+		Error:    "Error: unknown flag: --tlscacert",
+	})
+}


### PR DESCRIPTION
Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

We should make all `pouch` flags only be flags of itself, rather than flags of pouch's subcommands.

For example:
```
pouch pull --tlscacert /data/cert/ca.crt --tlscert /data/cert/20.26.38.138.cert  --tlskey /data/cert/20.26.38.138.key kube-proxy:v1.13.4
```
is illegal.

Only 
```
pouch --tlscacert /data/cert/ca.crt --tlscert /data/cert/20.26.38.138.cert  --tlskey /data/cert/20.26.38.138.key pull kube-proxy:v1.13.4
```
is legal.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
This issue is reported from issue https://github.com/alibaba/pouch/issues/2771#issuecomment-476930794

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added

### Ⅳ. Describe how to verify it
none

### Ⅴ. Special notes for reviews
none

