### PR TITLE
fix: pull should return 404 when image not exists

### DIFF
--- a/ctrd/interface.go
+++ b/ctrd/interface.go
@@ -13,8 +13,10 @@ import (
 	containerdtypes "github.com/containerd/containerd/api/types"
 	ctrdmetaimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/snapshots"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 )
 
 // APIClient defines common methods of containerd api client
@@ -77,8 +79,10 @@ type ImageAPIClient interface {
 	GetImage(ctx context.Context, ref string) (containerd.Image, error)
 	// ListImages returns the list of containerd.Image filtered by the given conditions.
 	ListImages(ctx context.Context, filter ...string) ([]containerd.Image, error)
-	// FetchImage fetchs image content by the given reference.
-	FetchImage(ctx context.Context, name string, refs []string, authConfig *types.AuthConfig, stream *jsonstream.JSONStream) (containerd.Image, error)
+	// FetchImage fetches image content by the given reference.
+	FetchImage(ctx context.Context, resolver remotes.Resolver, ref string, authConfig *types.AuthConfig, stream *jsonstream.JSONStream) (containerd.Image, error)
+	// ResolveImage attempts to resolve the image reference into a available reference and resolver.
+	ResolveImage(ctx context.Context, nameRef string, refs []string, authConfig *types.AuthConfig, opts docker.ResolverOptions) (remotes.Resolver, string, error)
 	// RemoveImage removes the image by the given reference.
 	RemoveImage(ctx context.Context, ref string) error
 	// ImportImage creates a set of images by tarstream.

--- a/ctrd/utils.go
+++ b/ctrd/utils.go
@@ -3,7 +3,6 @@ package ctrd
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -166,7 +165,8 @@ func (c *Client) getResolver(ctx context.Context, authConfig *types.AuthConfig, 
 	}
 
 	if availableRef == "" {
-		return nil, "", fmt.Errorf("there is no available image reference after trying %+q", refs)
+		logrus.Warnf("there is no available image reference after trying %+q", refs)
+		return nil, "", errtypes.ErrNotfound
 	}
 
 	refToName := map[string]string{

--- a/test/api_image_create_test.go
+++ b/test/api_image_create_test.go
@@ -47,6 +47,19 @@ func (suite *APIImageCreateSuite) TestImageCreateNil(c *check.C) {
 	CheckRespStatus(c, resp, 400)
 }
 
+// TestImageCreateNonExistentImage tests pulling a non-existent image.
+func (suite *APIImageCreateSuite) TestImageCreateNonExistentImage(c *check.C) {
+	q := url.Values{}
+	image := "qwefghjm:zxcvbn_efgh_nonexist"
+
+	q.Add("fromImage", image)
+	query := request.WithQuery(q)
+
+	resp, err := request.Post("/images/create", query)
+	c.Assert(err, check.IsNil)
+	CheckRespStatus(c, resp, 404)
+}
+
 // TestImageCreateWithoutTag tests creating an image without tag, will use "latest" by default.
 func (suite *APIImageCreateSuite) TestImageCreateWithoutTag(c *check.C) {
 	q := url.Values{}

--- a/test/z_cli_daemon_test.go
+++ b/test/z_cli_daemon_test.go
@@ -367,14 +367,14 @@ func (suite *PouchDaemonSuite) TestDaemonLabelNeg(c *check.C) {
 func (suite *PouchDaemonSuite) TestDaemonDefaultRegistry(c *check.C) {
 	dcfg, err := StartDefaultDaemonDebug(
 		"--default-registry",
-		"reg.docker.alibaba-inc.com",
+		"registry.hub.docker.com",
 		"--default-registry-namespace",
-		"base")
+		"library")
 	c.Assert(err, check.IsNil)
 
 	// Check pull image with default registry using the registry specified in daemon.
-	result := RunWithSpecifiedDaemon(dcfg, "pull", "hello-world")
-	err = util.PartialEqual(result.Combined(), "reg.docker.alibaba-inc.com/base/hello-world")
+	result := RunWithSpecifiedDaemon(dcfg, "pull", "nginx:latest")
+	err = util.PartialEqual(result.Combined(), "registry.hub.docker.com/library/nginx:latest")
 	c.Assert(err, check.IsNil)
 
 	defer dcfg.KillDaemon()


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
fix bugs in #2913, when error happens, we should not write anything to Writer, if you write anything, then we will get resp code 200.
In this pr, add a `resolveImage` interface to check the ref is exists or not, if not, will return err.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix bugs in #2913

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
takes on #2913 


### Ⅳ. Describe how to verify it
wait for CI

### Ⅴ. Special notes for reviews
when image pull No.5 layer error,  the error msg still in json stream, this pr doesn't handle this case.

