### PR TITLE
feature: support registry mirrors

### DIFF
--- a/ctrd/image.go
+++ b/ctrd/image.go
@@ -251,6 +251,20 @@ func (c *Client) PushImage(ctx context.Context, ref string, authConfig *types.Au
 	return nil
 }
 
+// ResolveImage attempts to resolve the image reference into a name and descriptor.
+func (c *Client) ResolveImage(ctx context.Context, ref string, authConfig *types.AuthConfig) (name string, desc ocispec.Descriptor, err error) {
+	resolver, err := c.getResolver(authConfig, ref, docker.ResolverOptions{})
+	if err != nil {
+		return "", ocispec.Descriptor{}, err
+	}
+
+	name, desc, err = resolver.Resolve(ctx, ref)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to resolve reference %q", ref)
+	}
+	return
+}
+
 // FetchImage fetches image content from the remote repository.
 func (c *Client) FetchImage(ctx context.Context, ref string, authConfig *types.AuthConfig, stream *jsonstream.JSONStream) (containerd.Image, error) {
 	wrapperCli, err := c.Get(ctx)

--- a/ctrd/interface.go
+++ b/ctrd/interface.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
 	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // APIClient defines common methods of containerd api client
@@ -79,6 +80,8 @@ type ImageAPIClient interface {
 	ListImages(ctx context.Context, filter ...string) ([]containerd.Image, error)
 	// FetchImage fetchs image content by the given reference.
 	FetchImage(ctx context.Context, ref string, authConfig *types.AuthConfig, stream *jsonstream.JSONStream) (containerd.Image, error)
+	// ResolveImage attempts to resolve the image reference into a name and descriptor.
+	ResolveImage(ctx context.Context, ref string, authConfig *types.AuthConfig) (name string, desc ocispec.Descriptor, err error)
 	// RemoveImage removes the image by the given reference.
 	RemoveImage(ctx context.Context, ref string) error
 	// ImportImage creates a set of images by tarstream.

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -107,8 +107,8 @@ type Config struct {
 	// Default log configuration
 	DefaultLogConfig types.LogConfig `json:"default-log-config,omitempty"`
 
-	// RegistryService
-	RegistryService types.RegistryServiceConfig `json:"registry-service,omitempty" `
+	// RegistryMirrors is a list of registry URLs that act as a mirror for the default registry.
+	RegistryMirrors []string `json:"registry-mirrors,omitempty"`
 
 	// oom_score_adj for the daemon
 	OOMScoreAdjust int `json:"oom-score-adjust,omitempty"`

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -118,33 +118,6 @@ func TestConfigValidate(t *testing.T) {
 	cfg = &Config{
 		DefaultRegistry:   "registry.hub.docker.com",
 		DefaultRegistryNS: "library",
-		RegistryService: types.RegistryServiceConfig{
-			AllowNondistributableArtifactsCIDRs: []string{
-				"::1/128",
-				"127.0.0.0/8",
-			},
-			AllowNondistributableArtifactsHostnames: []string{
-				"registry.internal.corp.example.com:3000",
-				"[2001:db8:a0b:12f0::1]:443",
-			},
-			InsecureRegistryCIDRs: []string{
-				"insecure.hub.docker.com",
-			},
-			IndexConfigs: map[string]types.IndexInfo{
-				"127.0.0.1:5000": {
-					Name: "127.0.0.1:5000",
-					Mirrors: []string{
-						"https://hub-mirror.corp.example.com:5000/",
-					},
-					Secure:   false,
-					Official: false,
-				},
-			},
-			Mirrors: []string{
-				"https://[2001:db8:a0b:12f0::1]/",
-				"https://hub-mirror.corp.example.com:5000/",
-			},
-		},
 	}
 	assert.Equal(nil, cfg.Validate())
 

--- a/daemon/mgr/system.go
+++ b/daemon/mgr/system.go
@@ -167,7 +167,10 @@ func (mgr *SystemManager) Info() (types.SystemInfo, error) {
 		OperatingSystem:    OSName,
 		OSType:             runtime.GOOS,
 		PouchRootDir:       mgr.config.HomeDir,
-		RegistryConfig:     &mgr.config.RegistryService,
+		RegistryConfig: &types.RegistryServiceConfig{
+			InsecureRegistryCIDRs: mgr.config.InsecureRegistries,
+			Mirrors:               mgr.config.RegistryMirrors,
+		},
 		// RuncCommit: ,
 		Runtimes:        mgr.config.Runtimes,
 		SecurityOptions: securityOpts,

--- a/main.go
+++ b/main.go
@@ -140,6 +140,7 @@ func setupFlags(cmd *cobra.Command) {
 
 	// registry
 	flagSet.StringArrayVar(&cfg.InsecureRegistries, "insecure-registries", []string{}, "enable insecure registry")
+	flagSet.StringArrayVar(&cfg.RegistryMirrors, "registry-mirrors", []string{}, "preferred mirror registry list")
 
 	// buildkit
 	flagSet.BoolVar(&cfg.EnableBuilder, "enable-builder", false, "Enable buildkit functionality")


### PR DESCRIPTION
Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

registryMirrors is a list of registry URLs that act as a mirror for the default registry.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

we need a new test framework to inject the deamon config.

### Ⅳ. Describe how to verify it

```bash
# start pouchd with --registry-mirrors parameters
$ pouchd --registry-mirrors fake --registry-mirrors gcr.io

# pull a image without full reference
[root@pouch ~]# pouch pull cri-tools/hostnet-nginx:latest
gcr.io/cri-tools/hostnet-nginx:latest:                                            resolved       |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:d629efc3a5de1fe63bac3d877ed642968add1e795260b71a40802a3e9e3c5371: done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:c59fd35c9fab19f6db27c1aeb7f4d9fb8862c8fd9400104af66bc3e589ed0ee9:    done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:1e4531df184ea4708d9274d9dd8accf7352906c45cff67bdd276b68c87bfdea5:   done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:2a72cbf407d67c7a7a76dd48e432091678e297140dce050ad5eccad918a9f8d6:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:bce480ca577d3e311502bf1cc6192c72e2ec1d7d705ee905e9f1acf8f3c3ab10:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:fd4bd92a13906102906bdfb79dc15c6736f240338576b69b94f6a0078948d1d9:    done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 97.2s
```

### Ⅴ. Special notes for reviews


