### PR TITLE
bugfix: not save ExecIds to meta.json file

### DIFF
--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -192,7 +192,7 @@ type Container struct {
 	Driver string `json:"Driver,omitempty"`
 
 	// exec ids
-	ExecIds []string `json:"ExecIDs,omitempty"`
+	ExecIds []string `json:"-"`
 
 	// Snapshotter, GraphDriver is same, keep both
 	// just for compatibility


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>


### Ⅰ. Describe what this PR did
The `ExecIds` are all stored in memory, so we no need to store them to the container `meta.json` file.

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


