### PR TITLE
bugfix: removing image by ID should conflict with running container.

### DIFF
--- a/apis/server/image_bridge.go
+++ b/apis/server/image_bridge.go
@@ -136,8 +136,17 @@ func (s *Server) removeImage(ctx context.Context, rw http.ResponseWriter, req *h
 	}(time.Now())
 
 	isForce := httputils.BoolValue(req, "force")
-	// We only should check the image whether used by container when there is only one primary reference.
-	if len(refs) == 1 {
+
+	isImageIDPrefix := func(imageID string, name string) bool {
+		if strings.HasPrefix(imageID, name) || strings.HasPrefix(digest.Digest(imageID).Hex(), name) {
+			return true
+		}
+		return false
+	}
+
+	// We should check the image whether used by container when there is only one primary reference
+	// or the image is removed by image ID.
+	if len(refs) == 1 || isImageIDPrefix(image.ID, name) {
 		containers, err := s.ContainerMgr.List(ctx, &mgr.ContainerListOption{
 			All: true,
 			FilterFunc: func(c *mgr.Container) bool {

--- a/test/environment/cleanup.go
+++ b/test/environment/cleanup.go
@@ -33,7 +33,7 @@ func PruneAllContainers(apiClient client.ContainerAPIClient) error {
 	ctx := context.Background()
 	containers, err := apiClient.ContainerList(ctx, types.ContainerListOptions{All: true})
 	if err != nil {
-		return errors.Wrap(err, "fail to list images")
+		return errors.Wrap(err, "fail to list containers")
 	}
 
 	for _, ctr := range containers {


### PR DESCRIPTION
If image is used by a running container and this image has another tag,
there are two reference of this image. Remove the image by ID without
"--force" will success that is unexpected.

This patch will fix it. We should check if any containers using this
image ID. And add tests.

Signed-off-by: Wang Rui <baijia.wr@antfin.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
step 1. Pull image registry.hub.docker.com/library/busybox:1.28
step 2. Tag this image to registry.hub.docker.com/library/busybox:tag2
step 3. Run a container with this image
step 4. Pouch rmi without "--force", the image will removed unexpected.
With this patch, it won't be successful in Step 4.
### Ⅴ. Special notes for reviews


