### PR TITLE
feature: add network prune command

### DIFF
--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -89,6 +89,7 @@ func initRoute(s *Server) *mux.Router {
 		{Method: http.MethodDelete, Path: "/networks/{id:.*}", HandlerFunc: s.deleteNetwork},
 		{Method: http.MethodPost, Path: "/networks/{id:.*}/connect", HandlerFunc: s.connectToNetwork},
 		{Method: http.MethodPost, Path: "/networks/{id:.*}/disconnect", HandlerFunc: s.disconnectNetwork},
+		{Method: http.MethodPost, Path: "/networks/prune", HandlerFunc: s.pruneNetwork},
 
 		// metrics
 		{Method: http.MethodGet, Path: "/metrics", HandlerFunc: s.metrics},

--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -1498,6 +1498,30 @@ paths:
             $ref: "#/definitions/NetworkDisconnect"
       tags: ["Network"]
 
+  /networks/prune:
+    post:
+      summary: "Delete unused networks"
+      produces:
+        - "application/json"
+      operationId: "NetworkPrune"
+      responses:
+        200:
+          description: "No error"
+          schema:
+            type: "object"
+            title: "NetworkPruneResp"
+            properties:
+              NetworksDeleted:
+                description: "Networks that were deleted"
+                type: "array"
+                items:
+                  type: "string"
+        500:
+          description: "Server error"
+          schema:
+            $ref: "#/responses/500ErrorResponse"
+      tags: ["Network"]
+
   /commit:
     post:
       summary: "Create an image from a container"

--- a/client/interface.go
+++ b/client/interface.go
@@ -91,4 +91,5 @@ type NetworkAPIClient interface {
 	NetworkList(ctx context.Context) ([]types.NetworkResource, error)
 	NetworkConnect(ctx context.Context, network string, req *types.NetworkConnect) error
 	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
+	NetworkPrune(ctx context.Context) ([]string, error)
 }

--- a/client/network_prune.go
+++ b/client/network_prune.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"context"
+	"net/url"
+)
+
+// NetworkPrune delete unused networks.
+func (client *APIClient) NetworkPrune(ctx context.Context) ([]string, error) {
+	resp, err := client.post(ctx, "/networks/prune", url.Values{}, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []string{}
+	err = decodeBody(&result, resp.Body)
+	ensureCloseReader(resp)
+
+	return result, err
+}

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworkPruneError(t *testing.T) {
+	client := &APIClient{
+		HTTPCli: newMockClient(errorMockResponse(http.StatusInternalServerError, "Server error")),
+	}
+
+	_, err := client.NetworkPrune(context.Background())
+
+	if err == nil || err.Error() == "Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestNetworkPruneList(t *testing.T) {
+	expectedURL := "/networks/prune"
+
+	httpClient := newMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+
+		networksPruneJSON := []string{
+			"network0",
+			"network1",
+			"network2",
+		}
+
+		b, err := json.Marshal(networksPruneJSON)
+		if err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(b))),
+		}, nil
+	})
+
+	client := &APIClient{
+		HTTPCli: httpClient,
+	}
+	networkPruneResp, err := client.NetworkPrune(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(networkPruneResp) != 3 {
+		t.Fatalf("expected 3 networks, got %v", networkPruneResp)
+	}
+	assert.Equal(t, networkPruneResp[0], "network0")
+	assert.Equal(t, networkPruneResp[1], "network1")
+	assert.Equal(t, networkPruneResp[2], "network2")
+}

--- a/test/api_network_prune_test.go
+++ b/test/api_network_prune_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+	"github.com/alibaba/pouch/test/request"
+
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// APINetworkPruneSuite is the test suite for network prune API.
+type APINetworkPruneSuite struct{}
+
+func init() {
+	check.Suite(&APINetworkPruneSuite{})
+}
+
+// SetUpTest does common setup in the beginning of each test.
+func (suite *APINetworkPruneSuite) SetUpTest(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+}
+
+// TestNetworkPruneOk test if prune network is ok
+func (suite *APINetworkPruneSuite) TestNetworkPruneOk(c *check.C) {
+	network1 := "TestPruneNetwork1"
+	command.PouchRun("network", "create", network1, "-d", "bridge", "--gateway", "192.168.1.1", "--subnet", "192.168.1.0/24").Assert(c, icmd.Success)
+
+	network2 := "TestPruneNetwork2"
+	command.PouchRun("network", "create", network2, "-d", "bridge", "--gateway", "192.168.2.1", "--subnet", "192.168.2.0/24").Assert(c, icmd.Success)
+
+	// prune the network.
+	path := "/networks/prune"
+	resp, err := request.Post(path)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 200)
+
+	var networkPruneResp []string
+	err = request.DecodeBody(&networkPruneResp, resp.Body)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(networkPruneResp), check.Equals, 2)
+}


### PR DESCRIPTION
Signed-off-by: Junjun Li <junjunli666@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

add `pouch network prune` command

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix #2213

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

finish it

### Ⅳ. Describe how to verify it

```
$ pouch network prune
WARNING! This will remove all networks not used by at least one container.
Are you sure you want to continue? [y/N]
Deleted Networks:
n1
n2
```
### Ⅴ. Special notes for reviews


