### PR TITLE
feature: cli support add --add-host

### DIFF
--- a/apis/opts/hosts.go
+++ b/apis/opts/hosts.go
@@ -1,0 +1,35 @@
+package opts
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ValidateExtraHost validates the provided string is a valid extra-host.
+func ValidateExtraHost(val string) error {
+	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
+	arr := strings.SplitN(val, ":", 2)
+	if len(arr) != 2 || len(arr[0]) == 0 {
+		return errors.Errorf("bad format for add-host: %q", val)
+	}
+	// TODO(lang710): Skip ipaddr validation for special "host-gateway" string
+	//  If the IP Address is a string called "host-gateway", replace this
+	//  value with the IP address stored in the daemon level HostGatewayIP
+	//  config variable
+	if _, err := validateIPAddress(arr[1]); err != nil {
+		return errors.Wrapf(err, "invalid IP address in add-host: %q", arr[1])
+	}
+	return nil
+}
+
+// validateIPAddress validates an Ip address.
+func validateIPAddress(val string) (string, error) {
+	var ip = net.ParseIP(strings.TrimSpace(val))
+	if ip != nil {
+		return ip.String(), nil
+	}
+	return "", fmt.Errorf("%s is not an ip address", val)
+}

--- a/apis/opts/hosts_test.go
+++ b/apis/opts/hosts_test.go
@@ -1,0 +1,38 @@
+package opts
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateExtraHosts(t *testing.T) {
+	valid := []string{
+		`myhost:192.168.0.1`,
+		`thathost:10.0.2.1`,
+		`anipv6host:2003:ab34:e::1`,
+		`ipv6local:::1`,
+	}
+
+	invalid := map[string]string{
+		`myhost:192.notanipaddress.1`:  `invalid IP`,
+		`thathost-nosemicolon10.0.0.1`: `bad format`,
+		`anipv6host:::::1`:             `invalid IP`,
+		`ipv6local:::0::`:              `invalid IP`,
+	}
+
+	for _, extrahost := range valid {
+		if err := ValidateExtraHost(extrahost); err != nil {
+			t.Fatalf("ValidateExtraHost(`"+extrahost+"`) should succeed: error %v", err)
+		}
+	}
+
+	for extraHost, expectedError := range invalid {
+		if err := ValidateExtraHost(extraHost); err == nil {
+			t.Fatalf("ValidateExtraHost(`%q`) should have failed validation", extraHost)
+		} else {
+			if !strings.Contains(err.Error(), expectedError) {
+				t.Fatalf("ValidateExtraHost(`%q`) error should contain %q", extraHost, expectedError)
+			}
+		}
+	}
+}

--- a/cli/common_flags.go
+++ b/cli/common_flags.go
@@ -72,6 +72,7 @@ func addCommonFlags(flagSet *pflag.FlagSet) *container {
 	flagSet.StringVar(&c.ip, "ip", "", "Set IPv4 address of container endpoint")
 	flagSet.StringVar(&c.ipv6, "ip6", "", "Set IPv6 address of container endpoint")
 	flagSet.Int64Var(&c.netPriority, "net-priority", 0, "net priority")
+	flagSet.StringArrayVar(&c.extraHosts, "add-host", nil, "Add a custom host-to-IP mapping (host:ip)")
 	// dns
 	flagSet.StringArrayVar(&c.dns, "dns", nil, "Set DNS servers")
 	flagSet.StringSliceVar(&c.dnsOptions, "dns-option", nil, "Set DNS options")

--- a/cli/container.go
+++ b/cli/container.go
@@ -72,6 +72,7 @@ type container struct {
 	ipv6        string
 	macAddress  string
 	netPriority int64
+	extraHosts  []string
 	dns         []string
 	dnsOptions  []string
 	dnsSearch   []string
@@ -268,6 +269,7 @@ func (c *container) config() (*types.ContainerCreateConfig, error) {
 				Ulimits:       c.ulimit.Value(),
 				PidsLimit:     c.pidsLimit,
 			},
+			ExtraHosts:      c.extraHosts,
 			DNS:             c.dns,
 			DNSOptions:      c.dnsOptions,
 			DNSSearch:       c.dnsSearch,

--- a/test/cli_run_network_test.go
+++ b/test/cli_run_network_test.go
@@ -122,3 +122,28 @@ func (suite *PouchRunNetworkSuite) TestRunWithIP(c *check.C) {
 
 	c.Assert(found, check.Equals, true)
 }
+
+// TestRunAddHost is to verify run container with add-host flag
+func (suite *PouchRunNetworkSuite) TestRunAddHost(c *check.C) {
+	name := "TestRunAddHost"
+	res := command.PouchRun("run", "--name", name, "--add-host=extra:86.75.30.9", busyboxImage, "grep", "extra", "/etc/hosts")
+	res.Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+
+	stdout := res.Stdout()
+	actual := strings.Trim(stdout, "\r\n")
+	if !strings.Contains(actual, "86.75.30.9\textra") {
+		c.Fatalf("expected '86.75.30.9\textra', but says: %q", actual)
+	}
+}
+
+func (suite *PouchRunNetworkSuite) TestRunAddHostInHostMode(c *check.C) {
+	name := "TestRunAddHostInHostMode"
+	expectedOutput := "1.2.3.4\textra"
+	res := command.PouchRun("run", "--name", name, "--add-host=extra:1.2.3.4", "--net=host", busyboxImage, "cat", "/etc/hosts")
+	res.Assert(c, icmd.Success)
+	defer DelContainerForceMultyTime(c, name)
+	if !strings.Contains(res.Stdout(), expectedOutput) {
+		check.Commentf("Expected '%s', but got %q", expectedOutput, res.Stdout())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Lang Chi <21860405@zju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
feature: cli support `--add-host`
`--add-host` flag can be used to add additional lines to `/etc/hosts`.

This is a client flag for network setting, `--add-host` option can be used in host network mode. This option update `/etc/hosts` inside the container. No change are made to `/etc/hosts` on the host.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE.

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Added.


### Ⅳ. Describe how to verify it
```
root@compatibility:~# pouch run -it  busybox cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
192.168.5.2	bee635290c2f


root@compatibility:~# pouch run -it --add-host=extra:1.2.3.4  busybox cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
1.2.3.4	extra
192.168.5.2	1e4c791dbe8


root@compatibility:~# pouch run -it --add-host=extra:1.2.3.4  --add-host=extra2:2.3.4.5 busybox cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
1.2.3.4	extra
2.3.4.5	extra2
192.168.5.2	1e4c791dbe8

```
### Ⅴ. Special notes for reviews
`--add-host` option can be used in host network mode. Extra network config validation should be provided.

