### PR TITLE
fix: copy cmd support copy from networkMounts

### DIFF
--- a/test/cli_container_cp_test.go
+++ b/test/cli_container_cp_test.go
@@ -132,3 +132,21 @@ func (suite *PouchContainerCopySuite) TestStopContainerCopy(c *check.C) {
 	// test stopped container can start after cp
 	command.PouchRun("start", name).Assert(c, icmd.Success)
 }
+
+// TestCopyHosts tests copy /etc/hosts from container can work well
+func (suite *PouchContainerCopySuite) TestCopyHosts(c *check.C) {
+	testDataPath := "testdata/cp/test-copy-container-hosts"
+	c.Assert(os.MkdirAll(testDataPath, 0755), check.IsNil)
+	defer os.RemoveAll(testDataPath)
+
+	name := "TestCopyHosts"
+	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+
+	localTestPath := fmt.Sprintf("%s/%s", testDataPath, "TestCopyHosts.txt")
+	containerTestPath := fmt.Sprintf("%s:%s", name, "/etc/hosts")
+	command.PouchRun("cp", containerTestPath, localTestPath).Assert(c, icmd.Success)
+	res := command.PouchRun("exec", name, "cat", "/etc/hosts")
+	res.Assert(c, icmd.Success)
+	checkFileContains(c, localTestPath, res.Combined())
+}


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
current impl doesn't support copy /etc/hosts or /etc/hostname from container, this pr fix it.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added.

### Ⅳ. Describe how to verify it
wait for CI

### Ⅴ. Special notes for reviews
None.

