### PR TITLE
bugfix: fix error to set volume options

### DIFF
--- a/apis/opts/config/volumes.go
+++ b/apis/opts/config/volumes.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"fmt"
+)
+
+// Volumes holds a list of values.
+type Volumes struct {
+	values *[]string
+}
+
+// NewVolumes creates a new Volumes.
+func NewVolumes(v *Volumes) *Volumes {
+	var values []string
+	if v == nil {
+		v = &Volumes{}
+	}
+	if v.values == nil {
+		v.values = &values
+	}
+	return v
+}
+
+// Set implement Volumes as pflag.Value interface.
+func (v *Volumes) Set(val string) error {
+	for _, s := range *v.values {
+		if s == val {
+			return nil
+		}
+	}
+	(*v.values) = append((*v.values), val)
+	return nil
+}
+
+// String implement Volumes as pflag.Value interface.
+func (v *Volumes) String() string {
+	return fmt.Sprintf("%v", *v.values)
+}
+
+// Type implement Volumes as pflag.Value interface.
+func (v *Volumes) Type() string {
+	return "volumes"
+}
+
+// Value return values as type Volumes
+func (v *Volumes) Value() []string {
+	return (*v.values)
+}

--- a/apis/opts/config/volumes_test.go
+++ b/apis/opts/config/volumes_test.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewVolumes(t *testing.T) {
+	tests := []struct {
+		name string
+		args *Volumes
+		want *Volumes
+	}{
+		{
+			name: "values != nil",
+			args: &Volumes{
+				values: &[]string{
+					"abc:def",
+				},
+			},
+			want: &Volumes{
+				values: &[]string{
+					"abc:def",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewVolumes(tt.args)
+			if got == nil {
+				t.Errorf("want got is not nil")
+			}
+			if got.values == nil {
+				t.Errorf("want values is not nil")
+			}
+			if tt.args != nil && tt.args.values != nil && !reflect.DeepEqual(*got.values, *tt.want.values) {
+				t.Errorf("NewVolumes() = %v, want %v", *got.values, *tt.want.values)
+			}
+		})
+	}
+}
+
+func TestVolumesSet(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want *Volumes
+	}{
+		{
+			name: "args = \"\"",
+			args: []string{""},
+			want: &Volumes{
+				values: &[]string{""},
+			},
+		},
+		{
+
+			name: "values = abc",
+			args: []string{"abc", "def", "abc"},
+			want: &Volumes{
+				values: &[]string{"abc", "def"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewVolumes(nil)
+			if v == nil {
+				t.Errorf("want volumes is nil")
+			}
+			for _, arg := range tt.args {
+				err := v.Set(arg)
+				if err != nil {
+					t.Errorf("failed to set value, err(%v)", err)
+				}
+			}
+
+			if !reflect.DeepEqual(*v, *tt.want) {
+				t.Errorf("Set() = %v, want %v", *v, *tt.want)
+			}
+		})
+	}
+}
+
+func TestVolumesString(t *testing.T) {
+	tests := []struct {
+		name string
+		args *Volumes
+		want string
+	}{
+		{
+			name: "args = \"\"",
+			args: &Volumes{
+				values: &[]string{""},
+			},
+			want: "[]",
+		},
+		{
+
+			name: "values = abc",
+			args: &Volumes{
+				values: &[]string{"abc"},
+			},
+			want: "[abc]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.args.String()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVolumesValue(t *testing.T) {
+	tests := []struct {
+		name string
+		args *Volumes
+		want *[]string
+	}{
+		{
+			name: "args = \"\"",
+			args: &Volumes{
+				values: &[]string{""},
+			},
+			want: &[]string{""},
+		},
+		{
+
+			name: "values = abc",
+			args: &Volumes{
+				values: &[]string{"abc"},
+			},
+			want: &[]string{"abc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.args.Value()
+			if !reflect.DeepEqual(got, *tt.want) {
+				t.Errorf("Value() = %v, want %v", got, *tt.want)
+			}
+		})
+	}
+}

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/alibaba/pouch/apis/opts/config"
 	"github.com/alibaba/pouch/apis/types"
 
 	"github.com/spf13/pflag"
@@ -89,7 +90,8 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 
 	flagSet.StringVar(&c.utsMode, "uts", "", "UTS namespace to use")
 
-	flagSet.StringSliceVarP(&c.volume, "volume", "v", nil, "Bind mount volumes to container, format is: [source:]<destination>[:mode], [source] can be volume or host's path, <destination> is container's path, [mode] can be \"ro/rw/dr/rr/z/Z/nocopy/private/rprivate/slave/rslave/shared/rshared\"")
+	flagSet.VarP(config.NewVolumes(&c.volume), "volume", "v", "Bind mount volumes to container, format is: [source:]<destination>[:mode], [source] can be volume or host's path, <destination> is container's path, [mode] can be \"ro/rw/dr/rr/z/Z/nocopy/private/rprivate/slave/rslave/shared/rshared\"")
+	//flagSet.StringSliceVarP(&c.volume, "volume", "v", nil, "Bind mount volumes to container, format is: [source:]<destination>[:mode], [source] can be volume or host's path, <destination> is container's path, [mode] can be \"ro/rw/dr/rr/z/Z/nocopy/private/rprivate/slave/rslave/shared/rshared\"")
 	flagSet.StringSliceVar(&c.volumesFrom, "volumes-from", nil, "set volumes from other containers, format is <container>[:mode]")
 
 	flagSet.StringVarP(&c.workdir, "workdir", "w", "", "Set the working directory in a container")

--- a/cli/container.go
+++ b/cli/container.go
@@ -14,7 +14,7 @@ type container struct {
 	labels              []string
 	name                string
 	tty                 bool
-	volume              []string
+	volume              config.Volumes
 	volumesFrom         []string
 	runtime             string
 	env                 []string
@@ -216,7 +216,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 		},
 
 		HostConfig: &types.HostConfig{
-			Binds:       c.volume,
+			Binds:       c.volume.Value(),
 			VolumesFrom: c.volumesFrom,
 			Runtime:     c.runtime,
 			Resources: types.Resources{

--- a/test/cli_run_volume_test.go
+++ b/test/cli_run_volume_test.go
@@ -556,3 +556,25 @@ func (suite *PouchRunVolumeSuite) TestRunOverrideVolume(c *check.C) {
 
 	command.PouchRun("exec", cname, "ls", "/sys/fs/cgroup/memory/default/"+containerID).Assert(c, icmd.Success)
 }
+
+func (suite *PouchRunVolumeSuite) TestRunWithVolumesOpts(c *check.C) {
+	cname := "TestRunWithVolumesOpts"
+	res := command.PouchRun("run", "-d", "-v", "/tmp/test123:/mnt/test123:rslave,ro",
+		"--name", cname, busyboxImage, "top")
+
+	defer DelContainerForceMultyTime(c, cname)
+	res.Assert(c, icmd.Success)
+
+	res = command.PouchRun("exec", cname, "cat", "/proc/mounts")
+	res.Assert(c, icmd.Success)
+
+	found := false
+	for _, line := range strings.Split(res.Stdout(), "\n") {
+		if strings.Contains(line, "/mnt/test123") && strings.Contains(line, "ro") {
+			found = true
+			break
+		}
+	}
+
+	c.Assert(found, check.Equals, true)
+}


### PR DESCRIPTION
using pouch cli to run container, command is:
```bash
 # pouch run -d -v /tmp/test:/tmp/test:rslave,ro busybox top
```
it will parse `-v` become to bind ["/tmp/test:/tmp/test:rslave", "ro"]

by default, `,` is separator of command, so we should refact the default
rules.

Signed-off-by: Rudy Zhang <rudyflyzhang@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
ci pass

### Ⅴ. Special notes for reviews


