### PR TITLE
cli/daemon/apis/test: support to load docker images without name

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -167,9 +167,6 @@ func (s *Server) postImageTag(ctx context.Context, rw http.ResponseWriter, req *
 // loadImage loads an image by http tar stream.
 func (s *Server) loadImage(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 	imageName := req.FormValue("name")
-	if imageName == "" {
-		imageName = "unknown/unknown"
-	}
 
 	if err := s.ImageMgr.LoadImage(ctx, imageName, req.Body); err != nil {
 		return err

--- a/cli/load.go
+++ b/cli/load.go
@@ -9,7 +9,9 @@ import (
 )
 
 // loadDescription is used to describe load command in detail and auto generate command doc.
-var loadDescription = "load a set of images by tar stream"
+var loadDescription = "load a set of images by tar stream.\n" +
+	"for docker image format, no need to set the image name because pouch" +
+	" will parse image name from tar stream."
 
 // LoadCommand use to implement 'load' command.
 type LoadCommand struct {

--- a/daemon/mgr/image_load.go
+++ b/daemon/mgr/image_load.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/alibaba/pouch/pkg/multierror"
 	"github.com/alibaba/pouch/pkg/reference"
@@ -17,22 +18,34 @@ import (
 func (mgr *ImageManager) LoadImage(ctx context.Context, imageName string, tarstream io.ReadCloser) error {
 	defer tarstream.Close()
 
-	namedRef, err := reference.Parse(imageName)
-	if err != nil {
-		return pkgerrors.Wrapf(err, "failed to parse image name %s", imageName)
+	var opts []containerd.ImportOpt
+
+	// NOTE: for the docker image, we should pass empty image name because
+	// the containerd will help us to get the original name.
+	if imageName == "" {
+		imageName = fmt.Sprintf("import-%s", time.Now().Format("2006-01-02"))
+		opts = append(opts, containerd.WithImageRefTranslator(archive.AddRefPrefix(imageName)))
+	} else {
+		// When provided, filter out references which do not match
+
+		namedRef, err := reference.Parse(imageName)
+		if err != nil {
+			return pkgerrors.Wrapf(err, "failed to parse image name %s", imageName)
+		}
+
+		// NOTE: in the image ocispec.v1, the org.opencontainers.image.ref.name
+		// annotation represents a "tag" for image. For example, an image may
+		// have a tag for different versions or builds of the software.
+		// And containerd.importer will append ":" and annotation to the name
+		// so that we don't allow imageName to contains any digest or tag
+		// information, like foo/bar:latest:v1.2.
+		if !reference.IsNamedOnly(namedRef) {
+			return fmt.Errorf("the image name should not contains any digest or tag information")
+		}
+		opts = append(opts, containerd.WithImageRefTranslator(archive.FilterRefPrefix(imageName)))
 	}
 
-	// NOTE: in the image ocispec.v1, the org.opencontainers.image.ref.name
-	// annotation represents a "tag" for image. For example, an image may
-	// have a tag for different versions or builds of the software.
-	// And containerd.importer will append ":" and annotation to the name
-	// so that we don't allow imageName to contains any digest or tag
-	// information, like foo/bar:latest:v1.2.
-	if !reference.IsNamedOnly(namedRef) {
-		return fmt.Errorf("the image name should not contains any digest or tag information")
-	}
-
-	imgs, err := mgr.client.ImportImage(ctx, tarstream, containerd.WithImageRefTranslator(archive.FilterRefPrefix(imageName)))
+	imgs, err := mgr.client.ImportImage(ctx, tarstream, opts...)
 	if err != nil {
 		return pkgerrors.Wrap(err, "failed to import image into containerd by tarstream")
 	}

--- a/test/cli_save_and_load_test.go
+++ b/test/cli_save_and_load_test.go
@@ -27,6 +27,35 @@ func (suite *PouchSaveLoadSuite) SetUpSuite(c *check.C) {
 	environment.PruneAllContainers(apiClient)
 }
 
+// TestSaveLoadDockerImages tests "pouch load" docker images.
+func (suite *PouchSaveLoadSuite) TestSaveLoadDockerImages(c *check.C) {
+	environment.PruneAllImages(apiClient)
+
+	// the tar file contains the busybox:1.25 and alpine:3.7
+	filename := filepath.Join("testdata", "images", "docker-busybox_1_25-and-alpine_3_7.tar")
+	command.PouchRun("load", "-i", filename).Assert(c, icmd.Success)
+
+	command.PouchRun("image", "inspect", "docker.io/library/busybox:1.25").Assert(c, icmd.Success)
+	command.PouchRun("image", "inspect", "docker.io/library/alpine:3.7").Assert(c, icmd.Success)
+}
+
+// TestSaveLoadOneDockerImage tests "pouch load -i <docker images> one-image.
+func (suite *PouchSaveLoadSuite) TestSaveLoadOneDockerImage(c *check.C) {
+	environment.PruneAllImages(apiClient)
+
+	// the tar file contains the busybox:1.25 and alpine:3.7
+	filename := filepath.Join("testdata", "images", "docker-busybox_1_25-and-alpine_3_7.tar")
+
+	// only load alpine
+	command.PouchRun("load", "-i", filename, "docker.io/library/alpine").Assert(c, icmd.Success)
+
+	command.PouchRun("image", "inspect", "docker.io/library/alpine:3.7").Assert(c, icmd.Success)
+
+	// busybox should be ignored
+	res := command.PouchRun("image", "inspect", "docker.io/library/busybox:1.25")
+	c.Assert(res.ExitCode, check.Not(check.Equals), 0)
+}
+
 // TestSaveLoadWorks tests "pouch save" and "pouch load" work.
 func (suite *PouchSaveLoadSuite) TestSaveLoadWorks(c *check.C) {
 	res := command.PouchRun("pull", busyboxImage125)


### PR DESCRIPTION


Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


For the docker image format, the tar file will contain the image
reference information. For this case, when we load the docker images, we
should not set the image name. If there are too many images and you just
want to load one of them, you can set the name.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #2787


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

added

### Ⅳ. Describe how to verify it

CI

### Ⅴ. Special notes for reviews


