### PR TITLE
feature: cli supports --env-file

### DIFF
--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -36,6 +36,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.BoolVar(&c.enableLxcfs, "enableLxcfs", false, "Enable lxcfs for the container, only effective when enable-lxcfs switched on in Pouchd")
 	flagSet.StringVar(&c.entrypoint, "entrypoint", "", "Overwrite the default ENTRYPOINT of the image")
 	flagSet.StringArrayVarP(&c.env, "env", "e", nil, "Set environment variables for container('--env A=' means setting env A to empty, '--env B' means removing env B from container env inherited from image)")
+	flagSet.StringArrayVar(&c.envfile, "env-file", nil, "Read in a file of environment variables")
 	flagSet.StringVar(&c.hostname, "hostname", "", "Set container's hostname")
 	flagSet.BoolVar(&c.disableNetworkFiles, "disable-network-files", false, "Disable the generation of network files(/etc/hostname, /etc/hosts and /etc/resolv.conf) for container. If true, no network files will be generated. Default false")
 

--- a/cli/container.go
+++ b/cli/container.go
@@ -18,6 +18,7 @@ type container struct {
 	volumesFrom         []string
 	runtime             string
 	env                 []string
+	envfile             []string
 	entrypoint          string
 	workdir             string
 	user                string

--- a/cli/create.go
+++ b/cli/create.go
@@ -55,6 +55,12 @@ func (cc *CreateCommand) runCreate(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create container: %v", err)
 	}
+
+	// collect all the environment variables for the container
+	config.Env, err = readKVStrings(cc.envfile, cc.env)
+	if err != nil {
+		return nil
+	}
 	config.ContainerConfig.OpenStdin = cc.openstdin
 
 	config.Image = args[0]

--- a/cli/envfile.go
+++ b/cli/envfile.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+)
+
+// reads a file of line terminated key=value pairs, and overrides any keys
+// present in the file with additional pairs specified in the override parameter
+func readKVStrings(files []string, override []string) ([]string, error) {
+	envVariables := []string{}
+	for _, ef := range files {
+		parsedVars, err := parseEnvFile(ef)
+		if err != nil {
+			return nil, err
+		}
+		envVariables = append(envVariables, parsedVars...)
+	}
+	// parse the '-e' and '--env' after, to allow override
+	envVariables = append(envVariables, override...)
+
+	return envVariables, nil
+}
+
+// parseEnvFile reads a file with environment variables enumerated by lines
+func parseEnvFile(filename string) ([]string, error) {
+	fh, err := os.Open(filename)
+	if err != nil {
+		return []string{}, err
+	}
+	defer fh.Close()
+
+	lines := []string{}
+	scanner := bufio.NewScanner(fh)
+	for scanner.Scan() {
+		// trim the line from all leading whitespace first
+		line := strings.TrimLeftFunc(scanner.Text(), unicode.IsSpace)
+		// line is not empty, and not starting with '#'
+		if len(line) > 0 && !strings.HasPrefix(line, "#") {
+			data := strings.SplitN(line, "=", 2)
+
+			// trim the front of a variable, but nothing else
+			variable := data[0]
+			if strings.IndexFunc(variable, unicode.IsSpace) != -1 {
+				return []string{}, ErrBadEnvVariable{fmt.Sprintf("variable '%s' has white spaces", variable)}
+			}
+
+			if len(data) > 1 {
+				// pass the value through, no trimming
+				lines = append(lines, fmt.Sprintf("%s=%s", variable, data[1]))
+			} else {
+				// if only a pass-through variable is given, clean it up.
+				lines = append(lines, fmt.Sprintf("%s=%s", strings.TrimSpace(line), os.Getenv(line)))
+			}
+		}
+	}
+	return lines, scanner.Err()
+}
+
+// ErrBadEnvVariable typed error for bad environment variable
+type ErrBadEnvVariable struct {
+	msg string
+}
+
+// Error implements error interface.
+func (e ErrBadEnvVariable) Error() string {
+	return fmt.Sprintf("poorly formatted environment: %s", e.msg)
+}

