### PR TITLE
feature: add kernel info to EngineVersion metric

### DIFF
--- a/apis/metrics/metrics.go
+++ b/apis/metrics/metrics.go
@@ -38,7 +38,7 @@ var (
 	ImageActionsTimer = metrics.NewLabelTimer(subsystemPouch, "image_actions", "The number of seconds it takes to process each image action", "action")
 
 	// EngineVersion records the version and commit information of the engine process.
-	EngineVersion = metrics.NewLabelGauge(subsystemPouch, "engine", "The version and commit information of the engine process", "commit")
+	EngineVersion = metrics.NewLabelGauge(subsystemPouch, "engine", "The version and commit information of the engine process", "commit", "version", "kernel")
 )
 
 var registerMetrics sync.Once

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alibaba/pouch/daemon/config"
 	"github.com/alibaba/pouch/lxcfs"
 	"github.com/alibaba/pouch/pkg/debug"
+	"github.com/alibaba/pouch/pkg/kernel"
 	"github.com/alibaba/pouch/pkg/utils"
 	"github.com/alibaba/pouch/storage/quota"
 	"github.com/alibaba/pouch/version"
@@ -167,7 +168,15 @@ func runDaemon(cmd *cobra.Command) error {
 		fmt.Printf("pouchd version: %s, build: %s, build at: %s\n", version.Version, version.GitCommit, version.BuildTime)
 		return nil
 	}
-	metrics.EngineVersion.WithLabelValues(version.GitCommit).Set(1)
+
+	kernelVersion, err := kernel.GetKernelVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get kernel version: %s", err)
+	}
+	metrics.EngineVersion.WithLabelValues(
+		version.GitCommit,
+		version.Version,
+		kernelVersion.String()).Set(1)
 	// initialize log.
 	initLog()
 

--- a/test/api_system_metrics_test.go
+++ b/test/api_system_metrics_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"regexp"
+
+	"github.com/alibaba/pouch/pkg/kernel"
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/version"
+
+	"github.com/go-check/check"
+)
+
+// APIEngineVersionMetricsSuite is the test suite for EngineVersion metrics API.
+type APIEngineVersionMetricsSuite struct{}
+
+func init() {
+	check.Suite(&APIEngineVersionMetricsSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each suite.
+func (suite *APIEngineVersionMetricsSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+}
+
+// TestEngineVersionMetrics tests metrics of EngineVersion.
+func (suite *APIEngineVersionMetricsSuite) TestEngineVersionMetrics(c *check.C) {
+	commitExpected := version.GitCommit
+	versionExpected := version.Version
+	kernelVersion, err := kernel.GetKernelVersion()
+	c.Assert(err, check.IsNil)
+	kernelExpected := kernelVersion.String()
+
+	key := "engine_daemon_engine_info{"
+	versionMetrics := GetMetricLine(c, key)
+
+	regularCommit := `^.*commit="(.*?)".*$`
+	regular := regexp.MustCompile(regularCommit)
+	params := regular.FindStringSubmatch(versionMetrics)
+	c.Assert(params[1], check.Equals, commitExpected)
+
+	regularVersion := `^.*version="(.*?)".*$`
+	regular = regexp.MustCompile(regularVersion)
+	params = regular.FindStringSubmatch(versionMetrics)
+	c.Assert(params[1], check.Equals, versionExpected)
+
+	regularKernel := `^.*kernel="(.*?)".*$`
+	regular = regexp.MustCompile(regularKernel)
+	params = regular.FindStringSubmatch(versionMetrics)
+	c.Assert(params[1], check.Equals, kernelExpected)
+
+}

--- a/test/util_api.go
+++ b/test/util_api.go
@@ -345,3 +345,18 @@ func GetMetric(c *check.C, key string, keySuccess string) (int, int) {
 
 	return iCount, iCountSuccess
 }
+
+// GetMetricLine get metrics from prometheus server, return the single metric.
+func GetMetricLine(c *check.C, key string) string {
+	resp, err := request.Get("/metrics")
+	c.Assert(err, check.IsNil)
+	defer resp.Body.Close()
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, key) {
+			return line
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
add kernel info to EngineVersion metric

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2881 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added


### Ⅳ. Describe how to verify it
`$ pouchd -l tcp://0.0.0.0:4243`
`
$ curl http://127.0.0.1:4243/metrics
`

### Ⅴ. Special notes for reviews


