### PR TITLE
bugfix: remove max-size >=2 condition

### DIFF
--- a/daemon/logger/jsonfile/jsonfile.go
+++ b/daemon/logger/jsonfile/jsonfile.go
@@ -131,7 +131,7 @@ func (lf *JSONLogFile) WriteLogMessage(msg *logger.LogMessage) error {
 // checkRotate rotates logs according to maxSize and maxFile parameters
 // TODO: after rotating logs, a notice should be made to the log reader
 func (lf *JSONLogFile) checkRotate() error {
-	if lf.maxSize == 0 || lf.maxFile < 2 || lf.currentSize < lf.maxSize {
+	if lf.maxSize == 0 || lf.currentSize < lf.maxSize {
 		// no need to rotate
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
no need this condition， because we can still do logrotate when max-file = 1

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
NONE


### Ⅳ. Describe how to verify it
step1. launch pouchd with max-size and max-file flags

 `pouchd --log-opt max-size=10k`
step2. run a container which could write stdout to its log

 `pouch run docker.io/library/busybox:latest top`
step3. check container log is rotated


### Ⅴ. Special notes for reviews
none

