### PR TITLE
bugfix: fix update container rootfs disk quota recursively timeout

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1351,7 +1351,7 @@ func (mgr *ContainerManager) updateContainerDiskQuota(ctx context.Context, c *Co
 	}
 
 	// set mount point disk quota
-	if err = mgr.setDiskQuota(ctx, c, false); err != nil {
+	if err = mgr.setDiskQuota(ctx, c, false, true); err != nil {
 		return errors.Wrapf(err, "failed to set mount point disk quota")
 	}
 

--- a/daemon/mgr/container_storage.go
+++ b/daemon/mgr/container_storage.go
@@ -527,7 +527,7 @@ func checkDupQuotaMap(qms []*quota.QMap, qm *quota.QMap) *quota.QMap {
 	return nil
 }
 
-func (mgr *ContainerManager) setDiskQuota(ctx context.Context, c *Container, mounted bool) error {
+func (mgr *ContainerManager) setDiskQuota(ctx context.Context, c *Container, mounted bool, update bool) error {
 	var (
 		err           error
 		globalQuotaID uint32
@@ -629,7 +629,7 @@ func (mgr *ContainerManager) setDiskQuota(ctx context.Context, c *Container, mou
 	for _, qm := range qms {
 		if qm.Destination == "/" {
 			// set rootfs quota
-			_, err = quota.SetRootfsDiskQuota(qm.Source, qm.Size, qm.QuotaID)
+			_, err = quota.SetRootfsDiskQuota(qm.Source, qm.Size, qm.QuotaID, update)
 			if err != nil {
 				logrus.Warnf("failed to set rootfs quota, mountfs(%s), size(%s), quota id(%d), err(%v)",
 					qm.Source, qm.Size, qm.QuotaID, err)
@@ -763,7 +763,7 @@ func (mgr *ContainerManager) initContainerStorage(ctx context.Context, c *Contai
 	}
 
 	// set mount point disk quota
-	if err = mgr.setDiskQuota(ctx, c, true); err != nil {
+	if err = mgr.setDiskQuota(ctx, c, true, false); err != nil {
 		// just ignore failed to set disk quota
 		logrus.Warnf("failed to set disk quota, err(%v)", err)
 	}

--- a/storage/quota/quota.go
+++ b/storage/quota/quota.go
@@ -188,7 +188,7 @@ func GetQuotaID(dir string) (uint32, error) {
 }
 
 // SetRootfsDiskQuota is to set container rootfs dir disk quota.
-func SetRootfsDiskQuota(basefs, size string, quotaID uint32) (uint32, error) {
+func SetRootfsDiskQuota(basefs, size string, quotaID uint32, update bool) (uint32, error) {
 	overlayMountInfo, err := getOverlayMountInfo(basefs)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to get overlay(%s) mount info", basefs)
@@ -211,7 +211,9 @@ func SetRootfsDiskQuota(basefs, size string, quotaID uint32) (uint32, error) {
 			return 0, errors.Wrapf(err, "failed to set dir(%s) disk quota", dir)
 		}
 
-		if err := SetQuotaForDir(dir, quotaID); err != nil {
+		if update {
+			go SetQuotaForDir(dir, quotaID)
+		} else if err := SetQuotaForDir(dir, quotaID); err != nil {
 			return 0, errors.Wrapf(err, "failed to set dir(%s) quota recursively", dir)
 		}
 	}


### PR DESCRIPTION
Updating disk quota to a running container will set quota ID to all files
and directories under UpperDir in function SetQuotaForDir, which will
take a long while. Because it will costs much time in
getMountpointFstype, CheckRegularFile and filepath.Walk.

Call SetQuotaForDir Asynchronously when updating disk quota .

Signed-off-by: Wang Rui <baijia.wr@antfin.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This patch will optimize efficiency of updating disk quota. It may take a long while in function SetQuotaForDir if container has a lot of new files and directories in UpperDir.

So we can change to call SetQuotaForDir in go routine.

### Ⅱ. Does this pull request fix one issue?
NONE


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
step 1.  Run many containers with disk quota so that /proc/mounts has a lot of lines
step 2. Make a running container create many files and directories.
step3.  Before this path,  update disk quota of this container will take a log while. After this path, it will be more efficient.  

### Ⅴ. Special notes for reviews