--- a/cli/envfile_test.go
+++ b/cli/envfile_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// tmpFileWithContent provide tmp file
+func tmpFileWithContent(content string, t *testing.T) string {
+	tmpFile, err := ioutil.TempFile("", "envfile-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpFile.Close()
+
+	tmpFile.WriteString(content)
+	return tmpFile.Name()
+}
+
+// Test ParseEnvFile for a file with a few well formatted lines
+func TestParseEnvFileGoodFile(t *testing.T) {
+	content := `foo=bar
+    baz=quux
+# comment
+
+_foobar=foobaz
+with.dots=working
+and_underscore=working too
+地址1=杭州
+	ADDRESS=杭州
+地址2=Hangzhou
+`
+	// Adding a newline + a line with pure whitespace.
+	// This is being done like this instead of the block above
+	// because it's common for editors to trim trailing whitespace
+	// from lines, which becomes annoying since that's the
+	// exact thing we need to test.
+	content += "\n    \t  "
+	tmpFile := tmpFileWithContent(content, t)
+	defer os.Remove(tmpFile)
+
+	lines, err := parseEnvFile(tmpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedLines := []string{
+		"foo=bar",
+		"baz=quux",
+		"_foobar=foobaz",
+		"with.dots=working",
+		"and_underscore=working too",
+		"地址1=杭州",
+		"ADDRESS=杭州",
+		"地址2=Hangzhou",
+	}
+
+	if !reflect.DeepEqual(lines, expectedLines) {
+		t.Fatal("lines not equal to expected_lines")
+	}
+}
+
+// Test ParseEnvFile for an empty file
+func TestParseEnvFileEmptyFile(t *testing.T) {
+	tmpFile := tmpFileWithContent("", t)
+	defer os.Remove(tmpFile)
+
+	lines, err := parseEnvFile(tmpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(lines) != 0 {
+		t.Fatal("lines not empty; expected empty")
+	}
+}
+
+// Test ParseEnvFile for a non existent file
+func TestParseEnvFileNonExistentFile(t *testing.T) {
+	_, err := parseEnvFile("foo_bar_baz")
+	if err == nil {
+		t.Fatal("ParseEnvFile succeeded; expected failure")
+	}
+	if _, ok := err.(*os.PathError); !ok {
+		t.Fatalf("Expected a PathError, got [%v]", err)
+	}
+}
+
+// Test ParseEnvFile for a badly formatted file
+func TestParseEnvFileBadlyFormattedFile(t *testing.T) {
+	content := `foo=bar
+    f   =quux
+`
+	tmpFile := tmpFileWithContent(content, t)
+	defer os.Remove(tmpFile)
+
+	_, err := parseEnvFile(tmpFile)
+	if err == nil {
+		t.Fatalf("Expected an ErrBadEnvVariable, got nothing")
+	}
+	if _, ok := err.(ErrBadEnvVariable); !ok {
+		t.Fatalf("Expected an ErrBadEnvVariable, got [%v]", err)
+	}
+	expectedMessage := "poorly formatted environment: variable 'f   ' has white spaces"
+	if err.Error() != expectedMessage {
+		t.Fatalf("Expected [%v], got [%v]", expectedMessage, err.Error())
+	}
+}
+
+// Test ParseEnvFile for a file with a line exceeding bufio.MaxScanTokenSize
+func TestParseEnvFileLineTooLongFile(t *testing.T) {
+	content := strings.Repeat("a", bufio.MaxScanTokenSize+42)
+	content = fmt.Sprint("foo=", content)
+
+	tmpFile := tmpFileWithContent(content, t)
+	defer os.Remove(tmpFile)
+
+	_, err := parseEnvFile(tmpFile)
+	if err == nil {
+		t.Fatal("ParseEnvFile succeeded; expected failure")
+	}
+}
+
+// ParseEnvFile with a random file, pass through
+func TestParseEnvFileRandomFile(t *testing.T) {
+	content := `first line
+another invalid line`
+	tmpFile := tmpFileWithContent(content, t)
+	defer os.Remove(tmpFile)
+
+	_, err := parseEnvFile(tmpFile)
+
+	if err == nil {
+		t.Fatalf("Expected an ErrBadEnvVariable, got nothing")
+	}
+	if _, ok := err.(ErrBadEnvVariable); !ok {
+		t.Fatalf("Expected an ErrBadEnvvariable, got [%v]", err)
+	}
+	expectedMessage := "poorly formatted environment: variable 'first line' has white spaces"
+	if err.Error() != expectedMessage {
+		t.Fatalf("Expected [%v], got [%v]", expectedMessage, err.Error())
+	}
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -66,6 +66,11 @@ func (rc *RunCommand) runRun(args []string) error {
 		return fmt.Errorf("failed to run container: %v", err)
 	}
 
+	//collect all the environment variables for the container
+	config.Env, err = readKVStrings(rc.envfile, rc.env)
+	if err != nil {
+		return nil
+	}
 	config.Image = args[0]
 	if len(args) > 1 {
 		config.Cmd = args[1:]

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 	"time"
 
@@ -94,4 +95,16 @@ func ParseCgroupFile(text string) map[string]string {
 		}
 	}
 	return cgroups
+}
+
+// TmpFileWithContent provide tmp file
+func TmpFileWithContent(content string) (string, error) {
+	tmpFile, err := ioutil.TempFile("", "envfile-test")
+	if err != nil {
+		return "", err
+	}
+	defer tmpFile.Close()
+
+	tmpFile.WriteString(content)
+	return tmpFile.Name(), nil
 }


### PR DESCRIPTION
Signed-off-by: Lang Chi <21860405@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
pouch command supports --env-file

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2857

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
# cat /home/abc
env_var_name=another_value

# pouch run --env-file=/home/abc -d busybox top
b2f0df7176e9459441276c7470ad95ae701329b49ff2709344706316597ce639

# pouch exec b2f0df7176e9459441276c7470ad95ae701329b49ff2709344706316597ce639 env | grep env_var_name
env_var_name=another_value
### Ⅴ. Special notes for reviews


