### PR TITLE
bug: fix rename a container with invalid name bug

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -1108,6 +1108,10 @@ func (mgr *ContainerManager) Rename(ctx context.Context, oldName, newName string
 		"oldName": oldName,
 	}
 
+	if !daemon_config.ValidNamePattern.MatchString(newName) {
+		return fmt.Errorf("Invalid container name (%s), only %s are allowed", newName, daemon_config.ValidNameChars)
+	}
+
 	name := c.Name
 	c.Name = newName
 

--- a/test/cli_rename_test.go
+++ b/test/cli_rename_test.go
@@ -27,11 +27,11 @@ func (suite *PouchRenameSuite) SetUpSuite(c *check.C) {
 }
 
 func (suite *PouchRenameSuite) TestRenameInvalidName(c *check.C) {
-	name := "myName"
+	name := "TestRenameInvalidName"
 	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
 	defer DelContainerForceMultyTime(c, name)
 
-	res := command.PouchRun("rename", "myName", "new:invalid")
+	res := command.PouchRun("rename", name, "new:invalid")
 	if !strings.Contains(res.Stdout(), "Invalid container name") {
 		check.Commentf("Expected '%s', but got %q", "Invalid container name", res.Stdout())
 	}

--- a/test/cli_rename_test.go
+++ b/test/cli_rename_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/alibaba/pouch/test/command"
+	"github.com/alibaba/pouch/test/environment"
+
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// PouchRenameSuite is the test suite for rename CLI.
+type PouchRenameSuite struct{}
+
+func init() {
+	check.Suite(&PouchRenameSuite{})
+}
+
+// SetUpSuite does common setup in the beginning of each test suite.
+func (suite *PouchRenameSuite) SetUpSuite(c *check.C) {
+	SkipIfFalse(c, environment.IsLinux)
+
+	environment.PruneAllContainers(apiClient)
+
+	PullImage(c, busyboxImage)
+}
+
+func (suite *PouchRenameSuite) TestRenameInvalidName(c *check.C) {
+	name := "myName"
+	command.PouchRun("run", "-d", "--name", name, busyboxImage, "top").Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+
+	res := command.PouchRun("rename", "myName", "new:invalid")
+	if !strings.Contains(res.Stdout(), "Invalid container name") {
+		check.Commentf("Expected '%s', but got %q", "Invalid container name", res.Stdout())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Lang Chi <21860405@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
 fix rename a container with invalid name bug

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Added.


### Ⅳ. Describe how to verify it
```
root@compatibility:~ # pouch run -d --name name1 busybox top
root@compatibility:~ # pouch rename name1 name:new
Error: {"message":"Invalid container name (name:new), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed"}
```

### Ⅴ. Special notes for reviews


