### PR TITLE
wait until all the on going requests go to a stable state before shuti…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.txt
 bin/
 coverage/
 test/testdata/cp/*
+.vscode

--- a/apis/server/router.go
+++ b/apis/server/router.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"sync/atomic"
 	"time"
 
 	serverTypes "github.com/alibaba/pouch/apis/server/types"
@@ -176,6 +177,9 @@ func filter(handler serverTypes.Handler, s *Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx, cancel := context.WithCancel(pctx)
 		defer cancel()
+
+		atomic.AddInt32(&s.FlyingReq, 1)
+		defer atomic.AddInt32(&s.FlyingReq, -1)
 
 		s.lock.RLock()
 		if len(s.ManagerWhiteList) > 0 && req.TLS != nil && len(req.TLS.PeerCertificates) > 0 {

--- a/main.go
+++ b/main.go
@@ -247,7 +247,7 @@ func runDaemon(cmd *cobra.Command) error {
 	}
 
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGHUP)
-	sigHandles = append(sigHandles, d.ShutdownPlugin, d.Shutdown)
+	sigHandles = append(sigHandles, d.Shutdown, d.ShutdownPlugin)
 
 	go func() {
 		// FIXME: I think the Run() should always return error.


### PR DESCRIPTION
…ng down daemon

Signed-off-by: shenling.yyb <shenling.yyb@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
We must make http requests finish their job or rollback before shutdown pouch daemon, or we will leave container or other object in unpredictable status. 

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
No, I have test inside our environment.


### Ⅳ. Describe how to verify it
```
StartContainer -> CreateEndpoint -> (shutdown)
```
If we can shutdown daemon at the exact time after CreateEndpoint, it will leave a veth network link on the host before applying this patch.

### Ⅴ. Special notes for reviews


