### PR TITLE
feature: stat snapshot before fetch

### DIFF
--- a/ctrd/image.go
+++ b/ctrd/image.go
@@ -2,6 +2,7 @@ package ctrd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,11 +14,16 @@ import (
 	"github.com/alibaba/pouch/pkg/reference"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	ctrdmetaimages "github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/remotes/docker/schema1"
+	"github.com/containerd/containerd/snapshots"
 	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -169,14 +175,14 @@ func (c *Client) importImage(ctx context.Context, reader io.Reader, opts ...cont
 	}
 
 	var (
-		res        = make([]containerd.Image, 0, len(imgs))
-		snaphotter = CurrentSnapshotterName(ctx)
+		res         = make([]containerd.Image, 0, len(imgs))
+		snapshotter = CurrentSnapshotterName(ctx)
 	)
 
 	for _, img := range imgs {
 		image := containerd.NewImage(wrapperCli.client, img)
 
-		err = image.Unpack(ctx, snaphotter)
+		err = image.Unpack(ctx, snapshotter)
 		if err != nil {
 			return nil, err
 		}
@@ -251,12 +257,19 @@ func (c *Client) PushImage(ctx context.Context, ref string, authConfig *types.Au
 	return nil
 }
 
-// FetchImage fetches image content from the remote repository.
-func (c *Client) FetchImage(ctx context.Context, name string, refs []string, authConfig *types.AuthConfig, stream *jsonstream.JSONStream) (containerd.Image, error) {
+// PullImage fetches image content from the remote repository, and then unpacks into snapshotter
+func (c *Client) PullImage(ctx context.Context, name string, refs []string, authConfig *types.AuthConfig, stream *jsonstream.JSONStream) (containerd.Image, error) {
 	wrapperCli, err := c.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get a containerd grpc client: %v", err)
 	}
+
+	// NOTE: make sure that gc scheduler doesn't remove content/snapshot during pull
+	ctx, done, err := wrapperCli.client.WithLease(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create lease for commit")
+	}
+	defer done(ctx)
 
 	resolver, availableRef, err := c.getResolver(ctx, authConfig, name, refs, docker.ResolverOptions{})
 	if err != nil {
@@ -307,16 +320,239 @@ func (c *Client) FetchImage(ctx context.Context, name string, refs []string, aut
 	}
 
 	logrus.Infof("success to fetch image: %s", img.Name())
+
+	// before image unpack, call WithImageUnpack
+	ctx = WithImageUnpack(ctx)
+
+	// unpack image
+	if err = img.Unpack(ctx, CurrentSnapshotterName(ctx)); err != nil {
+		return nil, err
+	}
+
 	return img, nil
 }
 
 func (c *Client) fetchImage(ctx context.Context, wrapperCli *WrapperClient, ref string, options []containerd.RemoteOpt) (containerd.Image, error) {
-	img, err := wrapperCli.client.Pull(ctx, ref, options...)
+	ctrdClient := wrapperCli.client
+	pullCtx := &containerd.RemoteContext{}
+	for _, o := range options {
+		if err := o(ctrdClient, pullCtx); err != nil {
+			return nil, err
+		}
+	}
+	// use the default platform
+	pullCtx.PlatformMatcher = platforms.Default()
+
+	ctx, done, err := ctrdClient.WithLease(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to pull image")
+		return nil, err
+	}
+	defer done(ctx)
+
+	store := ctrdClient.ContentStore()
+	name, desc, err := pullCtx.Resolver.Resolve(ctx, ref)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve reference %q", ref)
 	}
 
-	return img, nil
+	fetcher, err := pullCtx.Resolver.Fetcher(ctx, name)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get fetcher for %q", name)
+	}
+
+	var (
+		handler ctrdmetaimages.Handler
+
+		isConvertible bool
+		converterFunc func(context.Context, ocispec.Descriptor) (ocispec.Descriptor, error)
+	)
+
+	if desc.MediaType == ctrdmetaimages.MediaTypeDockerSchema1Manifest && pullCtx.ConvertSchema1 {
+		schema1Converter := schema1.NewConverter(store, fetcher)
+
+		handler = ctrdmetaimages.Handlers(append(pullCtx.BaseHandlers, schema1Converter)...)
+
+		isConvertible = true
+
+		converterFunc = func(ctx context.Context, _ ocispec.Descriptor) (ocispec.Descriptor, error) {
+			return schema1Converter.Convert(ctx)
+		}
+	} else {
+		// Get all the children for a descriptor
+		childrenHandler := ChildrenHandler(store, ctrdClient.SnapshotService(CurrentSnapshotterName(ctx)))
+		// Set any children labels for that content
+		childrenHandler = SetChildrenLabels(store, childrenHandler)
+		// Filter children by platforms
+		childrenHandler = ctrdmetaimages.FilterPlatforms(childrenHandler, pullCtx.PlatformMatcher)
+		// Sort and limit manifests if a finite number is needed
+		childrenHandler = ctrdmetaimages.LimitManifests(childrenHandler, pullCtx.PlatformMatcher, 1)
+
+		// set isConvertible to true if there is application/octet-stream media type
+		convertibleHandler := ctrdmetaimages.HandlerFunc(
+			func(_ context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+				if desc.MediaType == docker.LegacyConfigMediaType {
+					isConvertible = true
+				}
+
+				return []ocispec.Descriptor{}, nil
+			},
+		)
+
+		handler = ctrdmetaimages.Handlers(append(pullCtx.BaseHandlers,
+			remotes.FetchHandler(store, fetcher),
+			convertibleHandler,
+			childrenHandler,
+		)...)
+
+		converterFunc = func(ctx context.Context, desc ocispec.Descriptor) (ocispec.Descriptor, error) {
+			return docker.ConvertManifest(ctx, store, desc)
+		}
+	}
+
+	if err := ctrdmetaimages.Dispatch(ctx, handler, desc); err != nil {
+		return nil, err
+	}
+
+	if isConvertible {
+		if desc, err = converterFunc(ctx, desc); err != nil {
+			return nil, err
+		}
+	}
+
+	img := ctrdmetaimages.Image{
+		Name:   name,
+		Target: desc,
+		Labels: pullCtx.Labels,
+	}
+
+	is := ctrdClient.ImageService()
+	for {
+		if created, err := is.Create(ctx, img); err != nil {
+			if !errdefs.IsAlreadyExists(err) {
+				return nil, err
+			}
+
+			updated, err := is.Update(ctx, img)
+			if err != nil {
+				// if image was removed, try create again
+				if errdefs.IsNotFound(err) {
+					continue
+				}
+				return nil, err
+			}
+
+			img = updated
+		} else {
+			img = created
+		}
+
+		i := containerd.NewImageWithPlatform(ctrdClient, img, pullCtx.PlatformMatcher)
+		return i, nil
+	}
+}
+
+// ChildrenHandler returns the immediate children of content described by the descriptor.
+func ChildrenHandler(provider content.Provider, sn snapshots.Snapshotter) ctrdmetaimages.HandlerFunc {
+	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		var descs []ocispec.Descriptor
+		switch desc.MediaType {
+		case ctrdmetaimages.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+			p, err := content.ReadBlob(ctx, provider, desc)
+			if err != nil {
+				return nil, err
+			}
+
+			// TODO(stevvooe): We just assume oci manifest, for now. There may be
+			// subtle differences from the docker version.
+			var manifest ocispec.Manifest
+			if err := json.Unmarshal(p, &manifest); err != nil {
+				return nil, err
+			}
+
+			descs = append(descs, manifest.Config)
+
+			// if a snapshoot is already ok, then not fetch the tar
+			var (
+				chain []digest.Digest
+				i     = 0
+			)
+			for _, layer := range manifest.Layers {
+				chainID := identity.ChainID(append(chain, layer.Digest)).String()
+				if _, err := sn.Stat(ctx, chainID); err != nil {
+					if !errdefs.IsNotFound(err) {
+						return nil, errors.Wrapf(err, "failed to stat snapshot %s", chainID)
+					}
+					break
+				}
+				i++
+				chain = append(chain, layer.Digest)
+			}
+
+			descs = append(descs, manifest.Layers[i:]...)
+		case ctrdmetaimages.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+			p, err := content.ReadBlob(ctx, provider, desc)
+			if err != nil {
+				return nil, err
+			}
+
+			var index ocispec.Index
+			if err := json.Unmarshal(p, &index); err != nil {
+				return nil, err
+			}
+
+			descs = append(descs, index.Manifests...)
+		case ctrdmetaimages.MediaTypeDockerSchema2Layer, ctrdmetaimages.MediaTypeDockerSchema2LayerGzip,
+			ctrdmetaimages.MediaTypeDockerSchema2LayerForeign, ctrdmetaimages.MediaTypeDockerSchema2LayerForeignGzip,
+			ctrdmetaimages.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig,
+			ocispec.MediaTypeImageLayer, ocispec.MediaTypeImageLayerGzip,
+			ocispec.MediaTypeImageLayerNonDistributable, ocispec.MediaTypeImageLayerNonDistributableGzip,
+			ctrdmetaimages.MediaTypeContainerd1Checkpoint, ctrdmetaimages.MediaTypeContainerd1CheckpointConfig:
+			// childless data types.
+			return nil, nil
+		default:
+			logrus.Warnf("encountered unknown type %v; children may not be fetched", desc.MediaType)
+		}
+
+		return descs, nil
+	}
+}
+
+// SetChildrenLabels is a handler wrapper which sets labels for the content on
+// the children returned by the handler and passes through the children.
+// Must follow a handler that returns the children to be labeled.
+func SetChildrenLabels(manager content.Manager, f ctrdmetaimages.HandlerFunc) ctrdmetaimages.HandlerFunc {
+	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		children, err := f(ctx, desc)
+		if err != nil {
+			return children, err
+		}
+
+		if len(children) > 0 {
+			info := content.Info{
+				Digest: desc.Digest,
+				Labels: map[string]string{},
+			}
+			fields := []string{}
+			for i, ch := range children {
+				// only store config and manifest
+				if ch.MediaType != ctrdmetaimages.MediaTypeDockerSchema2Config &&
+					ch.MediaType != ocispec.MediaTypeImageConfig &&
+					ch.MediaType != ctrdmetaimages.MediaTypeDockerSchema2Manifest &&
+					ch.MediaType != ocispec.MediaTypeImageManifest {
+					continue
+				}
+				info.Labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = ch.Digest.String()
+				fields = append(fields, fmt.Sprintf("labels.containerd.io/gc.ref.content.%d", i))
+			}
+
+			_, err := manager.Update(ctx, info, fields...)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return children, err
+	}
 }
 
 // FIXME(fuwei): put the fetchProgress into jsonstream and make it readable.

