### PR TITLE
remove _counter in metrics name for counter type

### DIFF
--- a/apis/metrics/metrics.go
+++ b/apis/metrics/metrics.go
@@ -20,16 +20,16 @@ var (
 	ImagePullSummary = metrics.NewLabelSummary(subsystemPouch, "image_pull_latency_microseconds", "Latency in microseconds to pull a image.", "image")
 
 	// ContainerActionsCounter records the number of container operations.
-	ContainerActionsCounter = metrics.NewLabelCounter(subsystemPouch, "container_actions_counter", "The number of container operations", "action")
+	ContainerActionsCounter = metrics.NewLabelCounter(subsystemPouch, "container_actions", "The number of container operations", "action")
 
 	// ContainerSuccessActionsCounter records the number of container success operations.
-	ContainerSuccessActionsCounter = metrics.NewLabelCounter(subsystemPouch, "container_success_actions_counter", "The number of container success operations", "action")
+	ContainerSuccessActionsCounter = metrics.NewLabelCounter(subsystemPouch, "container_success_actions", "The number of container success operations", "action")
 
 	// ImageActionsCounter records the number of image operations.
-	ImageActionsCounter = metrics.NewLabelCounter(subsystemPouch, "image_actions_counter", "The number of image operations", "action")
+	ImageActionsCounter = metrics.NewLabelCounter(subsystemPouch, "image_actions", "The number of image operations", "action")
 
-	// ImageSuccessActionsCounter the number of image success operations.
-	ImageSuccessActionsCounter = metrics.NewLabelCounter(subsystemPouch, "image_success_actions_counter", "The number of image success operations", "action")
+	// ImageSuccessActionsCounter records the number of successful image operations.
+	ImageSuccessActionsCounter = metrics.NewLabelCounter(subsystemPouch, "image_success_actions", "The number of image success operations", "action")
 
 	// ContainerActionsTimer records the time cost of each container action.
 	ContainerActionsTimer = metrics.NewLabelTimer(subsystemPouch, "container_actions", "The number of seconds it takes to process each container action", "action")

--- a/apis/server/image_bridge_test.go
+++ b/apis/server/image_bridge_test.go
@@ -47,8 +47,8 @@ func Test_pullImage_counter(t *testing.T) {
 	var s Server
 	ctx := context.Background()
 
-	key := fmt.Sprintf(`engine_daemon_image_actions_counter_total{action="%s"}`, "pull")
-	keySuccess := fmt.Sprintf(`engine_daemon_image_success_actions_counter_total{action="%s"}`, "pull")
+	key := fmt.Sprintf(`engine_daemon_image_actions_total{action="%s"}`, "pull")
+	keySuccess := fmt.Sprintf(`engine_daemon_image_success_actions_total{action="%s"}`, "pull")
 	countBefore, countSuccessBefore := getMetric(ctx, t, &s, key, keySuccess)
 
 	ch := make(chan int, 1)

--- a/pkg/utils/metrics/metrics.go
+++ b/pkg/utils/metrics/metrics.go
@@ -80,7 +80,7 @@ func NewLabelTimer(subsystem, name, help string, labels ...string) *prometheus.H
 		}, labels)
 }
 
-// GetPrometheusRegistry return a resigtry of Prometheus.
+// GetPrometheusRegistry return a registry of Prometheus.
 func GetPrometheusRegistry() *prometheus.Registry {
 	return prometheusRegistry
 }

--- a/test/api_container_metrics_test.go
+++ b/test/api_container_metrics_test.go
@@ -49,11 +49,10 @@ func (suite *APIContainerMetricsSuite) TestContainerMetrics(c *check.C) {
 }
 
 func (suite *APIContainerMetricsSuite) checkAction(c *check.C, cname string, label string) {
-	key := fmt.Sprintf(`engine_daemon_container_actions_counter_total{action="%s"}`, label)
-	keySuccess := fmt.Sprintf(`engine_daemon_container_success_actions_counter_total{action="%s"}`, label)
-	countBefore, countSuccessBefore := GetMetric(c,
-		key,
-		keySuccess)
+	key := fmt.Sprintf(`engine_daemon_container_actions_total{action="%s"}`, label)
+	keySuccess := fmt.Sprintf(`engine_daemon_container_success_actions_total{action="%s"}`, label)
+	countBefore, countSuccessBefore := GetMetric(c, key, keySuccess)
+
 	switch label {
 	case "create":
 		CreateBusyboxContainerOk(c, cname)

--- a/test/api_image_metrics_test.go
+++ b/test/api_image_metrics_test.go
@@ -40,11 +40,10 @@ func (suite *APIImageMetricsSuite) TestImageMetrics(c *check.C) {
 }
 
 func (suite *APIImageMetricsSuite) checkAction(c *check.C, label string) {
-	key := fmt.Sprintf(`engine_daemon_image_actions_counter_total{action="%s"}`, label)
-	keySuccess := fmt.Sprintf(`engine_daemon_image_success_actions_counter_total{action="%s"}`, label)
-	countBefore, countSuccessBefore := GetMetric(c,
-		key,
-		keySuccess)
+	key := fmt.Sprintf(`engine_daemon_image_actions_total{action="%s"}`, label)
+	keySuccess := fmt.Sprintf(`engine_daemon_image_success_actions_total{action="%s"}`, label)
+	countBefore, countSuccessBefore := GetMetric(c, key, keySuccess)
+
 	switch label {
 	case "pull":
 		PullImage(c, helloworldImage)


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Currently pouch has some counter type metrics. But they all use suffix `_counter_total`. I think we should change these suffix to `_total`. 
It is OK to just use `_total` here and it can represent counter. So this `_counter` is useless and should be removed.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


