### PR TITLE
enhancement: sort objects to solve out-of-order output

### DIFF
--- a/cli/network.go
+++ b/cli/network.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/alibaba/pouch/apis/types"
@@ -353,6 +354,10 @@ func (n *NetworkListCommand) runNetworkList(args []string) error {
 	if err != nil {
 		return err
 	}
+
+	sort.Slice(respNetworkResource, func(i, j int) bool {
+		return respNetworkResource[i].Name < respNetworkResource[j].Name
+	})
 
 	display := n.cli.NewTableDisplay()
 	display.AddRow([]string{"NETWORK ID", "NAME", "DRIVER", "SCOPE"})

--- a/cli/volume.go
+++ b/cli/volume.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/alibaba/pouch/apis/filters"
@@ -335,6 +336,10 @@ func (v *VolumeListCommand) runVolumeList(args []string) error {
 	if (v.size || v.mountPoint) && v.quiet {
 		return fmt.Errorf("Conflicting options: --size (or --mountpoint) and -q")
 	}
+
+	sort.Slice(volumeList.Volumes, func(i, j int) bool {
+		return volumeList.Volumes[i].Name < volumeList.Volumes[j].Name
+	})
 
 	display := v.cli.NewTableDisplay()
 	displayHead := []string{"VOLUME NAME"}

--- a/test/cli_network_test.go
+++ b/test/cli_network_test.go
@@ -605,3 +605,37 @@ func (suite *PouchNetworkSuite) TestNetworkConnectWithRestart(c *check.C) {
 
 	c.Assert(found, check.Equals, false)
 }
+
+func (suite *PouchNetworkSuite) TestNetworkList(c *check.C) {
+	// start the test pouch daemon
+	dcfg, err := StartDefaultDaemonDebug()
+	if err != nil {
+		c.Skip("daemon start failed.")
+	}
+	defer dcfg.KillDaemon()
+
+	// list pouch network
+	ret := RunWithSpecifiedDaemon(dcfg, "network", "ls").Assert(c, icmd.Success)
+	expect := []string{"bridge", "host", "none"}
+
+	actual := networkNamesToSlice(ret.Stdout())
+	for i := 0; i < len(actual); i++ {
+		c.Assert(actual[i], check.Equals, expect[i])
+	}
+}
+
+// networkNamesToSlice parses networks' name to slice.
+func networkNamesToSlice(volumes string) []string {
+	lines := strings.Split(volumes, "\n")[1:]
+
+	res := make([]string, 0)
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		items := strings.Fields(line)
+		res = append(res, items[1])
+	}
+	return res
+}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
It is a small enhancement. I found that some commands such as `pouch network ls` or `pouch volume ls` will produce some outputs with different orders. We should sort these output in the code of cli as docker cli does.

Here is an example with different output:
``` bash
root@cmzppppp:~# pouch network ls 
NETWORK ID   NAME     DRIVER   SCOPE
55ce21361b   bridge   bridge   local
d7026299ce   host     host     local
fd34017f24   none     null     local
root@cmzppppp:~# pouch network ls 
NETWORK ID   NAME     DRIVER   SCOPE
fd34017f24   none     null     local
55ce21361b   bridge   bridge   local
d7026299ce   host     host     local
```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


