### PR TITLE
feature: cli supports --env-file

### DIFF
--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -33,11 +33,6 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	// device related options
 	flagSet.StringSliceVarP(&c.devices, "device", "", nil, "Add a host device to the container")
 
-	// dns
-	flagSet.StringArrayVar(&c.dns, "dns", nil, "Set DNS servers")
-	flagSet.StringSliceVar(&c.dnsOptions, "dns-option", nil, "Set DNS options")
-	flagSet.StringArrayVar(&c.dnsSearch, "dns-search", nil, "Set DNS search domains")
-
 	flagSet.BoolVar(&c.enableLxcfs, "enableLxcfs", false, "Enable lxcfs for the container, only effective when enable-lxcfs switched on in Pouchd")
 	flagSet.StringVar(&c.entrypoint, "entrypoint", "", "Overwrite the default ENTRYPOINT of the image")
 	flagSet.StringArrayVarP(&c.env, "env", "e", nil, "Set environment variables for container('--env A=' means setting env A to empty, '--env B' means removing env B from container env inherited from image)")
@@ -67,11 +62,19 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringVar(&c.name, "name", "", "Specify name of container")
 	flagSet.StringVar(&c.specificID, "specific-id", "", "Specify id of container, length of id should be 64, characters of id should be in '0123456789abcdef'")
 
+	// network
 	flagSet.StringSliceVar(&c.networks, "net", nil, "Set networks to container")
 	flagSet.StringSliceVarP(&c.ports, "publish", "p", nil, "Set container ports mapping")
 	flagSet.StringSliceVar(&c.expose, "expose", nil, "Set expose container's ports")
 	flagSet.BoolVarP(&c.publishAll, "publish-all", "P", false, "Publish all exposed ports to random ports")
 	flagSet.StringVar(&c.macAddress, "mac-address", "", "Set mac address of container endpoint")
+	flagSet.StringVar(&c.ip, "ip", "", "Set IPv4 address of container endpoint")
+	flagSet.StringVar(&c.ipv6, "ip6", "", "Set IPv6 address of container endpoint")
+	flagSet.Int64Var(&c.netPriority, "net-priority", 0, "net priority")
+	// dns
+	flagSet.StringArrayVar(&c.dns, "dns", nil, "Set DNS servers")
+	flagSet.StringSliceVar(&c.dnsOptions, "dns-option", nil, "Set DNS options")
+	flagSet.StringArrayVar(&c.dnsSearch, "dns-search", nil, "Set DNS search domains")
 
 	flagSet.StringVar(&c.pidMode, "pid", "", "PID namespace to use")
 	flagSet.BoolVar(&c.privileged, "privileged", false, "Give extended privileges to the container")
@@ -102,7 +105,6 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringVar(&c.richMode, "rich-mode", "", "Choose one rich container mode. dumb-init(default), systemd, sbin-init")
 	flagSet.StringVar(&c.initScript, "initscript", "", "Initial script executed in container")
 	flagSet.StringVar(&c.shmSize, "shm-size", "", "Size of /dev/shm, default value is 64MB")
-	flagSet.Int64Var(&c.netPriority, "net-priority", 0, "net priority")
 
 	// cgroup
 	flagSet.StringVarP(&c.cgroupParent, "cgroup-parent", "", "", "Optional parent cgroup for the container")

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -33,9 +33,15 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	// device related options
 	flagSet.StringSliceVarP(&c.devices, "device", "", nil, "Add a host device to the container")
 
+	// dns
+	flagSet.StringArrayVar(&c.dns, "dns", nil, "Set DNS servers")
+	flagSet.StringSliceVar(&c.dnsOptions, "dns-option", nil, "Set DNS options")
+	flagSet.StringArrayVar(&c.dnsSearch, "dns-search", nil, "Set DNS search domains")
+
 	flagSet.BoolVar(&c.enableLxcfs, "enableLxcfs", false, "Enable lxcfs for the container, only effective when enable-lxcfs switched on in Pouchd")
 	flagSet.StringVar(&c.entrypoint, "entrypoint", "", "Overwrite the default ENTRYPOINT of the image")
 	flagSet.StringArrayVarP(&c.env, "env", "e", nil, "Set environment variables for container('--env A=' means setting env A to empty, '--env B' means removing env B from container env inherited from image)")
