### PR TITLE
fix: fix invalid memory limit

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -134,6 +134,9 @@ type Config struct {
 
 	// EnableBuilder enable builder functionality
 	EnableBuilder bool `json:"enable-builder,omitempty"`
+
+	// MachineMemory is the memory limit for a host.
+	MachineMemory uint64 `json:"-"`
 }
 
 // GetCgroupDriver gets cgroup driver used in runc.

--- a/daemon/mgr/container_stats.go
+++ b/daemon/mgr/container_stats.go
@@ -38,6 +38,11 @@ func (mgr *ContainerManager) StreamStats(ctx context.Context, name string, confi
 	wrapContainerStats := func(metricMeta *containerdtypes.Metric, metric *cgroups.Metrics) (*types.ContainerStats, error) {
 		stats := toContainerStats(c, metricMeta, metric)
 
+		// if the container does not set memory limit, use the machineMemory
+		if stats.MemoryStats.Limit > mgr.Config.MachineMemory && mgr.Config.MachineMemory > 0 {
+			stats.MemoryStats.Limit = mgr.Config.MachineMemory
+		}
+
 		systemCPUUsage, err := getSystemCPUUsage()
 		if err != nil {
 			return nil, err

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alibaba/pouch/lxcfs"
 	"github.com/alibaba/pouch/pkg/debug"
 	"github.com/alibaba/pouch/pkg/kernel"
+	"github.com/alibaba/pouch/pkg/system"
 	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/storage/quota"
 	"github.com/alibaba/pouch/version"
@@ -225,6 +226,10 @@ func runDaemon(cmd *cobra.Command) error {
 
 	if err := checkLxcfsCfg(); err != nil {
 		return err
+	}
+
+	if cfg.MachineMemory, err = system.GetTotalMem(); err != nil {
+		logrus.Warnf("failed to get system mem: %v", err)
 	}
 
 	// initialize signal and handle method.


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Fix a bug about invalid memory limit.
Here are the outputs of these two stats commands. For pouch, the memory limit is very high, we must constrain this value max to machine memory.
``` bash 
pouch stats 511d
CONTAINER ID   NAME     CPU %   MEM %   MEM USAGE / LIMIT   NET I/O       BLOCK I/O   PIDS
511d54d8e9ac   511d54   0.09%   0.00%   2.285MiB / 8EiB     51.5kB / 0B   0B / 0B     4
```

``` bash
docker stats ec57
CONTAINER ID        NAME                CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
ec57be63b4a7        eager_stonebraker   0.10%               2.199MiB / 7.682GiB   0.03%               41.3kB / 0B         0B / 0B             4

```

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
No

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Currently no.


### Ⅳ. Describe how to verify it
`pouch stats [container]`

### Ⅴ. Special notes for reviews


