### PR TITLE
feature: search the images from specific registry

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -370,6 +370,17 @@ paths:
               $ref: "#/definitions/SearchResultItem"
         500:
           $ref: "#/responses/500ErrorResponse"
+      parameters:
+        - name: "term"
+          in: "query"
+          description: "Term to search"
+          type: "string"
+          required: true
+        - name: "registry"
+          in: "query"
+          description: "Search images from specified registry"
+          type: "string"
+        # TODO: add limit and filters
 
   /images/{imageid}/tag:
     post:
@@ -3166,24 +3177,24 @@ definitions:
         x-nullable: false
 
   SearchResultItem:
-    type: "object"
-    description: "search result item in search results."
-    properties:
-      description:
-        type: "string"
-        description: "description just shows the description of this image"
-      is_official:
-        type: "boolean"
-        description: "is_official shows if this image is marked official."
-      is_automated:
-        type: "boolean"
-        description: "is_automated means whether this image is automated."
-      name:
-        type: "string"
-        description: "name represents the name of this image"
-      star_count:
-        type: "integer"
-        description: "star_count refers to the star count of this image."
+      type: "object"
+      description: "search result item in search results."
+      properties:
+        description:
+          type: "string"
+          description: "description just shows the description of this image"
+        is_official:
+          type: "boolean"
+          description: "is_official shows if this image is marked official."
+        is_automated:
+          type: "boolean"
+          description: "is_automated means whether this image is automated."
+        name:
+          type: "string"
+          description: "name represents the name of this image"
+        star_count:
+          type: "integer"
+          description: "star_count refers to the star count of this image."
 
   VolumeInfo:
     type: "object"

