### PR TITLE
feature: compatible with both k8s and cri-o annotations

### DIFF
--- a/cri/annotations/annotations.go
+++ b/cri/annotations/annotations.go
@@ -8,14 +8,20 @@ const (
 	// ContainerTypeContainer represents a container running within a pod
 	ContainerTypeContainer = "container"
 
+	// CRIOContainerType is the container type (sandbox or container) annotation
+	CRIOContainerType = "io.kubernetes.cri-o.ContainerType"
+
 	// ContainerType is the container type (sandbox or container) annotation
-	ContainerType = "io.kubernetes.cri-o.ContainerType"
+	ContainerType = "io.kubernetes.cri.container-type"
 
-	// SandboxName is the sandbox name annotation
-	SandboxName = "io.kubernetes.cri-o.SandboxName"
+	// CRIOSandboxName is the sandbox name annotation
+	CRIOSandboxName = "io.kubernetes.cri-o.SandboxName"
 
-	// SandboxID is the sandbox id annotation
-	SandboxID = "io.kubernetes.cri-o.SandboxID"
+	// CRIOSandboxID is the sandbox id annotation
+	CRIOSandboxID = "io.kubernetes.cri-o.SandboxID"
+
+	// SandboxID is the sandbox ID annotation
+	SandboxID = "io.kubernetes.cri.sandbox-id"
 
 	// KubernetesRuntime is the runtime
 	KubernetesRuntime = "io.kubernetes.runtime"

--- a/cri/v1alpha2/cri.go
+++ b/cri/v1alpha2/cri.go
@@ -690,9 +690,12 @@ func (c *CriManager) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		image = iSpec.Image
 	}
 
+	// compatible with both kubernetes and cri-o annotations
 	specAnnotation := make(map[string]string)
+	specAnnotation[anno.CRIOContainerType] = anno.ContainerTypeContainer
 	specAnnotation[anno.ContainerType] = anno.ContainerTypeContainer
-	specAnnotation[anno.SandboxName] = podSandboxID
+	specAnnotation[anno.CRIOSandboxName] = podSandboxID
+	specAnnotation[anno.CRIOSandboxID] = podSandboxID
 	specAnnotation[anno.SandboxID] = podSandboxID
 
 	resources := r.GetConfig().GetLinux().GetResources()

--- a/cri/v1alpha2/cri_utils.go
+++ b/cri/v1alpha2/cri_utils.go
@@ -349,6 +349,10 @@ func makeSandboxPouchConfig(config *runtime.PodSandboxConfig, runtimehandler, im
 	// Apply a label to distinguish sandboxes from regular containers.
 	labels[containerTypeLabelKey] = containerTypeLabelSandbox
 
+	specAnnotation := make(map[string]string)
+	specAnnotation[anno.CRIOContainerType] = anno.ContainerTypeSandbox
+	specAnnotation[anno.ContainerType] = anno.ContainerTypeSandbox
+
 	hc := &apitypes.HostConfig{}
 
 	// Apply runtime options.
@@ -357,9 +361,10 @@ func makeSandboxPouchConfig(config *runtime.PodSandboxConfig, runtimehandler, im
 
 	createConfig := &apitypes.ContainerCreateConfig{
 		ContainerConfig: apitypes.ContainerConfig{
-			Hostname: strfmt.Hostname(config.Hostname),
-			Image:    image,
-			Labels:   labels,
+			Hostname:       strfmt.Hostname(config.Hostname),
+			Image:          image,
+			Labels:         labels,
+			SpecAnnotation: specAnnotation,
 		},
 		HostConfig:       hc,
 		NetworkingConfig: &apitypes.NetworkingConfig{},


### PR DESCRIPTION
Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

write both of these two annotations
1. compatible with old container
2. enable runtime recognize the container type using popular annotation
3. these two annotation is only read by runtime, not used by pouch


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


