### PR TITLE
chore: add missing options in commandline docs

### DIFF
--- a/docs/commandline/pouch_create.md
+++ b/docs/commandline/pouch_create.md
@@ -20,6 +20,7 @@ e1d541722d68dc5d133cca9e7bd8fd9338603e1763096c8e853522b60d11f7b9
 ### Options
 
 ```
+      --add-host stringArray          Add a custom host-to-IP mapping (host:ip)
       --annotation stringArray        Additional annotation for runtime
       --blkio-weight uint16           Block IO (relative weight), between 10 and 1000, or 0 to disable
       --blkio-weight-device strings   Block IO weight (relative device weight), need CFQ IO Scheduler enable (default [])

--- a/docs/commandline/pouch_run.md
+++ b/docs/commandline/pouch_run.md
@@ -31,6 +31,7 @@ crw-rw-rw-    1 root     root        1,   3 Jan  8 09:40 /dev/testnull
 ### Options
 
 ```
+      --add-host stringArray          Add a custom host-to-IP mapping (host:ip)
       --annotation stringArray        Additional annotation for runtime
   -a, --attach                        Attach container's STDOUT and STDERR
       --blkio-weight uint16           Block IO (relative weight), between 10 and 1000, or 0 to disable


### PR DESCRIPTION
bc5839e3 commit add --add-host flag, but forget to add it to the docs. Just use `pouch gen-doc` to fix it!

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Just use `pouch gen-doc` to update docs.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
Yes.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