+	flagSet.StringArrayVar(&c.envfile, "env-file", nil, "Read in a file of environment variables")
 	flagSet.StringVar(&c.hostname, "hostname", "", "Set container's hostname")
 	flagSet.BoolVar(&c.disableNetworkFiles, "disable-network-files", false, "Disable the generation of network files(/etc/hostname, /etc/hosts and /etc/resolv.conf) for container. If true, no network files will be generated. Default false")
 
@@ -61,19 +67,11 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringVar(&c.name, "name", "", "Specify name of container")
 	flagSet.StringVar(&c.specificID, "specific-id", "", "Specify id of container, length of id should be 64, characters of id should be in '0123456789abcdef'")
 
-	// network
 	flagSet.StringSliceVar(&c.networks, "net", nil, "Set networks to container")
 	flagSet.StringSliceVarP(&c.ports, "publish", "p", nil, "Set container ports mapping")
 	flagSet.StringSliceVar(&c.expose, "expose", nil, "Set expose container's ports")
 	flagSet.BoolVarP(&c.publishAll, "publish-all", "P", false, "Publish all exposed ports to random ports")
 	flagSet.StringVar(&c.macAddress, "mac-address", "", "Set mac address of container endpoint")
-	flagSet.StringVar(&c.ip, "ip", "", "Set IPv4 address of container endpoint")
-	flagSet.StringVar(&c.ipv6, "ip6", "", "Set IPv6 address of container endpoint")
-	flagSet.Int64Var(&c.netPriority, "net-priority", 0, "net priority")
-	// dns
-	flagSet.StringArrayVar(&c.dns, "dns", nil, "Set DNS servers")
-	flagSet.StringSliceVar(&c.dnsOptions, "dns-option", nil, "Set DNS options")
-	flagSet.StringArrayVar(&c.dnsSearch, "dns-search", nil, "Set DNS search domains")
 
 	flagSet.StringVar(&c.pidMode, "pid", "", "PID namespace to use")
 	flagSet.BoolVar(&c.privileged, "privileged", false, "Give extended privileges to the container")
@@ -104,6 +102,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringVar(&c.richMode, "rich-mode", "", "Choose one rich container mode. dumb-init(default), systemd, sbin-init")
 	flagSet.StringVar(&c.initScript, "initscript", "", "Initial script executed in container")
 	flagSet.StringVar(&c.shmSize, "shm-size", "", "Size of /dev/shm, default value is 64MB")
+	flagSet.Int64Var(&c.netPriority, "net-priority", 0, "net priority")
 
 	// cgroup
 	flagSet.StringVarP(&c.cgroupParent, "cgroup-parent", "", "", "Optional parent cgroup for the container")

