### PR TITLE
create time should in seconds instead of nano seconds

### DIFF
--- a/apis/server/container_bridge.go
+++ b/apis/server/container_bridge.go
@@ -174,7 +174,7 @@ func (s *Server) getContainers(ctx context.Context, rw http.ResponseWriter, req 
 			ImageID:         c.Image,
 			Command:         strings.Join(c.Config.Cmd, " "),
 			Status:          status,
-			Created:         t.UnixNano(),
+			Created:         t.Unix(),
 			Labels:          c.Config.Labels,
 			HostConfig:      c.HostConfig,
 			NetworkSettings: netSettings,

--- a/cli/history.go
+++ b/cli/history.go
@@ -91,7 +91,7 @@ func (h *HistoryCommand) runHistory(args []string) error {
 		}
 
 		if h.flagHuman {
-			created, err = utils.FormatTimeInterval(entry.Created)
+			created, err = utils.FormatTimeInterval(0, entry.Created)
 			if err != nil {
 				return err
 			}

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -93,7 +93,7 @@ func (p *PsCommand) runPs(args []string) error {
 	display.AddRow([]string{"Name", "ID", "Status", "Created", "Image", "Runtime"})
 
 	for _, c := range containers {
-		created, err := utils.FormatTimeInterval(c.Created)
+		created, err := utils.FormatTimeInterval(c.Created, 0)
 		if err != nil {
 			return err
 		}
@@ -160,7 +160,7 @@ func (c containerList) Swap(i, j int) {
 
 // Less implements the sort interface.
 func (c containerList) Less(i, j int) bool {
-	iValue := time.Unix(0, c[i].Created)
-	jValue := time.Unix(0, c[j].Created)
+	iValue := time.Unix(c[i].Created, 0)
+	jValue := time.Unix(c[j].Created, 0)
 	return iValue.After(jValue)
 }

--- a/daemon/mgr/container_types.go
+++ b/daemon/mgr/container_types.go
@@ -388,7 +388,7 @@ func (c *Container) FormatStatus() (string, error) {
 			return "", err
 		}
 
-		startAt, err := utils.FormatTimeInterval(start.UnixNano())
+		startAt, err := utils.FormatTimeInterval(0, start.UnixNano())
 		if err != nil {
 			return "", err
 		}
@@ -404,7 +404,7 @@ func (c *Container) FormatStatus() (string, error) {
 			return "", err
 		}
 
-		finishAt, err := utils.FormatTimeInterval(finish.UnixNano())
+		finishAt, err := utils.FormatTimeInterval(0, finish.UnixNano())
 		if err != nil {
 			return "", err
 		}

--- a/pkg/utils/timeutils.go
+++ b/pkg/utils/timeutils.go
@@ -31,8 +31,8 @@ const (
 var errInvalid = errors.New("invalid time")
 
 // FormatTimeInterval is used to show the time interval from input time to now.
-func FormatTimeInterval(input int64) (formattedTime string, err error) {
-	start := time.Unix(0, input)
+func FormatTimeInterval(sec, nano int64) (formattedTime string, err error) {
+	start := time.Unix(sec, nano)
 	diff := time.Since(start)
 
 	// That should not happen.

--- a/pkg/utils/timeutils_test.go
+++ b/pkg/utils/timeutils_test.go
@@ -96,7 +96,7 @@ func TestFormatTimeInterval(t *testing.T) {
 			err:      errInvalid,
 		},
 	} {
-		output, err := FormatTimeInterval(tc.input)
+		output, err := FormatTimeInterval(0, tc.input)
 		assert.Equal(t, tc.err, err, tc.name)
 		assert.Equal(t, tc.expected, output, tc.name)
 	}


### PR DESCRIPTION
Signed-off-by: frankyang <yyb196@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
when doing container list create time of every container should in seconds, or users who use docker as client to list containers will get the wrong create time. according to https://docs.docker.com/engine/api/v1.24/

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
test cases has been modified


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


