### PR TITLE
bugfix: fix error when input 'inspect -f {{.Id}}'

### DIFF
--- a/cli/inspect/inspector.go
+++ b/cli/inspect/inspector.go
@@ -41,6 +41,9 @@ func NewTemplateInspectorFromString(out io.Writer, tmplStr string) (Inspector, e
 	if tmplStr == "" {
 		return NewIndentedInspector(out), nil
 	}
+	if strings.Contains(tmplStr, ".Id") {
+		tmplStr = strings.Replace(tmplStr, ".Id", ".ID", -1)
+	}
 
 	tmpl, err := templates.Parse(tmplStr)
 	if err != nil {

--- a/cli/inspect/inspector_test.go
+++ b/cli/inspect/inspector_test.go
@@ -194,10 +194,19 @@ func TestInspect(t *testing.T) {
 			wantOut: "\n",
 			wantErr: false,
 		}, {
+			name: "testInspectTemplate{{.Id}}",
+			args: args{
+				references: []string{"reference"},
+				tmplStr:    "{{.Id}}",
+				getRef:     getRefFunc,
+			},
+			wantOut: "id",
+			wantErr: false,
+		}, {
 			name: "testInspectTemplateError",
 			args: args{
 				references: []string{"single reference"},
-				tmplStr:    "{{.Id}}",
+				tmplStr:    "{{.id}}",
 				getRef:     getRefFunc,
 			},
 			wantOut: "",

--- a/test/cli_inspect_test.go
+++ b/test/cli_inspect_test.go
@@ -58,6 +58,10 @@ func (suite *PouchInspectSuite) TestInspectCreateAndStartedFormat(c *check.C) {
 	output = command.PouchRun("inspect", "-f", "{{.ID}}", name).Stdout()
 	c.Assert(output, check.Equals, fmt.Sprintf("%s\n", containerID))
 
+	// inspect Container Id
+	output = command.PouchRun("inspect", "-f", "{{.Id}}", name).Stdout()
+	c.Assert(output, check.Equals, fmt.Sprintf("%s\n", containerID))
+
 	// inspect Memory
 	output = command.PouchRun("inspect", "-f", "{{.HostConfig.Memory}}", name).Stdout()
 	c.Assert(output, check.Equals, fmt.Sprintf("%d\n", result[0].HostConfig.Memory))


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
can not use pouch inspect -f "{{.Id}}" to get container id, so fix it.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2841

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
pouch inspect -f "{{.Id}}"

### Ⅴ. Special notes for reviews