--- a/ctrd/interface.go
+++ b/ctrd/interface.go
@@ -77,8 +77,8 @@ type ImageAPIClient interface {
 	GetImage(ctx context.Context, ref string) (containerd.Image, error)
 	// ListImages returns the list of containerd.Image filtered by the given conditions.
 	ListImages(ctx context.Context, filter ...string) ([]containerd.Image, error)
-	// FetchImage fetchs image content by the given reference.
-	FetchImage(ctx context.Context, name string, refs []string, authConfig *types.AuthConfig, stream *jsonstream.JSONStream) (containerd.Image, error)
+	// PullImage fetches image content from the remote repository, and then unpacks into snapshotter
+	PullImage(ctx context.Context, name string, refs []string, authConfig *types.AuthConfig, stream *jsonstream.JSONStream) (containerd.Image, error)
 	// RemoveImage removes the image by the given reference.
 	RemoveImage(ctx context.Context, ref string) error
 	// ImportImage creates a set of images by tarstream.

--- a/daemon/mgr/image.go
+++ b/daemon/mgr/image.go
@@ -217,17 +217,8 @@ func (mgr *ImageManager) PullImage(ctx context.Context, ref string, authConfig *
 	fullRefs := mgr.LookupImageReferences(ref)
 	namedRef = reference.TrimTagForDigest(reference.WithDefaultTagIfMissing(namedRef))
 
-	img, err := mgr.client.FetchImage(pctx, namedRef.String(), fullRefs, authConfig, stream)
+	img, err := mgr.client.PullImage(pctx, namedRef.String(), fullRefs, authConfig, stream)
 	if err != nil {
-		writeStream(err)
-		return err
-	}
-
-	// before image unpack, call WithImageUnpack
-	ctx = ctrd.WithImageUnpack(ctx)
-
-	// unpack image
-	if err = img.Unpack(ctx, ctrd.CurrentSnapshotterName(ctx)); err != nil {
 		writeStream(err)
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
add a doc to describe this feature https://www.yuque.com/zhangyue-jlgo3/kb/epa5ml

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
using current test case.


### Ⅳ. Describe how to verify it
```
 ~/go/src/github.com/alibaba/pouch$ sudo pouch pull hello-world
hello-world:latest:                                                               resolved       |++++++++++++++++++++++++++++++++++++++| 
index-sha256:41a65640635299bab090f783209c1e3a3f11934cf7756b09cb2f1e02147c6ed8:    done           |++++++++++++++++++++++++++++++++++++++| 
manifest-sha256:92c7f9c92844bbbb5d0a101b22f7c2a7949e40f8ea90c8b3bc396879d95e899a: done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:1b930d010525941c1d56ec53b97bd057a67ae1865eebf042686d2a2d18271ced:    done           |++++++++++++++++++++++++++++++++++++++| 
config-sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e:   done           |++++++++++++++++++++++++++++++++++++++| 
elapsed: 2.1 s 

sudo ctr -a /var/run/containerd.sock content ls | grep 1b930d010525941c1d56ec53b97bd057a67ae1865eebf042686d2a2d18271ced
sha256:1b930d010525941c1d56ec53b97bd057a67ae1865eebf042686d2a2d18271ced	977 B	2 minutes	containerd.io/uncompressed=sha256:af0b15c8625bb1938f1d7b17081031f649fd14e6b233688eea3c5483994a66a3
```                                    
hello-world only has one layer, and we can see that the layer don't any any fc ref point to it, so it will be deleted by containerd gc.

and other content keep original
```
sudo ctr -a /var/run/containerd.sock content ls
DIGEST									SIZE	AGE		LABELS
sha256:1b930d010525941c1d56ec53b97bd057a67ae1865eebf042686d2a2d18271ced	977 B	2 seconds	containerd.io/uncompressed=sha256:af0b15c8625bb1938f1d7b17081031f649fd14e6b233688eea3c5483994a66a3
sha256:41a65640635299bab090f783209c1e3a3f11934cf7756b09cb2f1e02147c6ed8	2.13 kB	3 seconds	containerd.io/gc.ref.content.0=sha256:92c7f9c92844bbbb5d0a101b22f7c2a7949e40f8ea90c8b3bc396879d95e899a,containerd.io/gc.ref.content.2=sha256:d1fd2e204af0a2bca3ab033b417b29c76d7950ed29a44e427d1c4d07d14f04f9,containerd.io/gc.ref.content.4=sha256:5a4bdadd9acd8779ed6fcf007a4e7ed7f919056a92c3c67824b4fded06ef0a6e,containerd.io/gc.ref.content.6=sha256:577ad4331d4fac91807308da99ecc107dcc6b2254bc4c7166325fd01113bea2a,containerd.io/gc.ref.content.8=sha256:26cbbd7458900f0d0e7bf460a08ebcb79c185b4a6c7a2c5eb45ea688cd7140c2,containerd.io/gc.ref.content.7=sha256:b0735fcb32a0e9f647c8758bfce2bf8b0e71a097549c7d3945d9ad978fd0dfec,containerd.io/gc.ref.content.1=sha256:1e44d8bca6fb0464794555e5ccd3a32e2a4f6e44a20605e4e82605189904f44d,containerd.io/gc.ref.content.3=sha256:d0d4c5389b53875b0f2364f94c466f77cf6f02811fb02f0477b97d609fb50568,containerd.io/gc.ref.content.5=sha256:12cf9ef90835465316cb0b3729c36bfd8654d7f2f697e23432fddfaa7d7e31b5
sha256:92c7f9c92844bbbb5d0a101b22f7c2a7949e40f8ea90c8b3bc396879d95e899a	524 B	3 seconds	containerd.io/gc.ref.content.0=sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e
sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e	1.51 kB	3 seconds	containerd.io/gc.ref.snapshot.overlayfs=sha256:af0b15c8625bb1938f1d7b17081031f649fd14e6b233688eea3c5483994a66a3
```

### Ⅴ. Special notes for reviews
when manifest is in schema 1 (application/vnd.docker.distribution.manifest.v1+prettyjws), this feature is not enable now. 

