### PR TITLE
support to set root dir of container log

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1280,6 +1280,14 @@ func (mgr *ContainerManager) Remove(ctx context.Context, name string, options *t
 	// remove the container IO
 	mgr.IOs.Remove(c.ID)
 
+	logRootDir, err := mgr.getLogRootDirFromOpt(c, false)
+	if err == nil && logRootDir != mgr.Store.Path(c.ID) {
+		rErr := os.RemoveAll(logRootDir)
+		if rErr != nil {
+			logrus.Warnf("failed to remove container %s log path %s: %v", c.ID, logRootDir, rErr)
+		}
+	}
+
 	// remove meta.json for container in local disk
 	if err := mgr.Store.Remove(c.Key()); err != nil {
 		logrus.Errorf("failed to remove container %s from meta store: %v", c.ID, err)
@@ -1652,7 +1660,11 @@ func (mgr *ContainerManager) initLogDriverBeforeStart(c *Container) error {
 		}
 	}
 
-	logInfo := mgr.convContainerToLoggerInfo(c)
+	logInfo, err := mgr.convContainerToLoggerInfo(c)
+	if err != nil {
+		return err
+	}
+
 	logDriver, err := logOptionsForContainerio(c, logInfo)
 	if err != nil {
 		return err

--- a/daemon/mgr/container_logs.go
+++ b/daemon/mgr/container_logs.go
@@ -48,7 +48,12 @@ func (mgr *ContainerManager) Logs(ctx context.Context, name string, logOpt *type
 		return msgCh, c.Config.Tty, nil
 	}
 
-	fileName := filepath.Join(mgr.Store.Path(c.ID), "json.log")
+	rootDir, err := mgr.getLogRootDirFromOpt(c, false)
+	if err != nil {
+		return nil, false, err
+	}
+
+	fileName := filepath.Join(rootDir, "json.log")
 
 	jf, err := jsonfile.NewJSONLogFile(fileName, 0640, nil, nil)
 

--- a/daemon/mgr/container_validation.go
+++ b/daemon/mgr/container_validation.go
@@ -38,6 +38,7 @@ var (
 	commonLogOpts = map[string]bool{
 		"mode":            true,
 		"max-buffer-size": true,
+		logRootDirKey:     true,
 	}
 )
 
@@ -335,7 +336,10 @@ func (mgr *ContainerManager) validateLogConfig(c *Container) error {
 	case types.LogConfigLogDriverNone, types.LogConfigLogDriverJSONFile:
 		return jsonfile.ValidateLogOpt(restOpts)
 	case types.LogConfigLogDriverSyslog:
-		info := mgr.convContainerToLoggerInfo(c)
+		info, err := mgr.convContainerToLoggerInfo(c)
+		if err != nil {
+			return err
+		}
 		return syslog.ValidateSyslogOption(info)
 	default:
 		return fmt.Errorf("not support (%v) log driver yet", logCfg.LogDriver)

--- a/main.go
+++ b/main.go
@@ -150,7 +150,10 @@ func runDaemon(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	cfg.DefaultLogConfig.LogOpts = logOptMap
+
+	if len(logOptMap) > 0 {
+		cfg.DefaultLogConfig.LogOpts = logOptMap
+	}
 
 	//user specifies --version or -v, print version and return.
 	if printVersion {

--- a/test/z_cli_daemon_test.go
+++ b/test/z_cli_daemon_test.go
@@ -692,10 +692,13 @@ func (suite *PouchDaemonSuite) TestContainerdPIDReuse(c *check.C) {
 	cfg := daemon.NewConfig()
 	cfg.NewArgs("--config-file", cfgFile)
 
+	err := os.MkdirAll("/tmp/test/pouch/containerd/state", 0664)
+	c.Assert(err, check.IsNil)
+
 	containerdPidPath := filepath.Join("/tmp/test/pouch/containerd/state", "containerd.pid")
 
 	// set containerd pid to 1 to make sure the pid must be alive
-	err := ioutil.WriteFile(containerdPidPath, []byte(fmt.Sprintf("%d", 1)), 0660)
+	err = ioutil.WriteFile(containerdPidPath, []byte(fmt.Sprintf("%d", 1)), 0660)
 	if err != nil {
 		c.Errorf("failed to write pid to file: %v", containerdPidPath)
 	}


### PR DESCRIPTION
Signed-off-by: allen.wang <allen.wq@alipay.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
The PR allows user to set container log path by parameters log-opt.  There are two ways to set container log path.

1. Set root dir of container log by pouch daemon config.  For example:

Start pouchd with  --log-opt.
```
/usr/local/bin/pouchd --log-opt root-dir=/tmp/daemon_log
```
Or set it to pouch config file like this:
```
{
...
"default-log-config": {
        "Config":{
            "root-dir":"/tmp/daemon_log"
        }
    },
...
}
```
 By this way, all new container will be applied this feature. The container log path will be `/tmp/daemon_log/<cid>/json.log`

2. Set root dir of container log by container create config. For example:
```
pouch run -d --name=test --log-opt root-key=/tmp/container_log busybox:latest sh -c "echo hello"
```
By this way, only the created container with "--log-opt root-key=/tmp/container_log" will be applied this feature.  The container log path will be `/tmp/container_log/<cid>/json.log`.  

**the second way has the high priority.** 


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix https://github.com/alibaba/pouch/issues/2783.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
add test.

### Ⅳ. Describe how to verify it
by test.

### Ⅴ. Special notes for reviews