--- a/cli/main.go
+++ b/cli/main.go
@@ -35,6 +35,7 @@ func main() {
 	cli.AddCommand(base, &LoadCommand{})
 	cli.AddCommand(base, &SaveCommand{})
 	cli.AddCommand(base, &HistoryCommand{})
+	cli.AddCommand(base, &SearchCommand{})
 
 	cli.AddCommand(base, &InspectCommand{})
 	cli.AddCommand(base, &RenameCommand{})

--- a/cli/search.go
+++ b/cli/search.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var searchDescription = "\nSearch the images from specific registry."
+
+// SearchCommand implements search images.
+type SearchCommand struct {
+	baseCommand
+	registry string
+}
+
+// Init initialize search command.
+func (s *SearchCommand) Init(c *Cli) {
+	s.cli = c
+
+	s.cmd = &cobra.Command{
+		Use:   "search [OPTIONS] TERM",
+		Short: "Search the images from specific registry",
+		Long:  searchDescription,
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return s.runSearch(args)
+		},
+		Example: searchExample(),
+	}
+	s.addFlags()
+}
+
+// addFlags adds flags for specific command.
+func (s *SearchCommand) addFlags() {
+	flagSet := s.cmd.Flags()
+
+	flagSet.StringVarP(&s.registry, "registry", "r", "", "set registry name")
+}
+
+func (s *SearchCommand) runSearch(args []string) error {
+	ctx := context.Background()
+	apiClient := s.cli.Client()
+
+	term := args[0]
+
+	// TODO: add flags --filter、--format、--limit、--no-trunc
+	searchResults, err := apiClient.ImageSearch(ctx, term, s.registry, fetchRegistryAuth(s.registry))
+
+	if err != nil {
+		return err
+	}
+
+	display := s.cli.NewTableDisplay()
+	display.AddRow([]string{"NAME", "DESCRIPTION", "STARS", "OFFICIAL", "AUTOMATED"})
+
+	for _, result := range searchResults {
+		display.AddRow([]string{result.Name, result.Description, fmt.Sprint(result.StarCount), boolToOKOrNot(result.IsOfficial), boolToOKOrNot(result.IsAutomated)})
+	}
+
+	display.Flush()
+	return nil
+}
+
+func boolToOKOrNot(isTrue bool) string {
+	if isTrue {
+		return "[OK]"
+	}
+	return ""
+}
+
+func searchExample() string {
+	return `$ pouch search nginx
+NAME                                                   DESCRIPTION                                     STARS               OFFICIAL            AUTOMATED
+nginx                                                  Official build of Nginx.                        11403               [OK]
+jwilder/nginx-proxy                                    Automated Nginx reverse proxy for docker con…   1600                                    [OK]
+richarvey/nginx-php-fpm                                Container running Nginx + PHP-FPM capable of…   712                                     [OK]
+jrcs/letsencrypt-nginx-proxy-companion                 LetsEncrypt container to use with nginx as p…   509                                     [OK]
+webdevops/php-nginx                                    Nginx with PHP-FPM                              127                                     [OK]
+zabbix/zabbix-web-nginx-mysql                          Zabbix frontend based on Nginx web-server wi…   101                                     [OK]
+bitnami/nginx                                          Bitnami nginx Docker Image                      66                                      [OK]
+linuxserver/nginx                                      An Nginx container, brought to you by LinuxS…   61
+1and1internet/ubuntu-16-nginx-php-phpmyadmin-mysql-5   ubuntu-16-nginx-php-phpmyadmin-mysql-5          50                                      [OK]
+zabbix/zabbix-web-nginx-pgsql                          Zabbix frontend based on Nginx with PostgreS…   33                                      [OK]
+tobi312/rpi-nginx                                      NGINX on Raspberry Pi / ARM                     26                                      [OK]
+nginx/nginx-ingress                                    NGINX Ingress Controller for Kubernetes         20
+schmunk42/nginx-redirect                               A very simple container to redirect HTTP tra…   15                                      [OK]
+nginxdemos/hello                                       NGINX webserver that serves a simple page co…   14                                      [OK]
+blacklabelops/nginx                                    Dockerized Nginx Reverse Proxy Server.          12                                      [OK]
+wodby/drupal-nginx                                     Nginx for Drupal container image                12                                      [OK]
+centos/nginx-18-centos7                                Platform for running nginx 1.8 or building n…   10
+centos/nginx-112-centos7                               Platform for running nginx 1.12 or building …   9
+nginxinc/nginx-unprivileged                            Unprivileged NGINX Dockerfiles                  4
+1science/nginx                                         Nginx Docker images that include Consul Temp…   4                                       [OK]
+nginx/nginx-prometheus-exporter                        NGINX Prometheus Exporter                       4
+mailu/nginx                                            Mailu nginx frontend                            3                                       [OK]
+toccoag/openshift-nginx                                Nginx reverse proxy for Nice running on same…   1                                       [OK]
+ansibleplaybookbundle/nginx-apb                        An APB to deploy NGINX                          0                                       [OK]
+wodby/nginx                                            Generic nginx                                   0                                       [OK]
+`
+}

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+
+	"github.com/alibaba/pouch/apis/types"
+)
+
+// ImageSearch requests daemon to search an image from registry.
+func (client *APIClient) ImageSearch(ctx context.Context, term, registry, encodedAuth string) ([]types.SearchResultItem, error) {
+	var results []types.SearchResultItem
+
+	q := url.Values{}
+	q.Set("term", term)
+	q.Set("registry", registry)
+
+	headers := map[string][]string{}
+	if encodedAuth != "" {
+		headers["X-Registry-Auth"] = []string{encodedAuth}
+	}
+
+	resp, err := client.post(ctx, "/images/search", q, nil, headers)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&results)
+	return results, err
+}

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/pouch/apis/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageSearchServerError(t *testing.T) {
+	client := &APIClient{
+		HTTPCli: newMockClient(errorMockResponse(http.StatusInternalServerError, "Server error")),
+	}
+	term, registry, auth := "", "nginx", ""
+	_, err := client.ImageSearch(context.Background(), term, registry, auth)
+	if err == nil || !strings.Contains(err.Error(), "Server error") {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestImageSearchOK(t *testing.T) {
+	expectedURL := "/images/search"
+
+	httpClient := newMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != "POST" {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+
+		searchResultResp, err := json.Marshal([]types.SearchResultItem{
+			{
+				Description: "nginx info",
+				IsAutomated: false,
+				IsOfficial:  true,
+				Name:        "nginx",
+				StarCount:   1233,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(searchResultResp))),
+		}, nil
+	})
+
+	client := &APIClient{
+		HTTPCli: httpClient,
+	}
+
+	searchResultResp, err := client.ImageSearch(context.Background(), "nginx", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, searchResultResp[0].StarCount, int64(1233))
+	assert.Equal(t, searchResultResp[0].Name, "nginx")
+}
+
+func TestImageSearchStatusUnauthorizedError(t *testing.T) {
+	client := &APIClient{
+		HTTPCli: newMockClient(errorMockResponse(http.StatusUnauthorized, "Unauthorized Error")),
+	}
+	term, registry, auth := "", "nginx", "some-auth-code"
+	_, err := client.ImageSearch(context.Background(), term, registry, auth)
+	if err == nil || !strings.Contains(err.Error(), "Unauthorized Error") {
+		t.Fatalf("expected a Unauthorized Error, got %v", err)
+	}
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -59,6 +59,7 @@ type ImageAPIClient interface {
 	ImageSave(ctx context.Context, imageName string) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, name string) ([]types.HistoryResultItem, error)
 	ImagePush(ctx context.Context, ref, encodedAuth string) (io.ReadCloser, error)
+	ImageSearch(ctx context.Context, term, registry, encodedAuth string) ([]types.SearchResultItem, error)
 }
 
 // VolumeAPIClient defines methods of Volume client.

--- a/registry/types/search_result_resp.go
+++ b/registry/types/search_result_resp.go
@@ -1,0 +1,16 @@
+package types
+
+import "github.com/alibaba/pouch/apis/types"
+
+// SearchResultResp response of search images from specific registry
+type SearchResultResp struct {
+
+	// NumResults indicates the number of results the query return
+	NumResults int64 `json:"num_results,omitempty"`
+
+	// query contains the query string that generated the search results
+	Query string `json:"query,omitempty"`
+
+	// Results is a slice containing the actual results for the search
+	Results []*types.SearchResultItem `json:"results"`
+}

--- a/test/api_image_search_test.go
+++ b/test/api_image_search_test.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"net/url"
+
+	"github.com/alibaba/pouch/apis/types"
 	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/test/request"
+	"github.com/alibaba/pouch/test/util"
 
 	"github.com/go-check/check"
 )
