### PR TITLE
fix: makes pouch stop command support timeout value 0

### DIFF
--- a/daemon/mgr/container.go
+++ b/daemon/mgr/container.go
@@ -955,10 +955,6 @@ func (mgr *ContainerManager) stop(ctx context.Context, c *Container, timeout int
 		return nil
 	}
 
-	if timeout == 0 {
-		timeout = c.StopTimeout()
-	}
-
 	id := c.ID
 	msg, err := mgr.Client.DestroyContainer(ctx, id, timeout)
 	if err != nil {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Make `pouch stop -t 0 ${cid}` behaves as its help message describes, that is to say stop container immediately. 
 See https://github.com/moby/moby/blob/68bec0fcf7a5eeb59c027287d06598098edc9f2c/daemon/stop.go#L71
### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it
Here's command to verify it: 
```
cid=$(pouch create -it --net=host --entrypoint=cat ubuntu:bionic)
pouch start ${cid}
time pouch stop -t 0 ${cid}
```
For now, `pouch stop` costs about 10 seconds to stop the container that doesn't response to sig-term.  With this commit, pouch stops container immediately. 

### Ⅴ. Special notes for reviews


