### PR TITLE
[bugfix] LogOpts doesn't take effect in pouchd config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,9 +151,6 @@ func setupFlags(cmd *cobra.Command) {
 
 // runDaemon prepares configs, setups essential details and runs pouchd daemon.
 func runDaemon(cmd *cobra.Command) error {
-	if err := loadDaemonFile(cfg, cmd.Flags()); err != nil {
-		return fmt.Errorf("failed to load daemon file: %s", err)
-	}
 
 	// parse log driver config
 	logOptMap, err := opts.ParseLogOptions(cfg.DefaultLogConfig.LogDriver, logOpts)
@@ -163,6 +160,10 @@ func runDaemon(cmd *cobra.Command) error {
 
 	if len(logOptMap) > 0 {
 		cfg.DefaultLogConfig.LogOpts = logOptMap
+	}
+
+	if err := loadDaemonFile(cfg, cmd.Flags()); err != nil {
+		return fmt.Errorf("failed to load daemon file: %s", err)
 	}
 
 	//user specifies --version or -v, print version and return.


### PR DESCRIPTION
Configure LogOpts in /etc/pouch/config.json such as:
"default-log-config": {
    "Type": "json-file",
    "Config": {
        "max-file": "5",
        "max-size": "300m"
    }
}
"max-file" and "max-size" are log options for pouchd.
We create a container which will set its log options from pouchd.
However, it doesn't take effect.

This patch will fix it. Config file and cmd flags will be merged.
So we should set LogOpts from cmd flags "--log-opt" before merging.

Signed-off-by: baijia.wr <baijia.wr@antfin.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
We set log options in config file of pouchd(/etc/pouch/config.json) such as
"default-log-config": {
    "Type": "json-file",
    "Config": {
        "max-file": "5",
        "max-size": "300m"
    }
}
It doesn't take effect because cfg.DefaultLogConfig.LogOpts is reset to logOpts which comes from --log-opt in cmd flag.
This patch will fix it.

### Ⅱ. Does this pull request fix one issue?
NONE


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


