### PR TITLE
bugfix: removing image by ID should conflict with running container.

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -136,8 +136,17 @@ func (s *Server) removeImage(ctx context.Context, rw http.ResponseWriter, req *h
 	}(time.Now())
 
 	isForce := httputils.BoolValue(req, "force")
-	// We only should check the image whether used by container when there is only one primary reference.
-	if len(refs) == 1 {
+
+	isImageIDPrefix := func(imageID string, name string) bool {
+		if strings.HasPrefix(imageID, name) || strings.HasPrefix(digest.Digest(imageID).Hex(), name) {
+			return true
+		}
+		return false
+	}
+
+	// We should check the image whether used by container when there is only one primary reference
+	// or the image is removed by image ID.
+	if len(refs) == 1 || isImageIDPrefix(image.ID, name) {
 		containers, err := s.ContainerMgr.List(ctx, &mgr.ContainerListOption{
 			All: true,
 			FilterFunc: func(c *mgr.Container) bool {

--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1351,7 +1351,7 @@ func (mgr *ContainerManager) updateContainerDiskQuota(ctx context.Context, c *Co
 	}
 
 	// set mount point disk quota
-	if err = mgr.setDiskQuota(ctx, c, false); err != nil {
+	if err = mgr.setDiskQuota(ctx, c, false, true); err != nil {
 		return errors.Wrapf(err, "failed to set mount point disk quota")
 	}
 

--- a/daemon/mgr/container_storage.go
+++ b/daemon/mgr/container_storage.go
@@ -527,7 +527,7 @@ func checkDupQuotaMap(qms []*quota.QMap, qm *quota.QMap) *quota.QMap {
 	return nil
 }
 
-func (mgr *ContainerManager) setDiskQuota(ctx context.Context, c *Container, mounted bool) error {
+func (mgr *ContainerManager) setDiskQuota(ctx context.Context, c *Container, mounted bool, update bool) error {
 	var (
 		err           error
 		globalQuotaID uint32
@@ -629,7 +629,7 @@ func (mgr *ContainerManager) setDiskQuota(ctx context.Context, c *Container, mou
 	for _, qm := range qms {
 		if qm.Destination == "/" {
 			// set rootfs quota
-			_, err = quota.SetRootfsDiskQuota(qm.Source, qm.Size, qm.QuotaID)
+			_, err = quota.SetRootfsDiskQuota(qm.Source, qm.Size, qm.QuotaID, update)
 			if err != nil {
 				logrus.Warnf("failed to set rootfs quota, mountfs(%s), size(%s), quota id(%d), err(%v)",
 					qm.Source, qm.Size, qm.QuotaID, err)
@@ -763,7 +763,7 @@ func (mgr *ContainerManager) initContainerStorage(ctx context.Context, c *Contai
 	}
 
 	// set mount point disk quota
-	if err = mgr.setDiskQuota(ctx, c, true); err != nil {
+	if err = mgr.setDiskQuota(ctx, c, true, false); err != nil {
 		// just ignore failed to set disk quota
 		logrus.Warnf("failed to set disk quota, err(%v)", err)
 	}

--- a/storage/quota/quota.go
+++ b/storage/quota/quota.go
@@ -188,7 +188,7 @@ func GetQuotaID(dir string) (uint32, error) {
 }
 
 // SetRootfsDiskQuota is to set container rootfs dir disk quota.
-func SetRootfsDiskQuota(basefs, size string, quotaID uint32) (uint32, error) {
+func SetRootfsDiskQuota(basefs, size string, quotaID uint32, update bool) (uint32, error) {
 	overlayMountInfo, err := getOverlayMountInfo(basefs)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to get overlay(%s) mount info", basefs)
@@ -211,7 +211,9 @@ func SetRootfsDiskQuota(basefs, size string, quotaID uint32) (uint32, error) {
 			return 0, errors.Wrapf(err, "failed to set dir(%s) disk quota", dir)
 		}
 
-		if err := SetQuotaForDir(dir, quotaID); err != nil {
+		if update {
+			go SetQuotaForDir(dir, quotaID)
+		} else if err := SetQuotaForDir(dir, quotaID); err != nil {
 			return 0, errors.Wrapf(err, "failed to set dir(%s) quota recursively", dir)
 		}
 	}

--- a/test/environment/cleanup.go
+++ b/test/environment/cleanup.go
@@ -33,7 +33,7 @@ func PruneAllContainers(apiClient client.ContainerAPIClient) error {
 	ctx := context.Background()
 	containers, err := apiClient.ContainerList(ctx, types.ContainerListOptions{All: true})
 	if err != nil {
-		return errors.Wrap(err, "fail to list images")
+		return errors.Wrap(err, "fail to list containers")
 	}
 
 	for _, ctr := range containers {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
If image is used by a running container and this image has another tag,
there are two reference of this image. Remove the image by ID without
"--force" will success that is unexpected.

This patch will fix it. We should check if any containers using this
image ID. 

### Ⅱ. Does this pull request fix one issue?
 NONE


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
step 1. Pull image  registry.hub.docker.com/library/busybox:1.28 
step 2. Tag this image to  registry.hub.docker.com/library/busybox:tag2
step 3. Run a container with this image
step 4. Pouch rmi <ImageID> without "--force", the image will removed unexpected.

### Ⅴ. Special notes for reviews