--- a/cli/container.go
+++ b/cli/container.go
@@ -18,6 +18,7 @@ type container struct {
 	volumesFrom         []string
 	runtime             string
 	env                 []string
+	envfile             []string
 	entrypoint          string
 	workdir             string
 	user                string
@@ -51,28 +52,23 @@ type container struct {
 	scheLatSwitch       int64
 	oomKillDisable      bool
 
-	devices       []string
-	enableLxcfs   bool
-	privileged    bool
-	restartPolicy string
-	ipcMode       string
-	pidMode       string
-	utsMode       string
-	sysctls       []string
+	dns        []string
+	dnsOptions []string
+	dnsSearch  []string
 
-	// set network options
-	networks    []string
-	ports       []string
-	expose      []string
-	publishAll  bool
-	ip          string
-	ipv6        string
-	macAddress  string
-	netPriority int64
-	dns         []string
-	dnsOptions  []string
-	dnsSearch   []string
-
+	devices        []string
+	enableLxcfs    bool
+	privileged     bool
+	restartPolicy  string
+	ipcMode        string
+	pidMode        string
+	utsMode        string
+	sysctls        []string
+	networks       []string
+	ports          []string
+	expose         []string
+	publishAll     bool
+	macAddress     string
 	securityOpt    []string
 	capAdd         []string
 	capDrop        []string
@@ -85,6 +81,7 @@ type container struct {
 	ulimit         config.Ulimit
 	pidsLimit      int64
 	shmSize        string
+	netPriority    int64
 
 	// log driver and log option
 	logDriver string
@@ -163,10 +160,6 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 
 	networkingConfig, networkMode, err := opts.ParseNetworks(c.networks)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := opts.SetEndpointIPAddress(networkingConfig, networkMode, c.ip, c.ipv6); err != nil {
 		return nil, err
 	}
 

--- a/cli/create.go
+++ b/cli/create.go
@@ -55,6 +55,12 @@ func (cc *CreateCommand) runCreate(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create container: %v", err)
 	}
+
+	// collect all the environment variables for the container
+	config.Env, err = readKVStrings(cc.envfile, cc.env)
+	if err != nil {
+		return nil
+	}
 	config.ContainerConfig.OpenStdin = cc.openstdin
 
 	config.Image = args[0]

--- a/cli/envfile.go
+++ b/cli/envfile.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// reads a file of line terminated key=value pairs, and overrides any keys
+// present in the file with additional pairs specified in the override parameter
+func readKVStrings(files []string, override []string) ([]string, error) {
+	envVariables := []string{}
+	for _, ef := range files {
+		parsedVars, err := ParseEnvFile(ef)
+		if err != nil {
+			return nil, err
+		}
+		envVariables = append(envVariables, parsedVars...)
+	}
+	// parse the '-e' and '--env' after, to allow override
+	envVariables = append(envVariables, override...)
+
+	return envVariables, nil
+}
+
+// ParseEnvFile reads a file with environment variables enumerated by lines
+func ParseEnvFile(filename string) ([]string, error) {
+	fh, err := os.Open(filename)
+	if err != nil {
+		return []string{}, err
+	}
+	defer fh.Close()
+
+	lines := []string{}
+	scanner := bufio.NewScanner(fh)
+	for scanner.Scan() {
+		// trim the line from all leading whitespace first
+		line := strings.TrimLeft(scanner.Text(), whiteSpaces)
+		// line is not empty, and not starting with '#'
+		if len(line) > 0 && !strings.HasPrefix(line, "#") {
+			data := strings.SplitN(line, "=", 2)
+
+			// trim the front of a variable, but nothing else
+			variable := strings.TrimLeft(data[0], whiteSpaces)
+			if strings.ContainsAny(variable, whiteSpaces) {
+				return []string{}, ErrBadEnvVariable{fmt.Sprintf("variable '%s' has white spaces", variable)}
+			}
+
+			if len(data) > 1 {
+
+				// pass the value through, no trimming
+				lines = append(lines, fmt.Sprintf("%s=%s", variable, data[1]))
+			} else {
+				// if only a pass-through variable is given, clean it up.
+				lines = append(lines, fmt.Sprintf("%s=%s", strings.TrimSpace(line), os.Getenv(line)))
+			}
+		}
+	}
+	return lines, scanner.Err()
+}
+
+var whiteSpaces = " \t"
+
+// ErrBadEnvVariable typed error for bad environment variable
+type ErrBadEnvVariable struct {
+	msg string
+}
+
+// Error implements error interface.
+func (e ErrBadEnvVariable) Error() string {
+	return fmt.Sprintf("poorly formatted environment: %s", e.msg)
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -66,6 +66,12 @@ func (rc *RunCommand) runRun(args []string) error {
 		return fmt.Errorf("failed to run container: %v", err)
 	}
 
+	// collect all the environment variables for the container
+	config.Env, err = readKVStrings(rc.envfile, rc.env)
+	if err != nil {
+		return nil
+	}
+
 	config.Image = args[0]
 	if len(args) > 1 {
 		config.Cmd = args[1:]


### PR DESCRIPTION
Signed-off-by: Lang Chi <21860405@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
pouch command supports --env-file

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2857 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
unit test

### Ⅳ. Describe how to verify it
# cat /home/abc
env_var_name=another_value

# pouch run --env-file=/home/abc -d busybox top
b2f0df7176e9459441276c7470ad95ae701329b49ff2709344706316597ce639

# pouch exec b2f0df7176e9459441276c7470ad95ae701329b49ff2709344706316597ce639 env | grep env_var_name
env_var_name=another_value
### Ⅴ. Special notes for reviews


