### PR TITLE
ctrd/daemon: support PlainHttp pull/push image

### DIFF
--- a/ctrd/client.go
+++ b/ctrd/client.go
@@ -40,6 +40,9 @@ type Client struct {
 	watch *watch
 	lock  *containerLock
 
+	// insecureRegistries stores the insecure registries
+	insecureRegistries []string
+
 	// containerd grpc pool
 	pool      []scheduler.Factory
 	scheduler scheduler.Scheduler
@@ -64,6 +67,7 @@ func NewClient(opts ...ClientOpt) (APIClient, error) {
 		rpcAddr:                unixSocketPath,
 		grpcClientPoolCapacity: defaultGrpcClientPoolCapacity,
 		maxStreamsClient:       defaultMaxStreamsClient,
+		insecureRegistries:     []string{},
 	}
 
 	for _, opt := range opts {
@@ -79,6 +83,7 @@ func NewClient(opts ...ClientOpt) (APIClient, error) {
 		watch: &watch{
 			containers: make(map[string]*containerPack),
 		},
+		insecureRegistries: copts.insecureRegistries,
 	}
 
 	for i := 0; i < copts.grpcClientPoolCapacity; i++ {

--- a/ctrd/client_opts_test.go
+++ b/ctrd/client_opts_test.go
@@ -1,0 +1,50 @@
+package ctrd
+
+import "testing"
+
+func TestWithInsecureRegistries(t *testing.T) {
+	testCases := []struct {
+		endpoints []string
+		hasError  bool
+	}{
+		{
+			endpoints: []string{"localhost:5000"},
+			hasError:  false,
+		},
+		{
+			endpoints: []string{"localhost:5000/v1"},
+			hasError:  true,
+		},
+		{
+			endpoints: []string{"myregistry.com"},
+			hasError:  false,
+		},
+		{
+			endpoints: []string{"myregistry.com:5000"},
+			hasError:  false,
+		},
+		{
+			endpoints: []string{"myregistry.com:5000/v1"},
+			hasError:  true,
+		},
+		{
+			endpoints: []string{"http://myregistry.com:5000"},
+			hasError:  true,
+		},
+		{
+			endpoints: []string{"dummy://myregistry.com:5000"},
+			hasError:  true,
+		},
+		{
+			endpoints: []string{"myregistry.com:65536"},
+			hasError:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := WithInsecureRegistries(tc.endpoints)(&clientOpts{})
+		if (err != nil) != tc.hasError {
+			t.Fatalf("expected hasError = %v, but got error = %v", tc.hasError, err)
+		}
+	}
+}

--- a/ctrd/image.go
+++ b/ctrd/image.go
@@ -199,7 +199,7 @@ func (c *Client) PushImage(ctx context.Context, ref string, authConfig *types.Au
 
 	pushTracker := docker.NewInMemoryTracker()
 
-	resolver, err := resolver(authConfig, docker.ResolverOptions{
+	resolver, err := c.getResolver(authConfig, ref, docker.ResolverOptions{
 		Tracker: pushTracker,
 	})
 	if err != nil {
@@ -248,7 +248,7 @@ func (c *Client) FetchImage(ctx context.Context, ref string, authConfig *types.A
 		return nil, fmt.Errorf("failed to get a containerd grpc client: %v", err)
 	}
 
-	resolver, err := resolver(authConfig, docker.ResolverOptions{})
+	resolver, err := c.getResolver(authConfig, ref, docker.ResolverOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -127,6 +127,10 @@ type Config struct {
 
 	// CgroupDriver sets cgroup driver for all containers
 	CgroupDriver string `json:"cgroup-driver,omitempty"`
+
+	// InsecureRegistries sets insecure registries to allow to pull
+	// insecure registries.
+	InsecureRegistries []string `json:"insecure-registries,omitempty"`
 }
 
 // GetCgroupDriver gets cgroup driver used in runc.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -97,6 +97,7 @@ func NewDaemon(cfg *config.Config) *Daemon {
 	ctrdClient, err := ctrd.NewClient(
 		ctrd.WithRPCAddr(cfg.ContainerdAddr),
 		ctrd.WithDefaultNamespace(cfg.DefaultNamespace),
+		ctrd.WithInsecureRegistries(cfg.InsecureRegistries),
 	)
 	if err != nil {
 		logrus.Errorf("failed to new containerd's client: %v", err)

--- a/main.go
+++ b/main.go
@@ -137,6 +137,9 @@ func setupFlags(cmd *cobra.Command) {
 	// to k8s.io
 	flagSet.StringVar(&cfg.DefaultNamespace, "default-namespace", namespaces.Default, "default-namespace is passed to containerd, the default value is 'default'")
 	flagSet.StringVar(&cfg.CgroupDriver, "cgroup-driver", "cgroupfs", "Set cgroup driver for all containers(cgroupfs|systemd), default cgroupfs")
+
+	// registry
+	flagSet.StringArrayVar(&cfg.InsecureRegistries, "insecure-registries", []string{}, "enable insecure registry")
 }
 
 // runDaemon prepares configs, setups essential details and runs pouchd daemon.


### PR DESCRIPTION


Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

If the user sets the insecure registries, pouch will use PlainHTTP or
HTTPs with unknown CA to pull or push image. For example, there are
two registries

  1. 172.17.0.7:5000
  2. 172.17.0.2:5000 my.testingregistry.com

We can use `pouchd --insecure-registries my.testingregistry.com:5000
--insecure-registries 172.17.0.7:5000` to start pouch daemon. Then we
can pull or push any images from my.testingregistry.com:5000 or
172.17.0.7:5000 with PlainHTTP. But we cannot do it with
172.17.0.2:5000.



### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Fix: #2663

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

added 

### Ⅳ. Describe how to verify it

CI

### Ⅴ. Special notes for reviews