@@ -16,7 +21,26 @@ func init() {
 // SetUpTest does common setup in the beginning of each test.
 func (suite *APIImageSearchSuite) SetUpTest(c *check.C) {
 	SkipIfFalse(c, environment.IsLinux)
+}
 
-	// TODO: missing case
-	helpwantedForMissingCase(c, "image api search cases")
+func (suite *APIImageSearchSuite) TestImageSearchOK(c *check.C) {
+	q := url.Values{}
+	q.Add("term", "nginx")
+	q.Add("registry", "")
+
+	query := request.WithQuery(q)
+	resp, err := request.Post("/images/search", query)
+
+	defer resp.Body.Close()
+	CheckRespStatus(c, resp, 200)
+	c.Assert(err, check.IsNil)
+
+	var got []types.SearchResultItem
+	request.DecodeBody(&got, resp.Body)
+
+	c.Assert(util.PartialEqual(got[0].Name, "nginx"), check.IsNil)
+	c.Assert(got[0].Description, check.NotNil)
+	c.Assert(got[0].IsOfficial, check.NotNil)
+	c.Assert(got[0].IsAutomated, check.NotNil)
+	c.Assert(got[0].StarCount, check.NotNil)
 }

--- a/test/cli_search_test.go
+++ b/test/cli_search_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/test/util"
+	"github.com/gotestyourself/gotestyourself/icmd"
+
+	"github.com/go-check/check"
+)
+
+// PouchSearchSuite is the test suite for search CLI.
+type PouchSearchSuite struct{}
+
+func init() {
+	check.Suite(&PouchSearchSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each test suite.
+func (suite *PouchSearchSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+}
+
+// TestSearchWorks tests "pouch search" work.
+func (suite *PouchSearchSuite) TestSearchWorks(c *check.C) {
+	res := command.PouchRun("search", "nginx")
+	res.Assert(c, icmd.Success)
+	if !strings.Contains(res.String(), "nginx") {
+		c.Fatalf("the search result should contain nginx")
+	}
+
+	resSpecificRegistry := command.PouchRun("search", "-r", "https://index.docker.io/v1/", "nginx")
+	resSpecificRegistry.Assert(c, icmd.Success)
+	if !strings.Contains(res.String(), "nginx") {
+		c.Fatalf("the search result should contain nginx")
+	}
+
+	resWrongRegistry := command.PouchRun("search", "-r", "index.docker.io", "nginx")
+	err := util.PartialEqual(resWrongRegistry.Stderr(), "unsupported protocol scheme")
+	c.Assert(err, check.IsNil)
+}


### PR DESCRIPTION
Signed-off-by: Junjun Li <junjunli666@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
add feature: pouch support search the images from specific registry

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

[feature] [pouch cli supports search image](https://github.com/alibaba/pouch/issues/2839)

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)


### Ⅳ. Describe how to verify it
pouch search nginx 
pouch search nginx -r https://a.b.com

### Ⅴ. Special notes for reviews
1、add parameters in `/images/search` api
2、are these  test cases reasonable？
