### PR TITLE
feature: cli support --add-host

### DIFF
--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -72,6 +72,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringVar(&c.ip, "ip", "", "Set IPv4 address of container endpoint")
 	flagSet.StringVar(&c.ipv6, "ip6", "", "Set IPv6 address of container endpoint")
 	flagSet.Int64Var(&c.netPriority, "net-priority", 0, "net priority")
+	flagSet.StringArrayVar(&c.extraHosts, "add-host", nil, "Add a custom host-to-IP mapping (host:ip)")
 	// dns
 	flagSet.StringArrayVar(&c.dns, "dns", nil, "Set DNS servers")
 	flagSet.StringSliceVar(&c.dnsOptions, "dns-option", nil, "Set DNS options")

--- a/cli/container.go
+++ b/cli/container.go
@@ -72,6 +72,7 @@ type container struct {
 	ipv6        string
 	macAddress  string
 	netPriority int64
+	extraHosts  []string
 	dns         []string
 	dnsOptions  []string
 	dnsSearch   []string
@@ -268,6 +269,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 				Ulimits:       c.ulimit.Value(),
 				PidsLimit:     c.pidsLimit,
 			},
+			ExtraHosts:      c.extraHosts,
 			DNS:             c.dns,
 			DNSOptions:      c.dnsOptions,
 			DNSSearch:       c.dnsSearch,

--- a/daemon/mgr/network.go
+++ b/daemon/mgr/network.go
@@ -694,7 +694,12 @@ func buildSandboxOptions(config network.Config, endpoint *types.Endpoint) ([]lib
 	}
 
 	// TODO: secondary ip address
-	// TODO: parse extra hosts
+	for _, extraHost := range endpoint.ExtraHosts {
+		// allow IPv6 addresses in extra hosts; only split on first ":"
+		parts := strings.SplitN(extraHost, ":", 2)
+		sandboxOptions = append(sandboxOptions, libnetwork.OptionExtraHost(parts[0], parts[1]))
+	}
+
 	var bindings = make(nat.PortMap)
 	if endpoint.PortBindings != nil {
 		for p, b := range endpoint.PortBindings {

--- a/test/cli_run_network_test.go
+++ b/test/cli_run_network_test.go
@@ -122,3 +122,28 @@ func (suite *PouchRunNetworkSuite) TestRunWithIP(c *check.C) {
 
 	c.Assert(found, check.Equals, true)
 }
+
+// TestRunAddHost is to verify run container with add-host flag
+func (suite *PouchRunNetworkSuite) TestRunAddHost(c *check.C) {
+	name := "TestRunAddHost"
+	res := command.PouchRun("run", "--name", name, "--add-host=extra:86.75.30.9", busyboxImage, "grep", "extra", "/etc/hosts")
+	res.Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+
+	stdout := res.Stdout()
+	actual := strings.Trim(stdout, "\r\n")
+	if !strings.Contains(actual, "86.75.30.9\textra") {
+		c.Fatalf("expected '86.75.30.9\textra', but says: %q", actual)
+	}
+}
+
+func (suite *PouchRunNetworkSuite) TestRunAddHostInHostMode(c *check.C) {
+	name := "TestRunAddHostInHostMode"
+	expectedOutput := "1.2.3.4\textra"
+	res := command.PouchRun("run", "--name", name, "--add-host=extra:1.2.3.4", "--net=host", busyboxImage, "cat", "/etc/hosts")
+	res.Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+	if !strings.Contains(res.Stdout(), expectedOutput) {
+		check.Commentf("Expected '%s', but got %q", expectedOutput, res.Stdout())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Lang Chi <21860405@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
feature: cli support --add-host

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Added


### Ⅳ. Describe how to verify it
```
root@compatibility:~# pouch run --add-host=extra:86.75.30.9 busybox grep extra /etc/hosts
86.75.30.9	extra
root@compatibility:~# pouch run --add-host=extra:1.2.3.4 --net=host busybox cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
1.2.3.4	extra
root@compatibility:~# pouch run --net=container:other --add-host=name:8.8.8.8 busybox ps
Error: failed to run container: {"message":"Conflicting options: custom host-to-IP mapping and the network mode"}
```
### Ⅴ. Special notes for reviews


