### PR TITLE
feature: cli supports --memory-reservation

### DIFF
--- a/apis/opts/memory_reservation.go
+++ b/apis/opts/memory_reservation.go
@@ -1,0 +1,11 @@
+package opts
+
+import units "github.com/docker/go-units"
+
+// ParseMemoryReservation parses the memory-reservation param of container.
+func ParseMemoryReservation(memoryReservation string) (int64, error) {
+	if memoryReservation == "" {
+		return 0, nil
+	}
+	return units.RAMInBytes(memoryReservation)
+}

--- a/apis/opts/memory_reservation_test.go
+++ b/apis/opts/memory_reservation_test.go
@@ -1,0 +1,56 @@
+package opts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseMemoryReservation(t *testing.T) {
+	type result struct {
+		memoryReservation int64
+		err               error
+	}
+	type TestCase struct {
+		input    string
+		expected result
+	}
+
+	testCases := []TestCase{
+		{
+			input: "",
+			expected: result{
+				memoryReservation: 0,
+				err:               nil,
+			},
+		},
+		{
+			input: "0",
+			expected: result{
+				memoryReservation: 0,
+				err:               nil,
+			},
+		},
+		{
+			input: "100m",
+			expected: result{
+				memoryReservation: 104857600,
+				err:               nil,
+			},
+		},
+		{
+			input: "10invalid",
+			expected: result{
+				memoryReservation: -1,
+				err:               fmt.Errorf("invalid size: '%s'", "10invalid"),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		memoryReservation, err := ParseMemoryReservation(testCase.input)
+		assert.Equal(t, testCase.expected.err, err)
+		assert.Equal(t, testCase.expected.memoryReservation, memoryReservation)
+	}
+}

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -51,6 +51,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 
 	// memory
 	flagSet.StringVarP(&c.memory, "memory", "m", "", "Memory limit")
+	flagSet.StringVar(&c.memoryReservation, "memory-reservation", "", "Memory soft limit")
 	flagSet.StringVar(&c.memorySwap, "memory-swap", "", "Swap limit equal to memory + swap, '-1' to enable unlimited swap")
 	flagSet.Int64Var(&c.memorySwappiness, "memory-swappiness", 0, "Container memory swappiness [0, 100]")
 	flagSet.StringVar(&c.kernelMemory, "kernel-memory", "", "Kernel memory limit (in bytes)")

--- a/cli/container.go
+++ b/cli/container.go
@@ -40,10 +40,11 @@ type container struct {
 	cpuperiod  int64
 	cpuquota   int64
 
-	memory           string
-	memorySwap       string
-	memorySwappiness int64
-	kernelMemory     string
+	memory            string
+	memoryReservation string
+	memorySwap        string
+	memorySwappiness  int64
+	kernelMemory      string
 
 	memoryWmarkRatio    int64
 	memoryExtra         int64
@@ -104,6 +105,11 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 	labels := opts.ParseLabels(c.labels)
 
 	memory, err := opts.ParseMemory(c.memory)
+	if err != nil {
+		return nil, err
+	}
+
+	memoryReservation, err := opts.ParseMemoryReservation(c.memoryReservation)
 	if err != nil {
 		return nil, err
 	}
@@ -233,10 +239,11 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 				CPUQuota:   c.cpuquota,
 
 				// memory
-				Memory:           memory,
-				MemorySwap:       memorySwap,
-				MemorySwappiness: &c.memorySwappiness,
-				KernelMemory:     kmemory,
+				Memory:            memory,
+				MemoryReservation: memoryReservation,
+				MemorySwap:        memorySwap,
+				MemorySwappiness:  &c.memorySwappiness,
+				KernelMemory:      kmemory,
 				// FIXME: validate in client side
 				MemoryWmarkRatio:    &c.memoryWmarkRatio,
 				MemoryExtra:         &c.memoryExtra,

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -41,6 +41,9 @@ var (
 	// MemoryWarn is warning for flag --memory
 	MemoryWarn = "Current Kernel does not support memory limit, discard --memory"
 
+	// MemoryReservationWarn is warning for flag --memory-reservation
+	MemoryReservationWarn = "Current Kernel does not support memory soft limit, discard --memory-reservation"
+
 	// MemorySwapWarn is warning for flag --memory-swap
 	MemorySwapWarn = "Current Kernel does not support memory swap, discard --memory-swap"
 

--- a/daemon/mgr/container_validation.go
+++ b/daemon/mgr/container_validation.go
@@ -180,6 +180,17 @@ func validateResource(r *types.Resources, update bool) ([]string, error) {
 			r.Memory = 0
 			r.MemorySwap = 0
 		}
+		if r.MemoryReservation > 0 && !cgroupInfo.Memory.MemoryReservation {
+			logrus.Warn(MemoryReservationWarn)
+			warnings = append(warnings, MemoryReservationWarn)
+			r.MemoryReservation = 0
+		}
+		if r.MemoryReservation != 0 && r.MemoryReservation < MinMemory {
+			return warnings, fmt.Errorf("Minimal memory reservation should greater than 4M")
+		}
+		if r.Memory > 0 && r.MemoryReservation > 0 && r.Memory < r.MemoryReservation {
+			return warnings, fmt.Errorf("Minimum memory limit should be larger than memory reservation limit")
+		}
 		if r.MemorySwap > 0 && !cgroupInfo.Memory.MemorySwap {
 			logrus.Warn(MemorySwapWarn)
 			warnings = append(warnings, MemorySwapWarn)

--- a/daemon/mgr/spec_linux.go
+++ b/daemon/mgr/spec_linux.go
@@ -192,6 +192,11 @@ func setupMemory(ctx context.Context, r types.Resources, s *specs.Spec) {
 		memory.Limit = &v
 	}
 
+	if r.MemoryReservation > 0 {
+		v := r.MemoryReservation
+		memory.Reservation = &v
+	}
+
 	if r.MemorySwap != 0 {
 		v := r.MemorySwap
 		memory.Swap = &v

--- a/pkg/system/cgroup.go
+++ b/pkg/system/cgroup.go
@@ -10,10 +10,11 @@ import (
 
 // MemoryCgroupInfo defines memory cgroup information on current machine
 type MemoryCgroupInfo struct {
-	MemoryLimit      bool
-	MemorySwap       bool
-	MemorySwappiness bool
-	OOMKillDisable   bool
+	MemoryLimit       bool
+	MemoryReservation bool
+	MemorySwap        bool
+	MemorySwappiness  bool
+	OOMKillDisable    bool
 }
 
 // CPUCgroupInfo defines cpu cgroup information on current machine
@@ -66,10 +67,11 @@ func NewCgroupInfo() *CgroupInfo {
 func getMemoryCgroupInfo(root string) *MemoryCgroupInfo {
 	path := path.Join(root, "memory")
 	return &MemoryCgroupInfo{
-		MemoryLimit:      isCgroupEnable(path, "memory.limit_in_bytes"),
-		MemorySwap:       isCgroupEnable(path, "memory.memsw.limit_in_bytes"),
-		MemorySwappiness: isCgroupEnable(path, "memory.swappiness"),
-		OOMKillDisable:   isCgroupEnable(path, "memory.oom_control"),
+		MemoryLimit:       isCgroupEnable(path, "memory.limit_in_bytes"),
+		MemoryReservation: isCgroupEnable(path, "memory.soft_limit_in_bytes"),
+		MemorySwap:        isCgroupEnable(path, "memory.memsw.limit_in_bytes"),
+		MemorySwappiness:  isCgroupEnable(path, "memory.swappiness"),
+		OOMKillDisable:    isCgroupEnable(path, "memory.oom_control"),
 	}
 }
 

--- a/test/environment/env.go
+++ b/test/environment/env.go
@@ -80,6 +80,11 @@ var (
 		return cgroupInfo.Memory.MemoryLimit
 	}
 
+	// IsMemoryReservationSupport checks if memory reservation cgroup is available
+	IsMemoryReservationSupport = func() bool {
+		return cgroupInfo.Memory.MemoryReservation
+	}
+
 	// IsMemorySwapSupport checks if memory swap cgroup is avaible
 	IsMemorySwapSupport = func() bool {
 		return cgroupInfo.Memory.MemorySwap


### PR DESCRIPTION
Signed-off-by: KevinBetterQ <1093850932@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
pouch command supports --memory-reservation


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2701 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
```
# pouch run -d --memory-reservation 4M busybox top
58369a469f0579234538717575d0338eb969b4009c6136ef32b678c432d8c072

# pouch inspect -f {{.HostConfig.MemoryReservation}} 5836
4194304

# cat /sys/fs/cgroup/memory/default/58369a469f0579234538717575d0338eb969b4009c6136ef32b678c432d8c072/memory.soft_limit_in_bytes
4194304
```

### Ⅴ. Special notes for reviews


