### PR TITLE
avoid exec_die filed before exec_start

### DIFF
--- a/daemon/mgr/container_exec.go
+++ b/daemon/mgr/container_exec.go
@@ -157,6 +157,8 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, cfg *
 	}()
 
 	execConfig.Running = true
+	mgr.LogContainerEvent(ctx, c, "exec_start")
+
 	if err := mgr.Client.ExecContainer(ctx, &ctrd.Process{
 		ContainerID: execConfig.ContainerID,
 		ExecID:      execid,
@@ -165,7 +167,6 @@ func (mgr *ContainerManager) StartExec(ctx context.Context, execid string, cfg *
 	}, timeout); err != nil {
 		return err
 	}
-	mgr.LogContainerEvent(ctx, c, "exec_start")
 	return <-attachErrCh
 }
 


### PR DESCRIPTION


Signed-off-by: Wei Fu <fuweid89@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

When the exec command is quick to quit, like echo command, the exec_die
event will show up before exec_start.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

none

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)

no need 

### Ⅳ. Describe how to verify it

CI

### Ⅴ. Special notes for reviews


