### PR TITLE
fix: not copy parent dir when path contains dot

### DIFF
--- a/daemon/mgr/container_copy.go
+++ b/daemon/mgr/container_copy.go
@@ -240,8 +240,9 @@ func (c *Container) getResolvedPath(path string, running bool) (resolvedPath, ab
 	}
 
 	// get the real path on the host
-	resolvedPath = filepath.Join(rootfs, absPath)
-	resolvedPath = filepath.Clean(resolvedPath)
+	resolvedPath = rootfs + string(os.PathSeparator) + path
+	cleanedPath := filepath.Clean(resolvedPath)
+	resolvedPath = archive.PreserveTrailingDotOrSeparator(cleanedPath, resolvedPath, os.PathSeparator)
 
 	return resolvedPath, absPath
 }


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
when path contains dot, such as test/. , we should not copy the test dir into dst, we just need to copy the file& dir under test/ into dst.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
added.


### Ⅳ. Describe how to verify it
wait for CI.

### Ⅴ. Special notes for reviews
None.

