### PR TITLE
bugfix: create container with invalid name

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -28,7 +29,12 @@ const (
 	CgroupSystemdDriver = "systemd"
 	// DefaultCgroupDriver is default cgroups driver
 	DefaultCgroupDriver = CgroupfsDriver
+	// ValidNameChars collects the characters allowed to represent a name, normally used to validate container and volume names.
+	ValidNameChars = `[a-zA-Z0-9][a-zA-Z0-9_.-]`
 )
+
+// ValidNamePattern is a regular expression to validate names against the collection of restricted characters.
+var ValidNamePattern = regexp.MustCompile(`^/?` + ValidNameChars + `+$`)
 
 // Config refers to daemon's whole configurations.
 type Config struct {

--- a/test/cli_create_log_options_test.go
+++ b/test/cli_create_log_options_test.go
@@ -78,7 +78,7 @@ func (suite *PouchCreateLogOptionsSuite) TestOK(c *check.C) {
 			driver:   "json-file",
 			expected: nil,
 		}, {
-			cname:   "TestCreateLogOptions_jsonfile_tag=1",
+			cname:   "TestCreateLogOptions_jsonfile_tag_1",
 			driver:  "json-file",
 			logOpts: []string{"tag=1"},
 			expected: map[string]string{

--- a/test/cli_create_test.go
+++ b/test/cli_create_test.go
@@ -608,3 +608,13 @@ func (suite *PouchCreateSuite) TestCreateWithoutNvidiaConfig(c *check.C) {
 	}
 	c.Assert(result[0].HostConfig.Resources.NvidiaConfig, check.IsNil)
 }
+
+// TestCreateWithInvalidName tests creating container with invalid name.
+func (suite *PouchRunSuite) TestCreateWithInvalidName(c *check.C) {
+	name := "new:invalid"
+	res := command.PouchRun("create", "--name", name, busyboxImage)
+	defer DelContainerForceMultyTime(c, name)
+	if !strings.Contains(res.Stdout(), "Invalid container name") {
+		check.Commentf("Expected '%s', but got %q", "Invalid container name", res.Stdout())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Lang Chi <21860405@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
bugfix: create contaienr with invalid name

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#2918 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Added.


### Ⅳ. Describe how to verify it
root@compatibility:~/go/src/github.com/alibaba/pouch# pouch create --name new:invalid busybox
Error: failed to create container: {"message":"Invalid container name (new:invalid), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed"}

### Ⅴ. Special notes for reviews


