### PR TITLE
ctrd: fix task unexpected exit

### DIFF
--- a/ctrd/watch.go
+++ b/ctrd/watch.go
@@ -62,7 +62,14 @@ func (w *watch) isContainerdDead() bool {
 // isChannelClosed means containerd break unexpected, all exit channel
 // ctrd watched will exit.
 func isChannelClosed(s containerd.ExitStatus) bool {
-	return s.ExitTime().IsZero() && strings.Contains(s.Error().Error(), "transport is closing")
+	if s.Error() == nil {
+		return false
+	}
+
+	rpcError := strings.Contains(s.Error().Error(), "transport is closing") ||
+		strings.Contains(s.Error().Error(), "rpc error")
+
+	return s.ExitTime().IsZero() && rpcError
 }
 
 func (w *watch) add(ctx context.Context, pack *containerPack) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -223,7 +223,7 @@ func (d *Daemon) Run() error {
 
 	// after initialize network manager, try to recover all
 	// running containers
-	if err := containerMgr.Restore(ctx); err != nil {
+	if err := containerMgr.Restore(context.Background()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
time="2019-11-01T09:54:30.981479019+08:00" level=info msg="the task has
quit, id:
e3954a23946f1415f3ed2f0010024536a119a3645bf4cdc884c04e33b725ae1e, err:
rpc error: code = Canceled desc = context canceled, exitcode: 255, time:
0001-01-01 00:00:00 +0000 UTC"
ContainerID=e3954a23946f1415f3ed2f0010024536a119a3645bf4cdc884c04e33b725ae1e

get task exit message, this caused by grpc server stop first, but pouch
still running, task will got this message

Signed-off-by: Ace-Tang <aceapril@126.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


